### PR TITLE
[quality] test isDestructiveKubectlCommand security predicate

### DIFF
--- a/pkg/agent/server_ai_websocket_test.go
+++ b/pkg/agent/server_ai_websocket_test.go
@@ -84,6 +84,81 @@ func TestIsReadOnlyKubectlCommand(t *testing.T) {
 	}
 }
 
+func TestIsDestructiveKubectlCommand(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		// Empty / defensive cases
+		{name: "empty args is not destructive", args: nil, want: false},
+		{name: "empty slice is not destructive", args: []string{}, want: false},
+
+		// Every destructive verb in the map
+		{name: "delete verb", args: []string{"delete", "pod", "foo"}, want: true},
+		{name: "drain verb", args: []string{"drain", "node-1"}, want: true},
+		{name: "cordon verb", args: []string{"cordon", "node-1"}, want: true},
+		{name: "taint verb", args: []string{"taint", "nodes", "node-1", "key=v:NoSchedule"}, want: true},
+
+		// Case insensitivity
+		{name: "DELETE uppercase", args: []string{"DELETE", "pod", "foo"}, want: true},
+		{name: "Drain mixed case", args: []string{"Drain", "node-1"}, want: true},
+
+		// Read/inspect verbs must not be considered destructive
+		{name: "get is not destructive", args: []string{"get", "pods"}, want: false},
+		{name: "describe is not destructive", args: []string{"describe", "pod", "foo"}, want: false},
+		{name: "logs is not destructive", args: []string{"logs", "pod/foo"}, want: false},
+		{name: "apply is not on the destructive list", args: []string{"apply", "-f", "x.yaml"}, want: false},
+		{name: "create is not on the destructive list", args: []string{"create", "-f", "x.yaml"}, want: false},
+
+		// replace: plain replace IS destructive (verb is in map).
+		{name: "plain replace is destructive", args: []string{"replace", "-f", "x.yaml"}, want: true},
+		{name: "replace with --force is destructive", args: []string{"replace", "--force", "-f", "x.yaml"}, want: true},
+		{name: "replace with --force after other flags", args: []string{"replace", "-f", "x.yaml", "--force"}, want: true},
+
+		// --force on a non-replace verb should NOT flip a non-destructive verb.
+		{name: "get with --force is not destructive", args: []string{"get", "--force", "pods"}, want: false},
+		{name: "apply with --force is not on the destructive list", args: []string{"apply", "--force", "-f", "x.yaml"}, want: false},
+
+		// Flag injection: leading "--" must not be treated as a verb match.
+		{name: "leading --delete flag is not a verb match", args: []string{"--delete", "pods"}, want: false},
+
+		// Substring of a destructive verb should not match.
+		{name: "prefix of delete is not destructive", args: []string{"del", "pod"}, want: false},
+		{name: "deleted is not the delete verb", args: []string{"deleted"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Copy args so we can detect accidental mutation.
+			args := append([]string(nil), tt.args...)
+			if got := isDestructiveKubectlCommand(args); got != tt.want {
+				t.Fatalf("isDestructiveKubectlCommand(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+			// Verify no mutation. Both nil and empty inputs are treated equivalently.
+			if len(args) != len(tt.args) {
+				t.Fatalf("isDestructiveKubectlCommand mutated args len: got %v want %v", args, tt.args)
+			}
+			for i := range args {
+				if args[i] != tt.args[i] {
+					t.Fatalf("isDestructiveKubectlCommand mutated args[%d]: got %q want %q", i, args[i], tt.args[i])
+				}
+			}
+		})
+	}
+}
+
+func TestIsDestructiveKubectlCommand_DisjointFromReadOnly(t *testing.T) {
+	// Sanity: no verb should be classified as BOTH read-only and destructive.
+	// If a future change adds a verb to one map without removing it from the
+	// other, this test will catch it.
+	for verb := range destructiveKubectlVerbs {
+		if readOnlyKubectlVerbs[verb] {
+			t.Errorf("verb %q appears in both destructiveKubectlVerbs and readOnlyKubectlVerbs", verb)
+		}
+	}
+}
+
 func TestServer_HandleWebSocket_TokenRequired(t *testing.T) {
 	s := &Server{
 		agentToken:     "secret",


### PR DESCRIPTION
## Test Improvement

Adds coverage for `pkg/agent/server_ai_websocket.go:isDestructiveKubectlCommand`, a **security-critical predicate** that gates user confirmation for mutating kubectl commands issued through the AI websocket. Previously at **0% coverage** despite being the trust boundary for command execution.

### Test cases

| Category | Cases |
|---|---|
| Every destructive verb | `delete`, `drain`, `cordon`, `taint`, `replace` |
| Defensive | `nil` args, empty slice |
| Case-insensitive | `DELETE`, `Drain` |
| Non-destructive | `get`, `describe`, `logs`, `apply`, `create` |
| `--force` handling | `replace --force`, `get --force`, `apply --force` |
| Flag-injection defense | Leading `--delete` must not match the delete verb |
| Substring / prefix confusion | `del`, `deleted` |
| Non-mutation | Caller's args slice is never modified |

Also adds `TestIsDestructiveKubectlCommand_DisjointFromReadOnly` — a regression guard asserting no verb appears in both `destructiveKubectlVerbs` and `readOnlyKubectlVerbs`. If a future change added such an overlap, the dry-run gate in `handleKubectlMessage` would silently break.

### Coverage

`isDestructiveKubectlCommand`: **0% → 70%**

The remaining 30% is the `if verb == "replace"` branch on lines 495–501 which is **unreachable**: `"replace"` is already in `destructiveKubectlVerbs`, so `destructiveKubectlVerbs[verb]` returns `true` on line 491 before the `--force` check can execute. That block appears to be dead code, but is left untouched by this quality-scoped PR (test-only).

### Follow-up (out of scope for this PR)

Consider either:
1. Removing the dead `if verb == "replace"` branch in `server_ai_websocket.go` (lines 494–501), or
2. Removing `"replace"` from `destructiveKubectlVerbs` so plain `replace` isn't blocked and only `replace --force` is destructive — whichever matches the intended UX. Filed as a bead advisory.

Refs #20957

---
*Filed by quality agent (ACMM L4/L6 — full mode)*