### PR TITLE
[scanner] fix: reduce test failure rate

### DIFF
--- a/web/src/lib/api.test.ts
+++ b/web/src/lib/api.test.ts
@@ -368,13 +368,23 @@ describe('api.ts - HTTP client layer', () => {
     })
 
     it('handles timeout with AbortError', async () => {
-      fetchMock.mockImplementationOnce(() => 
-        new Promise((_, reject) => 
+      // Use fake timers so the test doesn't spend 100ms of real wall-clock time
+      // and to guarantee deterministic ordering of the two timers:
+      //   1. api.get's internal AbortController fires at 50ms (fake)
+      //   2. mock fetch rejects with DOMException at 100ms (fake)
+      // isAbortError() name-checks DOMException.name because jsdom's DOMException
+      // does not extend Error, so `instanceof Error` alone would miss it.
+      vi.useFakeTimers()
+      fetchMock.mockImplementationOnce(
+        () => new Promise((_, reject) =>
           setTimeout(() => reject(new DOMException('Aborted', 'AbortError')), 100)
         )
       )
-      
-      await expect(api.get('/api/test', { timeout: 50 })).rejects.toThrow(/timeout/)
+
+      const pending = api.get('/api/test', { timeout: 50 })
+      // Advance past both the 50ms abort timeout and the 100ms mock rejection.
+      await vi.advanceTimersByTimeAsync(110)
+      await expect(pending).rejects.toThrow(/timeout/)
     })
 
     it('parses JSON response body', async () => {


### PR DESCRIPTION
Fixes #20924

## Summary

Investigation of the 46% Coverage Suite failure rate revealed **four root causes** across the past week's 100 runs (46 failures, 51 cancellations, 3 successes):

| Root Cause | Affected Tests | Status |
|------------|---------------|--------|
| Dynamic card compiler: `globalThis` TDZ in strict-mode IIFE | 11 tests in `compiler.test.ts`, 1 in `compiler.sandbox-hardening.test.ts` | Fixed in a6e173ef (#20907) |
| `DOMException` not `instanceof Error` in jsdom (AbortError path) | 3 tests in `api.test.ts` (timeout, network-error, backend-unavailable) | Fixed in a6e173ef (#20907) |
| Mock vars referenced in `vi.mock` factories before `vi.hoisted` | `useStackDiscovery.test.ts` + `useStackDiscovery-expand.test.ts` (failed to load) | Fixed in a6e173ef (#20907) |
| Missing `loadingState`/icon-color fields in observability card configs | 4–6 tests in `card-configs-observability.test.ts` | Fixed in a6e173ef (#20907) |

The companion commit **a6e173ef** fixed all 32 failing tests from Coverage Suite run #4211. Runs #4215–#4217 all succeeded afterwards.

## This PR

Hardens the `api.test.ts` timeout test that relied on 100ms of real wall-clock time to process two timers. Switching to `vi.useFakeTimers()` + `advanceTimersByTimeAsync(110)` makes it:
- **Deterministic**: both the 50ms AbortController abort and the 100ms mock DOMException rejection are advanced in a single step
- **Faster**: eliminates a 100ms real-time wait per test run
- **Self-documenting**: the comment explains why `isAbortError()` name-checks instead of using `instanceof Error` (jsdom compatibility regression guard)

Signed-off-by: Copilot <copilot@github.com>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>