### PR TITLE
🐛 fix: add missing Host headers to handler tests for fasthttp v1.72.0

### DIFF
--- a/pkg/api/handlers/auth_compat_test.go
+++ b/pkg/api/handlers/auth_compat_test.go
@@ -92,6 +92,7 @@ func TestRequireAdmin(t *testing.T) {
 			})
 
 			req := httptest.NewRequest("GET", "/test", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, resp.StatusCode)
@@ -172,6 +173,7 @@ func TestRequireEditorOrAdmin(t *testing.T) {
 			})
 
 			req := httptest.NewRequest("GET", "/test", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, resp.StatusCode)
@@ -259,6 +261,7 @@ func TestRequireViewerOrAbove(t *testing.T) {
 			})
 
 			req := httptest.NewRequest("GET", "/test", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, resp.StatusCode)
@@ -340,6 +343,7 @@ func TestRequireEditorOrAdminMiddleware(t *testing.T) {
 			})
 
 			req := httptest.NewRequest("GET", "/test", nil)
+			req.Host = "localhost"
 			resp, err := app.Test(req)
 			require.NoError(t, err)
 			require.Equal(t, tt.wantStatus, resp.StatusCode)

--- a/pkg/api/handlers/kagent_proxy_test.go
+++ b/pkg/api/handlers/kagent_proxy_test.go
@@ -176,7 +176,11 @@ func TestKagentProxyHandler_Authorization(t *testing.T) {
 			register: func(app *fiber.App, h *KagentProxyHandler) {
 				app.Get("/agents", h.ListAgents)
 			},
-			request:    httptest.NewRequest(http.MethodGet, "/agents", nil),
+			request: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/agents", nil)
+				req.Host = "localhost"
+				return req
+			}(),
 			wantStatus: http.StatusForbidden,
 		},
 		{


### PR DESCRIPTION
Fixes #20955

fasthttp v1.72.0 requires a non-empty `Host` header on HTTP/1.1 requests and returns 400 Bad Request otherwise. Two test files in `pkg/api/handlers/` were missing `req.Host = "localhost"` on their `httptest.NewRequest` calls, causing those tests to receive 400 instead of the expected status codes (200 or 403).

## Changes

- **`auth_compat_test.go`**: Added `req.Host = "localhost"` to all 4 test requests in `TestRequireAdmin`, `TestRequireEditorOrAdmin`, `TestRequireViewerOrAbove`, and `TestRequireEditorOrAdminMiddleware`.
- **`kagent_proxy_test.go`**: Converted the inline `viewer cannot list agents` request to a builder function and added `req.Host = "localhost"` to match the pattern used by sibling test cases.

This is consistent with how the rest of the handler test suite handles fasthttp's Host header requirement (57 other requests in the package already set `req.Host = "localhost"`).

Addresses advisory finding: *"fasthttp v1.72.0 Host header requirement breaks 57 test requests"* from the Hive Advisory Report.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>