### PR TITLE
✨ fix: add loading states on async actions

### DIFF
--- a/web/src/components/namespaces/NamespaceCard.tsx
+++ b/web/src/components/namespaces/NamespaceCard.tsx
@@ -1,4 +1,5 @@
-import { Folder, Trash2, ChevronRight } from 'lucide-react'
+import { useState } from 'react'
+import { Folder, Trash2, ChevronRight, Loader2 } from 'lucide-react'
 import { ClusterBadge } from '../ui/ClusterBadge'
 import type { NamespaceDetails } from './types'
 
@@ -6,12 +7,24 @@ interface NamespaceCardProps {
   namespace: NamespaceDetails
   isSelected: boolean
   onSelect: () => void
-  onDelete?: () => void
+  onDelete?: () => void | Promise<void>
   isSystem?: boolean
   showCluster?: boolean
 }
 
 export function NamespaceCard({ namespace, isSelected, onSelect, onDelete, isSystem, showCluster = true }: NamespaceCardProps) {
+  const [isDeleting, setIsDeleting] = useState(false)
+
+  const handleDelete = async (e: React.MouseEvent) => {
+    e.stopPropagation()
+    setIsDeleting(true)
+    try {
+      await onDelete?.()
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
   return (
     <div
       onClick={onSelect}
@@ -44,14 +57,14 @@ export function NamespaceCard({ namespace, isSelected, onSelect, onDelete, isSys
       {showCluster && <ClusterBadge cluster={namespace.cluster} size="sm" />}
       {!isSystem && onDelete && (
         <button
-          onClick={(e) => {
-            e.stopPropagation()
-            onDelete()
-          }}
-          className="p-2 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="p-2 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
           title="Delete namespace"
         >
-          <Trash2 className="w-4 h-4" />
+          {isDeleting
+            ? <Loader2 className="w-4 h-4 animate-spin" />
+            : <Trash2 className="w-4 h-4" />}
         </button>
       )}
       <ChevronRight className="w-4 h-4 text-muted-foreground" />


### PR DESCRIPTION
Fixes #20905

## Summary

Adds missing loading state to the `NamespaceCard` delete button to prevent double-submission and provide visual feedback during async namespace deletion operations.

## Changes

### `web/src/components/namespaces/NamespaceCard.tsx`
- Added `isDeleting` local state (`useState<boolean>`)
- Added `handleDelete` async handler that sets `isDeleting` during the operation
- Delete button now has `disabled={isDeleting}` to prevent double-clicks
- Delete button shows a `Loader2` spinner (existing convention: `animate-spin`) while deletion is in progress
- Updated `onDelete` prop type from `() => void` to `() => void | Promise<void>` to properly support async callers (e.g., `handleDeleteNamespace` in `NamespaceManager.tsx`)

## False Positives

The Auto-QA scanner flagged two test file lines that do not correspond to real UX issues:

| Flagged location | Why it's a false positive |
|---|---|
| `DeployConfirmDialog.test.tsx:44` | This is a test mock for `BaseModal.Header`'s close button. The real `DeployConfirmDialog` component already has `disabled={isLoading}` on the deploy button (line 292). Close buttons intentionally stay enabled during loading. |
| `NamespaceClusterGroup.test.tsx:32` | This is a test mock for `NamespaceCard`'s delete button. The real fix is applied to `NamespaceCard.tsx` itself. |

## Pattern Used

Follows the existing codebase convention (`Loader2` + `animate-spin` + `disabled={isX}` boolean state) as seen in `NamespaceQuotasDeleteModal.tsx`, `KyvernoPolicies.tsx`, `DeployConfirmDialog.tsx`, etc.