### PR TITLE
🌱 [scanner] fix: adopt semantic status tokens for status text colors

### DIFF
--- a/web/src/components/cards/EPPHealth.tsx
+++ b/web/src/components/cards/EPPHealth.tsx
@@ -100,10 +100,10 @@ function EPPHealthInternal() {
   const errorPct = (metrics.errorRate * 100).toFixed(2)
   const healthColor =
     summary.health === 'healthy'
-      ? 'text-green-400'
+      ? 'text-status-success'
       : summary.health === 'degraded'
-        ? 'text-yellow-400'
-        : 'text-red-400'
+        ? 'text-status-warning'
+        : 'text-status-error'
 
   return (
     <div className="space-y-3 p-1">
@@ -161,7 +161,7 @@ function EPPHealthInternal() {
           <span className="text-xs text-muted-foreground">Error rate</span>
           <span
             className={`text-sm font-semibold ${
-              metrics.errorRate > 0.05 ? 'text-red-400' : metrics.errorRate > 0.01 ? 'text-yellow-400' : 'text-green-400'
+              metrics.errorRate > 0.05 ? 'text-status-error' : metrics.errorRate > 0.01 ? 'text-status-warning' : 'text-status-success'
             }`}
           >
             {errorPct}%

--- a/web/src/components/cards/HardwareHealthCardHeader.tsx
+++ b/web/src/components/cards/HardwareHealthCardHeader.tsx
@@ -118,7 +118,7 @@ export const HardwareHealthCardHeader = memo(function HardwareHealthCardHeader({
   return (
     <>
       {(fetchError || retryError) && (
-        <div className="mb-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400 text-xs">
+        <div className="mb-3 p-3 rounded-lg bg-red-500/10 border border-red-500/20 text-status-error text-xs">
           <div className="flex flex-wrap items-center justify-between gap-y-2 gap-2">
             <div className="flex items-center gap-2">
               <AlertTriangle className="w-4 h-4 shrink-0" />
@@ -144,11 +144,11 @@ export const HardwareHealthCardHeader = memo(function HardwareHealthCardHeader({
       <div className="grid grid-cols-2 @md:grid-cols-3 gap-1.5 @md:gap-2 mb-4">
         <div className={cn('p-2 rounded-lg border', criticalCount > 0 ? 'bg-red-500/10 border-red-500/20' : 'bg-green-500/10 border-green-500/20')}>
           <div className="text-xl font-bold text-foreground">{criticalCount}</div>
-          <div className={cn('text-2xs', criticalCount > 0 ? 'text-red-400' : 'text-green-400')}>{t('common:common.critical', 'Critical')}</div>
+          <div className={cn('text-2xs', criticalCount > 0 ? 'text-status-error' : 'text-status-success')}>{t('common:common.critical', 'Critical')}</div>
         </div>
         <div className={cn('p-2 rounded-lg border', warningCount > 0 ? 'bg-yellow-500/10 border-yellow-500/20' : 'bg-green-500/10 border-green-500/20')}>
           <div className="text-xl font-bold text-foreground">{warningCount}</div>
-          <div className={cn('text-2xs', warningCount > 0 ? 'text-yellow-400' : 'text-green-400')}>{t('common:common.warning', 'Warning')}</div>
+          <div className={cn('text-2xs', warningCount > 0 ? 'text-status-warning' : 'text-status-success')}>{t('common:common.warning', 'Warning')}</div>
         </div>
         <button
           onClick={() => onViewModeChange('inventory')}
@@ -181,7 +181,7 @@ export const HardwareHealthCardHeader = memo(function HardwareHealthCardHeader({
             <AlertCircle className="w-3.5 h-3.5" />
             {t('cards:hardwareHealth.alerts', 'Alerts')}
             {activeAlertCount > 0 && (
-              <span className={cn('ml-1 px-1.5 py-0.5 text-2xs font-semibold rounded-full', criticalCount > 0 ? 'bg-red-500/20 text-red-400' : 'bg-yellow-500/20 text-yellow-400')}>{activeAlertCount}</span>
+              <span className={cn('ml-1 px-1.5 py-0.5 text-2xs font-semibold rounded-full', criticalCount > 0 ? 'bg-red-500/20 text-status-error' : 'bg-yellow-500/20 text-status-warning')}>{activeAlertCount}</span>
             )}
           </button>
         </div>
@@ -191,7 +191,7 @@ export const HardwareHealthCardHeader = memo(function HardwareHealthCardHeader({
             {snoozedAlertCount > 0 && (
               <button
                 onClick={onToggleShowSnoozed}
-                className={cn('flex items-center gap-1 px-2 py-1.5 text-xs rounded-md transition-colors', showSnoozed ? 'bg-yellow-500/20 text-yellow-400' : 'bg-muted/30 text-muted-foreground hover:text-foreground')}
+                className={cn('flex items-center gap-1 px-2 py-1.5 text-xs rounded-md transition-colors', showSnoozed ? 'bg-yellow-500/20 text-status-warning' : 'bg-muted/30 text-muted-foreground hover:text-foreground')}
                 title={showSnoozed ? t('cards:hardwareHealth.hideSnoozedAlerts') : t('cards:hardwareHealth.showSnoozedAlerts')}
                 aria-label={showSnoozed ? t('cards:hardwareHealth.hideSnoozedAlerts') : t('cards:hardwareHealth.showSnoozedAlerts')}
                 aria-pressed={showSnoozed}
@@ -241,7 +241,7 @@ export const HardwareHealthCardHeader = memo(function HardwareHealthCardHeader({
                         <button
                           role="menuitem"
                           onClick={onClearAllSnoozed}
-                          className="w-full px-3 py-1.5 text-xs text-left text-yellow-400 hover:bg-muted/50 transition-colors"
+                          className="w-full px-3 py-1.5 text-xs text-left text-status-warning hover:bg-muted/50 transition-colors"
                           aria-label={t('cards:hardwareHealth.clearAllSnoozesAria')}
                         >
                           {t('cards:hardwareHealth.clearAllSnoozes', 'Clear all snoozes')}

--- a/web/src/components/cards/backstage_status/index.tsx
+++ b/web/src/components/cards/backstage_status/index.tsx
@@ -83,9 +83,9 @@ function formatRelative(isoString: string, t: TFunction<'cards'>): string {
 function pluginStatusClass(status: BackstagePluginStatus): string {
   switch (status) {
     case 'enabled':
-      return 'bg-green-500/20 text-green-400'
+      return 'bg-green-500/20 text-status-success'
     case 'error':
-      return 'bg-red-500/20 text-red-400'
+      return 'bg-red-500/20 text-status-error'
     case 'disabled':
       return 'bg-secondary/40 text-muted-foreground'
     default:
@@ -236,8 +236,8 @@ export function BackstageStatus() {
           className={cn(
             'flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium',
             isHealthy
-              ? 'bg-green-500/15 text-green-400'
-              : 'bg-yellow-500/15 text-yellow-400',
+              ? 'bg-green-500/15 text-status-success'
+              : 'bg-yellow-500/15 text-status-warning',
           )}
         >
           {isHealthy ? <CheckCircle className="w-4 h-4" /> : <AlertTriangle className="w-4 h-4" />}
@@ -262,7 +262,7 @@ export function BackstageStatus() {
           value={`${data.replicas}/${data.desiredReplicas}`}
           colorClass={
             data.desiredReplicas > 0 && data.replicas < data.desiredReplicas
-              ? 'text-yellow-400'
+              ? 'text-status-warning'
               : 'text-cyan-400'
           }
           icon={<Server className="w-4 h-4 text-cyan-400" />}
@@ -277,9 +277,9 @@ export function BackstageStatus() {
           label={t('backstageStatus.pluginsEnabled', 'Plugins')}
           value={data.summary.enabledPlugins}
           colorClass={
-            data.summary.pluginErrors > 0 ? 'text-yellow-400' : 'text-green-400'
+            data.summary.pluginErrors > 0 ? 'text-status-warning' : 'text-status-success'
           }
-          icon={<Puzzle className="w-4 h-4 text-green-400" />}
+          icon={<Puzzle className="w-4 h-4 text-status-success" />}
         />
         <MetricTile
           label={t('backstageStatus.templates', 'Templates')}
@@ -323,7 +323,7 @@ export function BackstageStatus() {
         {/* Plugins */}
         <section className="space-y-2">
           <div className="flex items-center gap-2">
-            <Cpu className="w-4 h-4 text-green-400" />
+            <Cpu className="w-4 h-4 text-status-success" />
             <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
               {t('backstageStatus.sectionPlugins', 'Plugins')}
             </h3>

--- a/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
+++ b/web/src/components/cards/cloudevents_status/CloudEventsStatus.tsx
@@ -9,14 +9,14 @@ import { getHealthBadgeClasses } from '../../../lib/cards/statusColors'
 
 const STATUS_STYLE: Record<CloudEventResourceState, { badge: string; icon: React.ReactNode }> = {
   ready: {
-    badge: 'bg-green-500/20 text-green-400',
-    icon: <CheckCircle className="w-3.5 h-3.5 text-green-400" /> },
+    badge: 'bg-green-500/20 text-status-success',
+    icon: <CheckCircle className="w-3.5 h-3.5 text-status-success" /> },
   degraded: {
-    badge: 'bg-yellow-500/20 text-yellow-400',
-    icon: <CircleDashed className="w-3.5 h-3.5 text-yellow-400" /> },
+    badge: 'bg-yellow-500/20 text-status-warning',
+    icon: <CircleDashed className="w-3.5 h-3.5 text-status-warning" /> },
   error: {
-    badge: 'bg-red-500/20 text-red-400',
-    icon: <AlertTriangle className="w-3.5 h-3.5 text-red-400" /> } }
+    badge: 'bg-red-500/20 text-status-error',
+    icon: <AlertTriangle className="w-3.5 h-3.5 text-status-error" /> } }
 
 const STATUS_LABEL_KEY: Record<CloudEventResourceState, 'cloudevents.status_ready' | 'cloudevents.status_degraded' | 'cloudevents.status_error'> = {
   ready: 'cloudevents.status_ready',
@@ -63,8 +63,8 @@ export function CloudEventsStatus() {
   if (error && showEmptyState) {
     return (
       <div className="h-full flex flex-col items-center justify-center min-h-card text-muted-foreground gap-2">
-        <AlertTriangle className="w-6 h-6 text-red-400" />
-        <p className="text-sm text-red-400">{t('cloudevents.fetchError')}</p>
+        <AlertTriangle className="w-6 h-6 text-status-error" />
+        <p className="text-sm text-status-error">{t('cloudevents.fetchError')}</p>
       </div>
     )
   }
@@ -112,8 +112,8 @@ export function CloudEventsStatus() {
         <MetricTile
           label={t('cloudevents.deliveryFailures')}
           value={data.deliveries.failed}
-          colorClass={data.deliveries.failed > 0 ? 'text-red-400' : 'text-green-400'}
-          icon={<AlertTriangle className={`w-4 h-4 ${data.deliveries.failed > 0 ? 'text-red-400' : 'text-green-400'}`} />}
+          colorClass={data.deliveries.failed > 0 ? 'text-status-error' : 'text-status-success'}
+          icon={<AlertTriangle className={`w-4 h-4 ${data.deliveries.failed > 0 ? 'text-status-error' : 'text-status-success'}`} />}
         />
       </div>
 

--- a/web/src/components/cards/drasi/DrasiNodeCard.tsx
+++ b/web/src/components/cards/drasi/DrasiNodeCard.tsx
@@ -49,7 +49,7 @@ export function NodeControls({
         className={`w-5 h-5 flex items-center justify-center rounded border transition-colors ${
           isStopped
             ? 'bg-slate-700/60 border-slate-500/50 text-muted-foreground'
-            : 'bg-red-500/20 hover:bg-red-500/40 border-red-500/40 text-red-400'
+            : 'bg-red-500/20 hover:bg-red-500/40 border-red-500/40 text-status-error'
         }`}
         aria-label={isStopped ? 'Start' : 'Stop'}
         title={isStopped ? 'Start' : 'Stop'}

--- a/web/src/components/cards/otel_status/index.tsx
+++ b/web/src/components/cards/otel_status/index.tsx
@@ -151,18 +151,18 @@ export function OtelStatus() {
         <MetricTile
           label={t('otelStatus.running', 'Running')}
           value={data.summary.runningCollectors}
-          colorClass="text-green-400"
-          icon={<CheckCircle className="w-4 h-4 text-green-400" />}
+          colorClass="text-status-success"
+          icon={<CheckCircle className="w-4 h-4 text-status-success" />}
         />
         <MetricTile
           label={t('otelStatus.degradedCount', 'Degraded')}
           value={data.summary.degradedCollectors}
-          colorClass={data.summary.degradedCollectors > 0 ? 'text-yellow-400' : 'text-green-400'}
+          colorClass={data.summary.degradedCollectors > 0 ? 'text-status-warning' : 'text-status-success'}
           icon={
             data.summary.degradedCollectors > 0 ? (
-              <AlertTriangle className="w-4 h-4 text-yellow-400" />
+              <AlertTriangle className="w-4 h-4 text-status-warning" />
             ) : (
-              <CheckCircle className="w-4 h-4 text-green-400" />
+              <CheckCircle className="w-4 h-4 text-status-success" />
             )
           }
         />
@@ -175,12 +175,12 @@ export function OtelStatus() {
         <MetricTile
           label={t('otelStatus.dropped', 'Dropped')}
           value={formatCount(droppedTotal)}
-          colorClass={droppedTotal > 0 ? 'text-red-400' : 'text-green-400'}
+          colorClass={droppedTotal > 0 ? 'text-status-error' : 'text-status-success'}
           icon={
             droppedTotal > 0 ? (
-              <AlertTriangle className="w-4 h-4 text-red-400" />
+              <AlertTriangle className="w-4 h-4 text-status-error" />
             ) : (
-              <CheckCircle className="w-4 h-4 text-green-400" />
+              <CheckCircle className="w-4 h-4 text-status-success" />
             )
           }
         />
@@ -259,9 +259,9 @@ export function OtelStatus() {
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="min-w-0 flex items-center gap-1.5">
                     {healthy ? (
-                      <CheckCircle className="w-3.5 h-3.5 text-green-400 shrink-0" />
+                      <CheckCircle className="w-3.5 h-3.5 text-status-success shrink-0" />
                     ) : (
-                      <AlertTriangle className="w-3.5 h-3.5 text-yellow-400 shrink-0" />
+                      <AlertTriangle className="w-3.5 h-3.5 text-status-warning shrink-0" />
                     )}
                     <span className="text-xs font-medium truncate font-mono">
                       {collector.name}
@@ -276,8 +276,8 @@ export function OtelStatus() {
                     className={cn(
                       'text-xs px-1.5 py-0.5 rounded-full shrink-0',
                       healthy
-                        ? 'bg-green-500/20 text-green-400'
-                        : 'bg-yellow-500/20 text-yellow-400',
+                        ? 'bg-green-500/20 text-status-success'
+                        : 'bg-yellow-500/20 text-status-warning',
                     )}
                   >
                     {collector.state}
@@ -313,7 +313,7 @@ export function OtelStatus() {
                   <span
                     className={cn(
                       'shrink-0',
-                      collector.exportErrors > 0 ? 'text-red-400' : 'text-green-400',
+                      collector.exportErrors > 0 ? 'text-status-error' : 'text-status-success',
                     )}
                   >
                     {t('otelStatus.exportErrors', {

--- a/web/src/components/dashboard/CardFactoryTemplates.tsx
+++ b/web/src/components/dashboard/CardFactoryTemplates.tsx
@@ -44,7 +44,7 @@ export function CardFactoryTemplates({ onCardCreated, onSaveMessage }: CardFacto
   const [t1Columns, setT1Columns] = useState<DynamicCardColumn[]>([
     { field: 'name', label: 'Name' },
     // #9881 — Use design-system default shade (bg-*-500/10 + text-*-400) so generated cards match built-in cards.
-    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/10 text-green-400', error: 'bg-red-500/10 text-red-400' } },
+    { field: 'status', label: 'Status', format: 'badge', badgeColors: { healthy: 'bg-green-500/10 text-status-success', error: 'bg-red-500/10 text-status-error' } },
   ])
   const [t1DataJson, setT1DataJson] = useState(T1_SAMPLE_DATA_JSON)
   // #9061 — Track whether the user has already focused the JSON textarea

--- a/web/src/components/layout/navbar/UpdateIndicator.tsx
+++ b/web/src/components/layout/navbar/UpdateIndicator.tsx
@@ -70,10 +70,10 @@ export function UpdateIndicator({ showLabel = false }: UpdateIndicatorProps) {
   /** Resolve the button style based on upgrade phase */
   const buttonClassName = cn(
     'flex items-center gap-2 px-2 py-1.5 h-9 rounded-lg transition-colors',
-    isUpgradeError && 'bg-red-500/10 text-red-400 hover:bg-red-500/20',
-    isUpgradeComplete && 'bg-green-500/10 text-green-400 hover:bg-green-500/20',
+    isUpgradeError && 'bg-red-500/10 text-status-error hover:bg-red-500/20',
+    isUpgradeComplete && 'bg-green-500/10 text-status-success hover:bg-green-500/20',
     isUpgrading && 'bg-cyan-500/10 text-cyan-400 hover:bg-cyan-500/20',
-    !isUpgrading && !isUpgradeComplete && !isUpgradeError && 'bg-green-500/10 text-green-400 hover:bg-green-500/20',
+    !isUpgrading && !isUpgradeComplete && !isUpgradeError && 'bg-green-500/10 text-status-success hover:bg-green-500/20',
   )
 
   /** Resolve the tooltip title based on upgrade phase */

--- a/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
+++ b/web/src/components/settings/sections/OpsGenieNotificationSettings.tsx
@@ -72,7 +72,7 @@ export function OpsGenieNotificationSettings({
           className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-primary"
         />
         {hasStoredApiKey && (
-          <p className="mt-1 text-xs text-green-400">
+          <p className="mt-1 text-xs text-status-success">
             {t('settings.notifications.secretConfigured')}
           </p>
         )}
@@ -96,11 +96,11 @@ export function OpsGenieNotificationSettings({
           }`}
         >
           {testResult.success ? (
-            <Check className="w-4 h-4 text-green-400 shrink-0 mt-0.5" />
+            <Check className="w-4 h-4 text-status-success shrink-0 mt-0.5" />
           ) : (
-            <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+            <X className="w-4 h-4 text-status-error shrink-0 mt-0.5" />
           )}
-          <p className={cn('text-sm', testResult.success ? 'text-green-400' : 'text-red-400')}>
+          <p className={cn('text-sm', testResult.success ? 'text-status-success' : 'text-status-error')}>
             {testResult.message}
           </p>
         </div>

--- a/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
+++ b/web/src/components/settings/sections/PagerDutyNotificationSettings.tsx
@@ -72,7 +72,7 @@ export function PagerDutyNotificationSettings({
           className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-primary"
         />
         {hasStoredRoutingKey && (
-          <p className="mt-1 text-xs text-green-400">
+          <p className="mt-1 text-xs text-status-success">
             {t('settings.notifications.secretConfigured')}
           </p>
         )}
@@ -96,11 +96,11 @@ export function PagerDutyNotificationSettings({
           }`}
         >
           {testResult.success ? (
-            <Check className="w-4 h-4 text-green-400 shrink-0 mt-0.5" />
+            <Check className="w-4 h-4 text-status-success shrink-0 mt-0.5" />
           ) : (
-            <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+            <X className="w-4 h-4 text-status-error shrink-0 mt-0.5" />
           )}
-          <p className={cn('text-sm', testResult.success ? 'text-green-400' : 'text-red-400')}>
+          <p className={cn('text-sm', testResult.success ? 'text-status-success' : 'text-status-error')}>
             {testResult.message}
           </p>
         </div>


### PR DESCRIPTION
Fixes #20910

Partial fix scoped to the "Error/failed states using non-red colors" section of the Auto-QA report. Migrates plain text-red-400/text-green-400/text-yellow-400 usages in ~10 status/badge components to text-status-error / text-status-success / text-status-warning. Left opacity-suffixed background classes (bg-red-500/10 etc.) alone because the Tailwind var()-based status tokens don't support opacity modifiers. Additional cleanup can follow in subsequent PRs.