### PR TITLE
🌱 [scanner] Sanitize logged user input to address CodeQL log-injection alerts (#20956)

### DIFF
--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -121,7 +121,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 
 	config, err := s.k8sClient.GetRestConfig(cluster)
 	if err != nil {
-		slog.Error("[Prometheus] failed to get cluster config", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Error("[Prometheus] failed to get cluster config", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		writePrometheusError(w, http.StatusBadGateway, "failed to get cluster configuration")
 		return
 	}

--- a/pkg/agent/server_ai_chat.go
+++ b/pkg/agent/server_ai_chat.go
@@ -443,7 +443,7 @@ func (s *Server) handleSelectAgentMessage(msg protocol.Message) protocol.Message
 	// Store the agent selection per-session (not globally)
 	previousAgent := s.registry.GetSelectedAgent(sessionID)
 	if err := s.registry.SetSelectedAgent(sessionID, req.Agent); err != nil {
-		slog.Error("set selected agent error", "error", err, "sessionID", sanitize.LogString(sessionID))
+		slog.Error("set selected agent error", "error", sanitize.LogString(err.Error()), "sessionID", sanitize.LogString(sessionID))
 		return s.errorResponse(msg.ID, "invalid_agent", "invalid agent selection")
 	}
 

--- a/pkg/agent/server_argocd.go
+++ b/pkg/agent/server_argocd.go
@@ -95,13 +95,13 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if err := validateHelmK8sName(req.AppName, "appName"); err != nil {
-		slog.Error("invalid ArgoCD app name", "appName", sanitize.LogString(req.AppName), "error", err)
+		slog.Error("invalid ArgoCD app name", "appName", sanitize.LogString(req.AppName), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("", err), "success": false})
 		return
 	}
 	if err := validateHelmK8sName(req.Cluster, "cluster"); err != nil {
-		slog.Error("invalid ArgoCD cluster", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid ArgoCD cluster", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("", err), "success": false})
 		return
@@ -119,7 +119,7 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 	if namespace == "" {
 		namespace = defaultArgoNamespace
 	} else if err := validateHelmK8sName(namespace, "namespace"); err != nil {
-		slog.Error("invalid ArgoCD namespace", "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Error("invalid ArgoCD namespace", "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("", err), "success": false})
 		return
@@ -169,7 +169,7 @@ func (s *Server) handleArgoCDSync(w http.ResponseWriter, r *http.Request) {
 	// Strategy 3: Annotate the Application to trigger a refresh + sync.
 	dynamicClient, err := s.k8sClient.GetDynamicClient(req.Cluster)
 	if err != nil {
-		slog.Error("failed to get ArgoCD dynamic client", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("failed to get ArgoCD dynamic client", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("get cluster client", err), "success": false})
 		return
@@ -289,7 +289,7 @@ func (s *Server) discoverArgoServerURL(ctx context.Context, cluster string) stri
 
 	clientset, err := s.k8sClient.GetClient(cluster)
 	if err != nil {
-		slog.Warn("[agent ArgoCD] server discovery failed: cannot get client", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Warn("[agent ArgoCD] server discovery failed: cannot get client", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		return ""
 	}
 

--- a/pkg/agent/server_console_cr.go
+++ b/pkg/agent/server_console_cr.go
@@ -60,7 +60,7 @@ func (s *Server) resolveConsoleCRTarget(w http.ResponseWriter, r *http.Request) 
 	}
 	dyn, err := s.k8sClient.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Error("failed to resolve console CR target", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Error("failed to resolve console CR target", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, sanitizeAgentError("resolve console CR target", err))
 		return nil, "", false
 	}
@@ -144,7 +144,7 @@ func (s *Server) handleConsoleCRManagedWorkloads(w http.ResponseWriter, r *http.
 			return
 		}
 		if err := persistence.DeleteManagedWorkload(ctx, namespace, name); err != nil {
-			slog.Error("failed to delete managed workload", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+			slog.Error("failed to delete managed workload", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 			writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("delete managed workload", err))
 			return
 		}
@@ -230,7 +230,7 @@ func (s *Server) handleConsoleCRClusterGroups(w http.ResponseWriter, r *http.Req
 			return
 		}
 		if err := persistence.DeleteClusterGroup(ctx, namespace, name); err != nil {
-			slog.Error("failed to delete cluster group", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+			slog.Error("failed to delete cluster group", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 			writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("delete cluster group", err))
 			return
 		}
@@ -298,7 +298,7 @@ func (s *Server) handleConsoleCRWorkloadDeployments(w http.ResponseWriter, r *ht
 			return
 		}
 		if err := persistence.DeleteWorkloadDeployment(ctx, namespace, name); err != nil {
-			slog.Error("failed to delete workload deployment", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+			slog.Error("failed to delete workload deployment", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 			writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("delete workload deployment", err))
 			return
 		}
@@ -347,7 +347,7 @@ func (s *Server) handleConsoleCRWorkloadDeploymentStatus(w http.ResponseWriter, 
 	// just a WorkloadDeploymentStatus, not the whole WD.
 	current, err := persistence.GetWorkloadDeployment(ctx, namespace, name)
 	if err != nil {
-		slog.Error("failed to get workload deployment", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+		slog.Error("failed to get workload deployment", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusNotFound, sanitizeAgentError("get workload deployment", err))
 		return
 	}

--- a/pkg/agent/server_events_stream.go
+++ b/pkg/agent/server_events_stream.go
@@ -81,7 +81,7 @@ func (s *Server) handleEventsStreamSSE(w http.ResponseWriter, r *http.Request) {
 
 	client, err := s.k8sClient.GetClient(cluster)
 	if err != nil {
-		slog.Error("failed to get event stream client", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Error("failed to get event stream client", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		sseWriteError(w, flusher, sanitizeAgentError("get cluster client", err))
 		return
 	}

--- a/pkg/agent/server_exec.go
+++ b/pkg/agent/server_exec.go
@@ -52,6 +52,7 @@ package agent
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -330,7 +331,7 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 	}
 	slog.Info("[AgentExec] exec session",
 		"cluster", sanitize.LogString(init.Cluster), "namespace", sanitize.LogString(init.Namespace), "pod", sanitize.LogString(init.Pod), "container", sanitize.LogString(init.Container), "command_binary", sanitize.LogString(cmdBinary), "command_argc", len(init.Command),
-		"tty", init.TTY,
+		"tty", sanitize.LogString(fmt.Sprint(init.TTY)),
 	)
 	slog.Debug("[AgentExec] full exec command", "command", sanitize.LogStrings(init.Command))
 
@@ -341,13 +342,13 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 	// applies to the backend handler does NOT apply here.
 	clientset, err := s.k8sClient.GetClient(init.Cluster)
 	if err != nil {
-		slog.Error("[Exec] failed to get client", "cluster", sanitize.LogString(init.Cluster), "error", err)
+		slog.Error("[Exec] failed to get client", "cluster", sanitize.LogString(init.Cluster), "error", sanitize.LogString(err.Error()))
 		agentExecWriteError(conn, "Failed to get cluster client")
 		return
 	}
 	restConfig, err := s.k8sClient.GetRestConfig(init.Cluster)
 	if err != nil {
-		slog.Error("[Exec] failed to get REST config", "cluster", sanitize.LogString(init.Cluster), "error", err)
+		slog.Error("[Exec] failed to get REST config", "cluster", sanitize.LogString(init.Cluster), "error", sanitize.LogString(err.Error()))
 		agentExecWriteError(conn, "Failed to get cluster configuration")
 		return
 	}

--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -178,7 +178,7 @@ func (s *Server) handleFederationRead(
 
 	contexts, err := s.resolveFederationContexts(ctx, r)
 	if err != nil {
-		slog.Error("failed to resolve federation contexts", "itemsKey", sanitize.LogString(itemsKey), "error", err)
+		slog.Error("failed to resolve federation contexts", "itemsKey", sanitize.LogString(itemsKey), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("resolve federation contexts", err))
 		return
 	}
@@ -553,7 +553,7 @@ func (s *Server) handleFederationAction(w http.ResponseWriter, r *http.Request) 
 	// Resolve the user's rest.Config for the specified hub context.
 	cfg, err := s.k8sClient.GetRestConfig(req.HubContext)
 	if err != nil {
-		slog.Error("failed to resolve federation action config", "hubContext", sanitize.LogString(req.HubContext), "error", err)
+		slog.Error("failed to resolve federation action config", "hubContext", sanitize.LogString(req.HubContext), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("resolve federation action config", err))
 		return
 	}
@@ -563,7 +563,7 @@ func (s *Server) handleFederationAction(w http.ResponseWriter, r *http.Request) 
 
 	result, err := ap.Execute(ctx, cfg, req)
 	if err != nil {
-		slog.Error("federation action execution failed", "provider", sanitize.LogString(string(req.Provider)), "actionID", sanitize.LogString(req.ActionID), "hubContext", sanitize.LogString(req.HubContext), "error", err)
+		slog.Error("federation action execution failed", "provider", sanitize.LogString(string(req.Provider)), "actionID", sanitize.LogString(req.ActionID), "hubContext", sanitize.LogString(req.HubContext), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("execute federation action", err))
 		return
 	}

--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -432,7 +432,7 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 	// Validate K8s name params before passing to kubectl CLI.
 	for field, val := range map[string]string{"cluster": req.Cluster, "namespace": req.Namespace} {
 		if err := validateHelmK8sName(val, field); err != nil {
-			slog.Error("invalid GitOps detect-drift input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", err)
+			slog.Error("invalid GitOps detect-drift input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 			return
@@ -441,7 +441,7 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 
 	// Validate path parameter to prevent path traversal attacks.
 	if err := validateGitopsPath(req.Path); err != nil {
-		slog.Error("invalid GitOps detect-drift path", "path", sanitize.LogString(req.Path), "error", err)
+		slog.Error("invalid GitOps detect-drift path", "path", sanitize.LogString(req.Path), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 		return
@@ -555,7 +555,7 @@ func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
 	}
 	for field, val := range map[string]string{"cluster": req.Cluster, "namespace": req.Namespace} {
 		if err := validateHelmK8sName(val, field); err != nil {
-			slog.Error("invalid GitOps sync input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", err)
+			slog.Error("invalid GitOps sync input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 			return
@@ -564,7 +564,7 @@ func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
 
 	// Validate path parameter to prevent path traversal attacks.
 	if err := validateGitopsPath(req.Path); err != nil {
-		slog.Error("invalid GitOps sync path", "path", sanitize.LogString(req.Path), "error", err)
+		slog.Error("invalid GitOps sync path", "path", sanitize.LogString(req.Path), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 		return

--- a/pkg/agent/server_gpu_health.go
+++ b/pkg/agent/server_gpu_health.go
@@ -122,7 +122,7 @@ func (s *Server) gpuHealthCronJobInstall(w http.ResponseWriter, r *http.Request)
 	defer cancel()
 
 	if err := s.k8sClient.InstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace, body.Schedule, body.Tier); err != nil {
-		slog.Warn("[agent] GPU health cronjob install failed", "cluster", sanitize.LogString(body.Cluster), "error", err)
+		slog.Warn("[agent] GPU health cronjob install failed", "cluster", sanitize.LogString(body.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("install GPU health CronJob", err), "source": "agent"})
 		return
@@ -156,7 +156,7 @@ func (s *Server) gpuHealthCronJobUninstall(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 
 	if err := s.k8sClient.UninstallGPUHealthCronJob(ctx, body.Cluster, body.Namespace); err != nil {
-		slog.Warn("[agent] GPU health cronjob uninstall failed", "cluster", sanitize.LogString(body.Cluster), "error", err)
+		slog.Warn("[agent] GPU health cronjob uninstall failed", "cluster", sanitize.LogString(body.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"error": sanitizeAgentError("remove GPU health CronJob", err), "source": "agent"})
 		return

--- a/pkg/agent/server_helm.go
+++ b/pkg/agent/server_helm.go
@@ -204,7 +204,7 @@ func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
 	}
 	for field, val := range map[string]string{"cluster": req.Cluster, "release": req.Release, "namespace": req.Namespace} {
 		if err := validateHelmK8sName(val, field); err != nil {
-			slog.Error("invalid Helm rollback input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", err)
+			slog.Error("invalid Helm rollback input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 			return
@@ -224,7 +224,7 @@ func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	slog.Info("[agent] helm rollback", "release", sanitize.LogString(req.Release), "revision", req.Revision, "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace))
+	slog.Info("[agent] helm rollback", "release", sanitize.LogString(req.Release), "revision", sanitize.LogString(fmt.Sprint(req.Revision)), "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace))
 	if err := cmd.Run(); err != nil {
 		slog.Warn("[agent] helm rollback failed", "release", sanitize.LogString(req.Release), "error", err, "stderr", sanitize.LogString(stderr.String()))
 		w.WriteHeader(http.StatusInternalServerError)
@@ -235,7 +235,7 @@ func (s *Server) handleHelmRollback(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	slog.Info("[agent] helm rollback succeeded", "release", sanitize.LogString(req.Release), "revision", req.Revision)
+	slog.Info("[agent] helm rollback succeeded", "release", sanitize.LogString(req.Release), "revision", sanitize.LogString(fmt.Sprint(req.Revision)))
 	writeJSON(w, map[string]interface{}{
 		"success": true,
 		"message": fmt.Sprintf("Rolled back %s to revision %d", req.Release, req.Revision),
@@ -277,7 +277,7 @@ func (s *Server) handleHelmUninstall(w http.ResponseWriter, r *http.Request) {
 	}
 	for field, val := range map[string]string{"cluster": req.Cluster, "release": req.Release, "namespace": req.Namespace} {
 		if err := validateHelmK8sName(val, field); err != nil {
-			slog.Error("invalid Helm uninstall input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", err)
+			slog.Error("invalid Helm uninstall input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 			return
@@ -350,26 +350,26 @@ func (s *Server) handleHelmUpgrade(w http.ResponseWriter, r *http.Request) {
 	}
 	for field, val := range map[string]string{"cluster": req.Cluster, "release": req.Release, "namespace": req.Namespace} {
 		if err := validateHelmK8sName(val, field); err != nil {
-			slog.Error("invalid Helm upgrade input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", err)
+			slog.Error("invalid Helm upgrade input", "field", sanitize.LogString(field), "value", sanitize.LogString(val), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 			return
 		}
 	}
 	if err := validateHelmChartArg(req.Chart); err != nil {
-		slog.Error("invalid Helm chart", "chart", sanitize.LogString(req.Chart), "error", err)
+		slog.Error("invalid Helm chart", "chart", sanitize.LogString(req.Chart), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := validateHelmChartHost(req.Chart); err != nil {
-		slog.Error("Helm chart host blocked (SSRF)", "chart", sanitize.LogString(req.Chart), "error", err)
+		slog.Error("Helm chart host blocked (SSRF)", "chart", sanitize.LogString(req.Chart), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": "chart registry host is not allowed"})
 		return
 	}
 	if err := validateHelmChartVersion(req.Version); err != nil {
-		slog.Error("invalid Helm chart version", "version", sanitize.LogString(req.Version), "error", err)
+		slog.Error("invalid Helm chart version", "version", sanitize.LogString(req.Version), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("", err)})
 		return

--- a/pkg/agent/server_http_kubeconfig.go
+++ b/pkg/agent/server_http_kubeconfig.go
@@ -222,7 +222,7 @@ func (s *Server) handleKubeconfigRemoveHTTP(w http.ResponseWriter, r *http.Reque
 	}
 
 	if err := s.k8sClient.RemoveContext(req.Context); err != nil {
-		slog.Error("[kubeconfig] failed to remove context", "context", sanitize.LogString(req.Context), "error", err)
+		slog.Error("[kubeconfig] failed to remove context", "context", sanitize.LogString(req.Context), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("remove cluster context", err)})
 		return

--- a/pkg/agent/server_http_resources.go
+++ b/pkg/agent/server_http_resources.go
@@ -129,7 +129,7 @@ func (s *Server) handleGPUNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		nodes, err := s.k8sClient.GetGPUNodes(ctx, cluster)
 		if err != nil {
 			retryIn := s.recordClusterResourceFailure(resourceName, cluster)
-			slog.Warn("error fetching nodes", "cluster", sanitize.LogString(cluster), "error", err, "retryIn", retryIn)
+			slog.Warn("error fetching nodes", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()), "retryIn", retryIn)
 			writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 			return
 		}
@@ -188,7 +188,7 @@ func (s *Server) handleNodesHTTP(w http.ResponseWriter, r *http.Request) {
 		nodes, err := s.k8sClient.GetNodes(ctx, cluster)
 		if err != nil {
 			retryIn := s.recordClusterResourceFailure(resourceName, cluster)
-			slog.Warn("error fetching nodes", "cluster", sanitize.LogString(cluster), "error", err, "retryIn", retryIn)
+			slog.Warn("error fetching nodes", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()), "retryIn", retryIn)
 			writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 			return
 		}

--- a/pkg/agent/server_http_resources_config.go
+++ b/pkg/agent/server_http_resources_config.go
@@ -151,19 +151,19 @@ func (s *Server) createServiceAccountHTTP(w http.ResponseWriter, r *http.Request
 	// #8034 followup: validate inputs at the HTTP boundary before calling the
 	// Kubernetes client, matching the pattern in createNamespaceHTTP.
 	if err := kube.ValidateKubeContext(req.Cluster); err != nil {
-		slog.Error("invalid cluster for create service account request", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid cluster for create service account request", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Error("invalid namespace for create service account request", "namespace", sanitize.LogString(req.Namespace), "error", err)
+		slog.Error("invalid namespace for create service account request", "namespace", sanitize.LogString(req.Namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", req.Name); err != nil {
-		slog.Error("invalid name for create service account request", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Error("invalid name for create service account request", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -174,7 +174,7 @@ func (s *Server) createServiceAccountHTTP(w http.ResponseWriter, r *http.Request
 
 	sa, err := s.k8sClient.CreateServiceAccount(ctx, req.Cluster, req.Namespace, req.Name)
 	if err != nil {
-		slog.Warn("error creating service account", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("error creating service account", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("create service account", err), "source": "agent"})
 		return
@@ -197,19 +197,19 @@ func (s *Server) deleteServiceAccountHTTP(w http.ResponseWriter, r *http.Request
 	// #8034 followup: validate inputs at the HTTP boundary before calling the
 	// Kubernetes client, matching the pattern in createNamespaceHTTP.
 	if err := kube.ValidateKubeContext(cluster); err != nil {
-		slog.Error("invalid cluster for delete service account request", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Error("invalid cluster for delete service account request", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", namespace); err != nil {
-		slog.Error("invalid namespace for delete service account request", "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Error("invalid namespace for delete service account request", "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", name); err != nil {
-		slog.Error("invalid name for delete service account request", "name", sanitize.LogString(name), "error", err)
+		slog.Error("invalid name for delete service account request", "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -219,7 +219,7 @@ func (s *Server) deleteServiceAccountHTTP(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	if err := s.k8sClient.DeleteServiceAccount(ctx, cluster, namespace, name); err != nil {
-		slog.Warn("error deleting service account", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+		slog.Warn("error deleting service account", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("delete service account", err), "source": "agent"})
 		return
@@ -284,19 +284,19 @@ func (s *Server) createServiceExportHTTP(w http.ResponseWriter, r *http.Request)
 	// #8034 followup: validate inputs at the HTTP boundary before calling the
 	// Kubernetes client, matching the pattern in createNamespaceHTTP.
 	if err := kube.ValidateKubeContext(req.Cluster); err != nil {
-		slog.Error("invalid cluster for create service export request", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid cluster for create service export request", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Error("invalid namespace for create service export request", "namespace", sanitize.LogString(req.Namespace), "error", err)
+		slog.Error("invalid namespace for create service export request", "namespace", sanitize.LogString(req.Namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("serviceName", req.ServiceName); err != nil {
-		slog.Error("invalid serviceName for create service export request", "serviceName", sanitize.LogString(req.ServiceName), "error", err)
+		slog.Error("invalid serviceName for create service export request", "serviceName", sanitize.LogString(req.ServiceName), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -306,7 +306,7 @@ func (s *Server) createServiceExportHTTP(w http.ResponseWriter, r *http.Request)
 	defer cancel()
 
 	if err := s.k8sClient.CreateServiceExport(ctx, req.Cluster, req.Namespace, req.ServiceName); err != nil {
-		slog.Warn("error creating service export", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "serviceName", sanitize.LogString(req.ServiceName), "error", err)
+		slog.Warn("error creating service export", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "serviceName", sanitize.LogString(req.ServiceName), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("create service export", err), "source": "agent"})
 		return
@@ -336,19 +336,19 @@ func (s *Server) deleteServiceExportHTTP(w http.ResponseWriter, r *http.Request)
 	// #8034 followup: validate inputs at the HTTP boundary before calling the
 	// Kubernetes client, matching the pattern in createNamespaceHTTP.
 	if err := kube.ValidateKubeContext(cluster); err != nil {
-		slog.Error("invalid cluster for delete service export request", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Error("invalid cluster for delete service export request", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", namespace); err != nil {
-		slog.Error("invalid namespace for delete service export request", "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Error("invalid namespace for delete service export request", "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", name); err != nil {
-		slog.Error("invalid name for delete service export request", "name", sanitize.LogString(name), "error", err)
+		slog.Error("invalid name for delete service export request", "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -358,7 +358,7 @@ func (s *Server) deleteServiceExportHTTP(w http.ResponseWriter, r *http.Request)
 	defer cancel()
 
 	if err := s.k8sClient.DeleteServiceExport(ctx, cluster, namespace, name); err != nil {
-		slog.Warn("error deleting service export", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+		slog.Warn("error deleting service export", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("delete service export", err), "source": "agent"})
 		return

--- a/pkg/agent/server_http_resources_rbac_storage.go
+++ b/pkg/agent/server_http_resources_rbac_storage.go
@@ -202,7 +202,7 @@ func (s *Server) createRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 	// so we return a specific 400 instead of passing empty/malformed values
 	// down to the apiserver and getting back an opaque 500.
 	if err := kube.ValidateKubeContext(req.Cluster); err != nil {
-		slog.Error("invalid cluster for role binding request", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid cluster for role binding request", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -256,7 +256,7 @@ func (s *Server) createRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	if err := s.k8sClient.CreateRoleBinding(ctx, k8sReq); err != nil {
-		slog.Warn("error creating role binding", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(bindingName), "error", err)
+		slog.Warn("error creating role binding", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(bindingName), "error", sanitize.LogString(err.Error()))
 		status, msg := mapK8sErrorToHTTP(err)
 		w.WriteHeader(status)
 		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
@@ -289,7 +289,7 @@ func (s *Server) deleteRoleBindingHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	if err := s.k8sClient.DeleteRoleBinding(ctx, cluster, namespace, name, isCluster); err != nil {
-		slog.Warn("error deleting role binding", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "isCluster", isCluster, "error", err)
+		slog.Warn("error deleting role binding", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "isCluster", isCluster, "error", sanitize.LogString(err.Error()))
 		status, msg := mapK8sErrorToHTTP(err)
 		w.WriteHeader(status)
 		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
@@ -325,7 +325,7 @@ func (s *Server) handleResourceQuotasHTTP(w http.ResponseWriter, r *http.Request
 	defer cancel()
 	quotas, err := s.k8sClient.GetResourceQuotas(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching resourcequotas", "error", err)
+		slog.Warn("error fetching resourcequotas", "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -359,7 +359,7 @@ func (s *Server) handleLimitRangesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ranges, err := s.k8sClient.GetLimitRanges(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching limitranges", "error", err)
+		slog.Warn("error fetching limitranges", "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -403,7 +403,7 @@ func (s *Server) handleResolveDepsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	kind, bundle, err := s.k8sClient.ResolveWorkloadDependencies(ctx, cluster, namespace, name)
 	if err != nil {
-		slog.Warn("error resolving dependencies", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Warn("error resolving dependencies", "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		writeJSON(w, map[string]interface{}{
 			"workload":     name,
 			"kind":         "Deployment",

--- a/pkg/agent/server_http_resources_workloads.go
+++ b/pkg/agent/server_http_resources_workloads.go
@@ -91,13 +91,13 @@ func (s *Server) createNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 	// render a specific error and so we don't lean on the apiserver for
 	// validation.
 	if err := kube.ValidateKubeContext(req.Cluster); err != nil {
-		slog.Error("invalid cluster for create namespace request", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid cluster for create namespace request", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", req.Name); err != nil {
-		slog.Error("invalid namespace name for create request", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Error("invalid namespace name for create request", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -108,7 +108,7 @@ func (s *Server) createNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 
 	ns, err := s.k8sClient.CreateNamespace(ctx, req.Cluster, req.Name, req.Labels)
 	if err != nil {
-		slog.Warn("error creating namespace", "cluster", sanitize.LogString(req.Cluster), "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("error creating namespace", "cluster", sanitize.LogString(req.Cluster), "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		status, msg := mapK8sErrorToHTTP(err)
 		w.WriteHeader(status)
 		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
@@ -132,13 +132,13 @@ func (s *Server) deleteNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 	// #8034 followup: validate inputs at the HTTP boundary before calling the
 	// Kubernetes client, matching the pattern in createNamespaceHTTP.
 	if err := kube.ValidateKubeContext(cluster); err != nil {
-		slog.Error("invalid cluster for delete namespace request", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Error("invalid cluster for delete namespace request", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", name); err != nil {
-		slog.Error("invalid namespace name for delete request", "name", sanitize.LogString(name), "error", err)
+		slog.Error("invalid namespace name for delete request", "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -148,7 +148,7 @@ func (s *Server) deleteNamespaceHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 
 	if err := s.k8sClient.DeleteNamespace(ctx, cluster, name); err != nil {
-		slog.Warn("error deleting namespace", "cluster", sanitize.LogString(cluster), "name", sanitize.LogString(name), "error", err)
+		slog.Warn("error deleting namespace", "cluster", sanitize.LogString(cluster), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		status, msg := mapK8sErrorToHTTP(err)
 		w.WriteHeader(status)
 		writeJSON(w, map[string]interface{}{"success": false, "error": msg, "source": "agent"})
@@ -363,7 +363,7 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ingresses, err := s.k8sClient.GetIngresses(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching ingresses", "error", err)
+		slog.Warn("error fetching ingresses", "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -397,7 +397,7 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	policies, err := s.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching networkpolicies", "error", err)
+		slog.Warn("error fetching networkpolicies", "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -431,7 +431,7 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	services, err := s.k8sClient.GetServices(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching services", "error", err)
+		slog.Warn("error fetching services", "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}

--- a/pkg/agent/server_http_workloads.go
+++ b/pkg/agent/server_http_workloads.go
@@ -120,20 +120,20 @@ func (s *Server) handleScaleHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := kube.ValidateDNS1123Label("namespace", namespace); err != nil {
-		slog.Error("invalid namespace for scale request", "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Error("invalid namespace for scale request", "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("workloadName", name); err != nil {
-		slog.Error("invalid workload name for scale request", "workloadName", sanitize.LogString(name), "error", err)
+		slog.Error("invalid workload name for scale request", "workloadName", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	for _, tc := range targetClusters {
 		if err := kube.ValidateKubeContext(tc); err != nil {
-			slog.Error("invalid target cluster for scale request", "targetCluster", sanitize.LogString(tc), "error", err)
+			slog.Error("invalid target cluster for scale request", "targetCluster", sanitize.LogString(tc), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 			return
@@ -259,26 +259,26 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := kube.ValidateDNS1123Label("workloadName", req.WorkloadName); err != nil {
-		slog.Error("invalid workload name for deploy request", "workloadName", sanitize.LogString(req.WorkloadName), "error", err)
+		slog.Error("invalid workload name for deploy request", "workloadName", sanitize.LogString(req.WorkloadName), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Error("invalid namespace for deploy request", "namespace", sanitize.LogString(req.Namespace), "error", err)
+		slog.Error("invalid namespace for deploy request", "namespace", sanitize.LogString(req.Namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateKubeContext(req.SourceCluster); err != nil {
-		slog.Error("invalid source cluster for deploy request", "sourceCluster", sanitize.LogString(req.SourceCluster), "error", err)
+		slog.Error("invalid source cluster for deploy request", "sourceCluster", sanitize.LogString(req.SourceCluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	for _, tc := range req.TargetClusters {
 		if err := kube.ValidateKubeContext(tc); err != nil {
-			slog.Error("invalid target cluster for deploy request", "targetCluster", sanitize.LogString(tc), "error", err)
+			slog.Error("invalid target cluster for deploy request", "targetCluster", sanitize.LogString(tc), "error", sanitize.LogString(err.Error()))
 			w.WriteHeader(http.StatusBadRequest)
 			writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 			return
@@ -307,7 +307,7 @@ func (s *Server) handleDeployWorkloadHTTP(w http.ResponseWriter, r *http.Request
 
 	result, err := s.k8sClient.DeployWorkload(ctx, req.SourceCluster, req.Namespace, req.WorkloadName, req.TargetClusters, req.Replicas, opts)
 	if err != nil {
-		slog.Warn("error deploying workload", "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.WorkloadName), "sourceCluster", sanitize.LogString(req.SourceCluster), "targetClusters", sanitize.LogStrings(req.TargetClusters), "error", err)
+		slog.Warn("error deploying workload", "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.WorkloadName), "sourceCluster", sanitize.LogString(req.SourceCluster), "targetClusters", sanitize.LogStrings(req.TargetClusters), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{
 			"success": false,
@@ -390,19 +390,19 @@ func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := kube.ValidateKubeContext(req.Cluster); err != nil {
-		slog.Error("invalid cluster for delete workload request", "cluster", sanitize.LogString(req.Cluster), "error", err)
+		slog.Error("invalid cluster for delete workload request", "cluster", sanitize.LogString(req.Cluster), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", req.Namespace); err != nil {
-		slog.Error("invalid namespace for delete workload request", "namespace", sanitize.LogString(req.Namespace), "error", err)
+		slog.Error("invalid namespace for delete workload request", "namespace", sanitize.LogString(req.Namespace), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
 	}
 	if err := kube.ValidateDNS1123Label("name", req.Name); err != nil {
-		slog.Error("invalid workload name for delete request", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Error("invalid workload name for delete request", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, map[string]interface{}{"success": false, "error": sanitizeAgentError("", err)})
 		return
@@ -421,7 +421,7 @@ func (s *Server) handleDeleteWorkloadHTTP(w http.ResponseWriter, r *http.Request
 	defer cancel()
 
 	if err := s.k8sClient.DeleteWorkload(ctx, req.Cluster, req.Namespace, req.Name); err != nil {
-		slog.Warn("error deleting workload", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("error deleting workload", "cluster", sanitize.LogString(req.Cluster), "namespace", sanitize.LogString(req.Namespace), "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]interface{}{
 			"success": false,
@@ -473,7 +473,7 @@ func (s *Server) handlePodsHTTP(w http.ResponseWriter, r *http.Request) {
 
 	pods, err := s.k8sClient.GetPods(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching pods", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching pods", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}

--- a/pkg/agent/server_nvidia.go
+++ b/pkg/agent/server_nvidia.go
@@ -91,7 +91,7 @@ func (s *Server) handleNvidiaOperatorsHTTP(w http.ResponseWriter, r *http.Reques
 	if cluster != "" {
 		client, err := s.k8sClient.GetClient(cluster)
 		if err != nil {
-			slog.Warn("[NvidiaOperators] failed to get client", "cluster", sanitize.LogString(cluster), "error", err)
+			slog.Warn("[NvidiaOperators] failed to get client", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 			writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 			return
 		}

--- a/pkg/agent/server_ops_clusters.go
+++ b/pkg/agent/server_ops_clusters.go
@@ -143,7 +143,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		// SECURITY: Validate cluster name against DNS-1123 to prevent command
 		// injection via crafted names that flow into exec.Command args (#7171).
 		if err := kube.ValidateDNS1123Label("cluster name", req.Name); err != nil {
-			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", err)
+			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 			http.Error(w, "invalid cluster name", http.StatusBadRequest)
 			return
 		}
@@ -153,7 +153,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		safego.GoWith("local-cluster-create", func() {
 			defer s.clusterOpsWG.Done()
 			if err := s.localClusters.CreateCluster(req.Tool, req.Name); err != nil {
-				slog.Error("[LocalClusters] failed to create cluster", "cluster", sanitize.LogString(req.Name), "tool", sanitize.LogString(req.Tool), "error", err)
+				slog.Error("[LocalClusters] failed to create cluster", "cluster", sanitize.LogString(req.Name), "tool", sanitize.LogString(req.Tool), "error", sanitize.LogString(err.Error()))
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     req.Tool,
@@ -204,7 +204,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 
 		// SECURITY: Validate cluster name against DNS-1123 (#7171).
 		if err := kube.ValidateDNS1123Label("cluster name", name); err != nil {
-			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(name), "error", err)
+			slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 			http.Error(w, "invalid cluster name", http.StatusBadRequest)
 			return
 		}
@@ -214,7 +214,7 @@ func (s *Server) handleLocalClusters(w http.ResponseWriter, r *http.Request) {
 		safego.GoWith("local-cluster-delete", func() {
 			defer s.clusterOpsWG.Done()
 			if err := s.localClusters.DeleteCluster(tool, name); err != nil {
-				slog.Error("[LocalClusters] failed to delete cluster", "cluster", sanitize.LogString(name), "error", err)
+				slog.Error("[LocalClusters] failed to delete cluster", "cluster", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 				errMsg := sanitizeClusterError(err)
 				s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 					"tool":     tool,
@@ -295,7 +295,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 	}
 	// SECURITY: Validate cluster name against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("cluster name", req.Name); err != nil {
-		slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("[LocalClusters] invalid cluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		http.Error(w, "invalid cluster name", http.StatusBadRequest)
 		return
 	}
@@ -322,7 +322,7 @@ func (s *Server) handleLocalClusterLifecycle(w http.ResponseWriter, r *http.Requ
 		}
 
 		if err != nil {
-			slog.Error("[LocalClusters] lifecycle action failed", "action", sanitize.LogString(req.Action), "cluster", sanitize.LogString(req.Name), "error", err)
+			slog.Error("[LocalClusters] lifecycle action failed", "action", sanitize.LogString(req.Action), "cluster", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 			errMsg := sanitizeClusterError(err)
 			s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 				"tool":     req.Tool,
@@ -414,7 +414,7 @@ func (s *Server) handleVClusterCreate(w http.ResponseWriter, r *http.Request) {
 
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -492,7 +492,7 @@ func (s *Server) handleVClusterConnect(w http.ResponseWriter, r *http.Request) {
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -566,7 +566,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}
@@ -577,7 +577,7 @@ func (s *Server) handleVClusterDisconnect(w http.ResponseWriter, r *http.Request
 	}
 
 	if err := s.localClusters.DisconnectVCluster(req.Name, req.Namespace); err != nil {
-		slog.Error("[vCluster] failed to disconnect from vcluster", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Error("[vCluster] failed to disconnect from vcluster", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		s.BroadcastToClients("local_cluster_progress", map[string]interface{}{
 			"tool":     "vcluster",
 			"name":     req.Name,
@@ -640,7 +640,7 @@ func (s *Server) handleVClusterDelete(w http.ResponseWriter, r *http.Request) {
 	}
 	// SECURITY: Validate name and namespace against DNS-1123 (#7171).
 	if err := kube.ValidateDNS1123Label("vcluster name", req.Name); err != nil {
-		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", err)
+		slog.Warn("[vCluster] invalid vcluster name", "name", sanitize.LogString(req.Name), "error", sanitize.LogString(err.Error()))
 		http.Error(w, "invalid vcluster name", http.StatusBadRequest)
 		return
 	}

--- a/pkg/agent/server_ops_settings.go
+++ b/pkg/agent/server_ops_settings.go
@@ -343,7 +343,7 @@ func (s *Server) handleSetKey(w http.ResponseWriter, r *http.Request) {
 		if !valid {
 			w.WriteHeader(http.StatusBadRequest)
 			if validationErr != nil {
-				slog.Error("API key validation error", "provider", sanitize.LogString(req.Provider), "error", validationErr)
+				slog.Error("API key validation error", "provider", sanitize.LogString(req.Provider), "error", sanitize.LogString(validationErr.Error()))
 			}
 			writeJSON(w, protocol.ErrorPayload{Code: "invalid_key", Message: "Invalid API key"})
 			return

--- a/pkg/agent/server_rbac.go
+++ b/pkg/agent/server_rbac.go
@@ -79,7 +79,7 @@ func (s *Server) handleCanIHTTP(w http.ResponseWriter, r *http.Request) {
 
 	result, err := s.k8sClient.CheckCanI(ctx, req.Cluster, req)
 	if err != nil {
-		slog.Error("failed to check permissions", "cluster", sanitize.LogString(req.Cluster), "verb", sanitize.LogString(req.Verb), "resource", sanitize.LogString(req.Resource), "error", err)
+		slog.Error("failed to check permissions", "cluster", sanitize.LogString(req.Cluster), "verb", sanitize.LogString(req.Verb), "resource", sanitize.LogString(req.Resource), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusInternalServerError, sanitizeAgentError("check permissions", err))
 		return
 	}

--- a/pkg/agent/websocket_deadline.go
+++ b/pkg/agent/websocket_deadline.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -9,11 +10,22 @@ import (
 	"github.com/kubestellar/console/pkg/sanitize"
 )
 
+// sanitizeLogArgs sanitizes user-controlled key/value pairs for structured
+// logging. Values at odd indices are treated as attribute values; strings are
+// sanitized with sanitize.LogString and non-strings are stringified via
+// fmt.Sprint and sanitized. Keys (even indices) are left untouched.
 func sanitizeLogArgs(logArgs []any) []any {
-	attrs := append([]any{}, logArgs...)
-	for i := 1; i < len(attrs); i += 2 {
-		if value, ok := attrs[i].(string); ok {
-			attrs[i] = sanitize.LogString(value)
+	attrs := make([]any, len(logArgs))
+	for i, v := range logArgs {
+		if i%2 == 1 {
+			switch value := v.(type) {
+			case string:
+				attrs[i] = sanitize.LogString(value)
+			default:
+				attrs[i] = sanitize.LogString(fmt.Sprint(v))
+			}
+		} else {
+			attrs[i] = v
 		}
 	}
 	return attrs
@@ -22,7 +34,7 @@ func sanitizeLogArgs(logArgs []any) []any {
 func setWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) error {
 	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
 		attrs := sanitizeLogArgs(logArgs)
-		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", err)
+		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", sanitize.LogString(err.Error()))
 		slog.Error(sanitize.LogString(logMsg), attrs...)
 		return err
 	}
@@ -32,7 +44,7 @@ func setWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) err
 func clearWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) error {
 	if err := conn.SetWriteDeadline(time.Time{}); err != nil {
 		attrs := sanitizeLogArgs(logArgs)
-		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", err)
+		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", sanitize.LogString(err.Error()))
 		slog.Error(sanitize.LogString(logMsg), attrs...)
 		return err
 	}

--- a/pkg/k8s/client_gpu_cronjob.go
+++ b/pkg/k8s/client_gpu_cronjob.go
@@ -312,7 +312,7 @@ func (m *MultiClusterClient) InstallGPUHealthCronJob(ctx context.Context, contex
 		}
 	}
 
-	slog.Info("[GPUHealthCronJob] installed", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "schedule", sanitize.LogString(schedule), "tier", tier, "version", gpuHealthScriptVersion)
+	slog.Info("[GPUHealthCronJob] installed", "cluster", sanitize.LogString(contextName), "namespace", sanitize.LogString(namespace), "schedule", sanitize.LogString(schedule), "tier", sanitize.LogString(fmt.Sprint(tier)), "version", gpuHealthScriptVersion)
 	return nil
 }
 

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -137,7 +137,7 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	client, err := m.GetClient(contextName)
 	if err != nil {
 		errType := classifyError(err.Error())
-		slog.Error("[Health] cluster client error", "cluster", sanitize.LogString(contextName), "error", err)
+		slog.Error("[Health] cluster client error", "cluster", sanitize.LogString(contextName), "error", sanitize.LogString(err.Error()))
 		return &ClusterHealth{
 			Cluster:      contextName,
 			Healthy:      false,

--- a/pkg/k8s/workload_deploy.go
+++ b/pkg/k8s/workload_deploy.go
@@ -113,7 +113,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 	// 2. Resolve dependencies (ConfigMaps, Secrets, SA, RBAC, PVCs, Services, Ingress, NetworkPolicy, HPA, PDB)
 	bundle, err := m.ResolveDependencies(ctx, sourceCluster, namespace, sourceObj, opts)
 	if err != nil {
-		slog.Warn("[deploy] dependency resolution failed", "cluster", sanitize.LogString(sourceCluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", err)
+		slog.Warn("[deploy] dependency resolution failed", "cluster", sanitize.LogString(sourceCluster), "namespace", sanitize.LogString(namespace), "name", sanitize.LogString(name), "error", sanitize.LogString(err.Error()))
 		bundle = &DependencyBundle{Workload: sourceObj}
 	}
 	if len(bundle.Warnings) > 0 {
@@ -163,7 +163,7 @@ func (m *MultiClusterClient) DeployWorkload(ctx context.Context, sourceCluster, 
 			// 4a. Ensure namespace exists on target
 			nsErr := m.ensureNamespace(clusterCtx, targetClient, namespace, opts)
 			if nsErr != nil {
-				slog.Warn("[deploy] namespace ensure failed", "cluster", sanitize.LogString(targetCluster), "error", nsErr)
+				slog.Warn("[deploy] namespace ensure failed", "cluster", sanitize.LogString(targetCluster), "error", sanitize.LogString(nsErr.Error()))
 			}
 
 			// 4b. Apply dependencies in order before the workload


### PR DESCRIPTION
Fixes #20956

🌱 Sanitize logged user input to close CodeQL `go/log-injection` alerts.

## What
Wraps user-controlled values passed to `slog.*` calls in the flagged files with `sanitize.LogString(…)`. Specifically:

- Error values returned by validators (e.g. `kube.ValidateKubeContext`, `kube.ValidateDNS1123Label`, request-body validators) can echo raw user input in their `Error()` message. All such `"error", err` attributes are rewritten as `"error", sanitize.LogString(err.Error())`.
- Non-string user-controlled fields (`int`/`bool`) that are logged as attributes (`req.Revision`, `init.TTY`, `tier`) are stringified with `fmt.Sprint(...)` and then passed through `sanitize.LogString`.
- `pkg/agent/websocket_deadline.go`: `sanitizeLogArgs` was rewritten so it sanitizes *both* string and non-string attribute values, and both call sites now pass `"error", sanitize.LogString(err.Error())` when appending the connection error.
- `pkg/agent/server_exec.go` picks up an `"fmt"` import so `init.TTY` can be stringified before sanitization.

## Why
CodeQL flagged 100 open `go/log-injection` alerts (CWE-117) across `pkg/agent/*.go` and `pkg/k8s/*.go` where user-supplied query params, body fields, and error strings reached `slog.*` without sanitization. An attacker controlling those inputs could inject `\n`/`\r`/ANSI sequences to forge or spoof log lines. This PR closes those alerts by routing each tainted value through the existing `sanitize.LogString` helper (which strips CR/LF, C0 controls, and ANSI escapes).

## Scope
Purely mechanical wrapping — no behavior change other than the sanitization of previously unsanitized log attributes.

Files touched (24):
- `pkg/agent/prometheus.go`
- `pkg/agent/server_ai_chat.go`
- `pkg/agent/server_argocd.go`
- `pkg/agent/server_console_cr.go`
- `pkg/agent/server_events_stream.go`
- `pkg/agent/server_exec.go`
- `pkg/agent/server_federation.go`
- `pkg/agent/server_gitops.go`
- `pkg/agent/server_gpu_health.go`
- `pkg/agent/server_helm.go`
- `pkg/agent/server_http_kubeconfig.go`
- `pkg/agent/server_http_resources.go`
- `pkg/agent/server_http_resources_config.go`
- `pkg/agent/server_http_resources_rbac_storage.go`
- `pkg/agent/server_http_resources_workloads.go`
- `pkg/agent/server_http_workloads.go`
- `pkg/agent/server_nvidia.go`
- `pkg/agent/server_ops_clusters.go`
- `pkg/agent/server_ops_settings.go`
- `pkg/agent/server_rbac.go`
- `pkg/agent/websocket_deadline.go`
- `pkg/k8s/client_gpu_cronjob.go`
- `pkg/k8s/client_health.go`
- `pkg/k8s/workload_deploy.go`

Filed by the scanner agent.