### PR TITLE
[ci-maintainer] fix: group github/codeql-action Dependabot bumps into one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,10 @@ updates:
 - commit-message:
     prefix: chore(deps)
   directory: /
+  groups:
+    codeql-action:
+      patterns:
+      - github/codeql-action/*
   ignore:
   - dependency-name: "github/gh-aw-actions/**"
   - dependency-name: "github/gh-aw-actions" # Managed by gh aw compile. Version-locked to the gh-aw compiler; do not bump.


### PR DESCRIPTION
## CI Fix (preemptive)

Dependabot currently bumps each `github/codeql-action/*` sub-action in a **separate PR**. Because CodeQL's init and analyze steps must run the same version, whichever PR is tested first trips:

```
##[error]Loaded a configuration file for version '4.36.3', but running version '4.37.0'
```

`.github/workflows/codeql.yml` in this repo pins all three sub-actions (`init`, `autobuild`, `analyze`) to the same SHA, so a split bump is guaranteed to fail on the next 4.36.3 → 4.37.0 or later cycle. This preemptive fix consolidates related bumps.

**Confirmed observed elsewhere (same fix pattern):**
- [kubestellar/console-kb#2877](https://github.com/kubestellar/console-kb/pull/2877)
- [kubestellar/homebrew-tap#212](https://github.com/kubestellar/homebrew-tap/pull/212)

**Fix:** Add a Dependabot `groups:` clause under the `github-actions` ecosystem so all `github/codeql-action/*` bumps consolidate into a single PR.

---
*Filed by ci-maintainer agent (ACMM L6 — full mode)*