### PR TITLE
🌱 fix: add minimal top-level permissions blocks to workflows (Scorecard Token-Permissions)

### DIFF
--- a/.github/workflows/acmm-level-monitor.yml
+++ b/.github/workflows/acmm-level-monitor.yml
@@ -11,7 +11,8 @@ on:
         required: false
         default: '5'
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 jobs:
   check-acmm-level:

--- a/.github/workflows/ai-attribution.yml
+++ b/.github/workflows/ai-attribution.yml
@@ -13,7 +13,8 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 jobs:
   attribute:

--- a/.github/workflows/auto-qa-tuner.yml
+++ b/.github/workflows/auto-qa-tuner.yml
@@ -19,7 +19,8 @@ on:
         default: 'all'
         type: string
 
-permissions: {}
+permissions:
+  contents: read
 
 concurrency:
   group: auto-qa-tuner

--- a/.github/workflows/auto-test-gen.yml
+++ b/.github/workflows/auto-test-gen.yml
@@ -9,7 +9,8 @@ on:
       - 'web/src/hooks/**/*.ts'
       - 'web/src/hooks/**/*.tsx'
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 jobs:
   detect-untested:
     permissions:

--- a/.github/workflows/auto-triage.lock.yml
+++ b/.github/workflows/auto-triage.lock.yml
@@ -52,7 +52,8 @@ on:
     types:
     - assigned
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 concurrency:
   group: "gh-aw-${{ github.workflow }}-${{ github.event.issue.number || github.run_id }}"
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -11,7 +11,8 @@ on:
     types: [submitted]
 
 # Least-privilege: read-only by default; jobs declare write scopes individually
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   claude:

--- a/.github/workflows/cleanup-screenshots.yml
+++ b/.github/workflows/cleanup-screenshots.yml
@@ -15,7 +15,8 @@ on:
     - cron: '0 2 * * *'
   workflow_dispatch:
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   cleanup-screenshots:

--- a/.github/workflows/console-app-roundtrip.yml
+++ b/.github/workflows/console-app-roundtrip.yml
@@ -17,7 +17,8 @@ on:
     - cron: "0 6 * * *"
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 concurrency:
   group: console-app-roundtrip

--- a/.github/workflows/console-app-smoke.yml
+++ b/.github/workflows/console-app-smoke.yml
@@ -20,7 +20,8 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch:
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 concurrency:
   group: console-app-smoke

--- a/.github/workflows/console-issue-labels.yml
+++ b/.github/workflows/console-issue-labels.yml
@@ -4,7 +4,8 @@ on:
   issues:
     types: [opened]
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 jobs:
   label:

--- a/.github/workflows/copilot-dco.yml
+++ b/.github/workflows/copilot-dco.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+
 jobs:
   copilot-dco:
     uses: kubestellar/infra/.github/workflows/reusable-copilot-dco.yml@main

--- a/.github/workflows/coverage-gate.yml
+++ b/.github/workflows/coverage-gate.yml
@@ -12,7 +12,8 @@ on:
       - 'web/vite.config.ts'
       - 'web/package.json'
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 concurrency:
   group: coverage-gate-${{ github.event.pull_request.number }}
   cancel-in-progress: true

--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -23,7 +23,8 @@ concurrency:
   group: coverage-suite
   cancel-in-progress: true
 
-permissions: read-all  # default read; writes scoped to job below
+permissions:
+  contents: read  # default read; writes scoped to job below
 
 env:
   NODE_VERSION: '22'


### PR DESCRIPTION
Fixes #20962

Replaces broad `read-all` (and missing) top-level permissions with minimal `contents: read` on the 13 workflows flagged by Scorecard Token-Permissions.