### PR TITLE
[quality] test 4 pure pkg/agent helpers previously at 0% coverage

### DIFF
--- a/pkg/agent/server_ai_mixed_security_test.go
+++ b/pkg/agent/server_ai_mixed_security_test.go
@@ -1,6 +1,7 @@
 package agent
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -495,4 +496,74 @@ func TestTouchesMixedModeSensitiveKubectlResource(t *testing.T) {
 			t.Errorf("unexpected sensitive resource in %v", args)
 		}
 	}
+}
+
+// TestFormatMixedModeRejectedCommands verifies the user-facing formatter
+// used when the mixed-mode command validator blocks LLM-generated commands.
+// This message is the primary UX surface for security decisions in mixed mode.
+func TestFormatMixedModeRejectedCommands(t *testing.T) {
+	t.Run("empty returns empty string", func(t *testing.T) {
+		if got := formatMixedModeRejectedCommands(nil); got != "" {
+			t.Errorf("expected empty string for nil, got %q", got)
+		}
+		if got := formatMixedModeRejectedCommands([]mixedModeRejectedCommand{}); got != "" {
+			t.Errorf("expected empty string for empty slice, got %q", got)
+		}
+	})
+
+	t.Run("single blocked command", func(t *testing.T) {
+		got := formatMixedModeRejectedCommands([]mixedModeRejectedCommand{
+			{Command: "kubectl delete ns kube-system", Reason: "destructive verb", RequiresApproval: false},
+		})
+		if !strings.Contains(got, "\u26a0\ufe0f Blocked LLM-generated commands before execution:") {
+			t.Errorf("missing header, got %q", got)
+		}
+		if !strings.Contains(got, "`kubectl delete ns kube-system`") {
+			t.Errorf("command not rendered in backticks, got %q", got)
+		}
+		if !strings.Contains(got, "destructive verb") {
+			t.Errorf("reason missing, got %q", got)
+		}
+		if !strings.Contains(got, "(blocked)") {
+			t.Errorf("expected (blocked) status for RequiresApproval=false, got %q", got)
+		}
+		if !strings.HasSuffix(got, "Only prevalidated read-only commands are auto-executed in mixed mode.\n") {
+			t.Errorf("missing trailer, got %q", got)
+		}
+	})
+
+	t.Run("requires-approval status is distinct from blocked", func(t *testing.T) {
+		got := formatMixedModeRejectedCommands([]mixedModeRejectedCommand{
+			{Command: "kubectl apply -f x.yaml", Reason: "mutation", RequiresApproval: true},
+		})
+		if !strings.Contains(got, "(approval required)") {
+			t.Errorf("expected (approval required) status, got %q", got)
+		}
+		if strings.Contains(got, "(blocked)") {
+			t.Errorf("status must not be (blocked) when RequiresApproval=true, got %q", got)
+		}
+	})
+
+	t.Run("multiple commands rendered in order with correct statuses", func(t *testing.T) {
+		got := formatMixedModeRejectedCommands([]mixedModeRejectedCommand{
+			{Command: "kubectl delete ns a", Reason: "destructive", RequiresApproval: false},
+			{Command: "kubectl apply -f b.yaml", Reason: "mutation", RequiresApproval: true},
+			{Command: "kubectl drain node-1", Reason: "destructive", RequiresApproval: false},
+		})
+
+		// Header + one bullet per command + trailer = 5 lines terminated by newline.
+		lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+		if len(lines) != 5 {
+			t.Fatalf("expected 5 lines (header + 3 bullets + trailer), got %d: %q", len(lines), got)
+		}
+		if !strings.HasPrefix(lines[1], "- `kubectl delete ns a`") || !strings.HasSuffix(lines[1], "(blocked)") {
+			t.Errorf("line 1 unexpected: %q", lines[1])
+		}
+		if !strings.HasPrefix(lines[2], "- `kubectl apply -f b.yaml`") || !strings.HasSuffix(lines[2], "(approval required)") {
+			t.Errorf("line 2 unexpected: %q", lines[2])
+		}
+		if !strings.HasPrefix(lines[3], "- `kubectl drain node-1`") || !strings.HasSuffix(lines[3], "(blocked)") {
+			t.Errorf("line 3 unexpected: %q", lines[3])
+		}
+	})
 }

--- a/pkg/agent/server_events_stream_test.go
+++ b/pkg/agent/server_events_stream_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -189,5 +190,94 @@ func TestForwardEventToStellar_SemaphoreTimeout(t *testing.T) {
 
 	if called {
 		t.Error("backend was called despite semaphore being full — event should have been dropped")
+	}
+}
+
+// TestPtrInt64 verifies the trivial int64 pointer helper: the returned
+// pointer is non-nil, dereferences to the input, and successive calls return
+// distinct pointers (no shared static storage).
+func TestPtrInt64(t *testing.T) {
+	t.Parallel()
+
+	cases := []int64{0, 1, -1, 1 << 32, -(1 << 32)}
+	for _, v := range cases {
+		got := ptrInt64(v)
+		if got == nil {
+			t.Fatalf("ptrInt64(%d) returned nil", v)
+		}
+		if *got != v {
+			t.Errorf("ptrInt64(%d) dereferenced to %d", v, *got)
+		}
+	}
+
+	// Distinct pointers on repeat calls with the same value.
+	a := ptrInt64(7)
+	b := ptrInt64(7)
+	if a == b {
+		t.Errorf("ptrInt64 returned the same pointer for successive calls")
+	}
+}
+
+// TestSseWriteError verifies the SSE error frame format matches the
+// SSE specification: event: <type>\ndata: <payload>\n\n
+func TestSseWriteError(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	sseWriteError(rec, rec, "boom")
+
+	body := rec.Body.String()
+
+	if !strings.HasPrefix(body, "event: error\n") {
+		t.Errorf("expected event line prefix, got %q", body)
+	}
+	if !strings.HasSuffix(body, "\n\n") {
+		t.Errorf("expected trailing blank line, got %q", body)
+	}
+
+	const dataPrefix = "data: "
+	idx := strings.Index(body, dataPrefix)
+	if idx < 0 {
+		t.Fatalf("no data line in %q", body)
+	}
+	dataLine := strings.TrimRight(body[idx+len(dataPrefix):], "\n")
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(dataLine), &payload); err != nil {
+		t.Fatalf("data line is not valid JSON: %v (%q)", err, dataLine)
+	}
+	if payload["error"] != "boom" {
+		t.Errorf("expected error=%q, got %q", "boom", payload["error"])
+	}
+}
+
+// TestSseWriteError_JSONEscapesSpecials verifies that special characters in
+// the error message are properly JSON-escaped so the resulting SSE frame
+// cannot inject additional SSE events.
+func TestSseWriteError_JSONEscapesSpecials(t *testing.T) {
+	t.Parallel()
+
+	rec := httptest.NewRecorder()
+	sseWriteError(rec, rec, "line1\nline2 \"quoted\"")
+
+	body := rec.Body.String()
+
+	const dataPrefix = "data: "
+	idx := strings.Index(body, dataPrefix)
+	if idx < 0 {
+		t.Fatalf("no data line in %q", body)
+	}
+	dataLine := strings.TrimRight(body[idx+len(dataPrefix):], "\n")
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(dataLine), &payload); err != nil {
+		t.Fatalf("data line is not valid JSON: %v (%q)", err, dataLine)
+	}
+	if payload["error"] != "line1\nline2 \"quoted\"" {
+		t.Errorf("round-trip mismatch: got %q", payload["error"])
+	}
+
+	if strings.Count(body, "\n\n") != 1 {
+		t.Errorf("expected exactly one SSE frame terminator, got body %q", body)
 	}
 }

--- a/pkg/agent/websocket_deadline_test.go
+++ b/pkg/agent/websocket_deadline_test.go
@@ -81,3 +81,77 @@ func TestSetWSWriteDeadline_ClosedConn(t *testing.T) {
 		t.Log("note: SetWriteDeadline may succeed on recently closed conn (OS-dependent)")
 	}
 }
+
+// TestSanitizeLogArgs verifies that odd-indexed values (attribute values) are
+// sanitized while even-indexed values (attribute keys) pass through untouched.
+// This function is used across all agent WebSocket logging to prevent
+// log-injection from user-controlled data.
+func TestSanitizeLogArgs(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		got := sanitizeLogArgs(nil)
+		if len(got) != 0 {
+			t.Fatalf("expected empty result for nil input, got %v", got)
+		}
+	})
+
+	t.Run("keys untouched, string values sanitized", func(t *testing.T) {
+		key := "user\nkey"
+		val := "value\nwith\nnewlines"
+		got := sanitizeLogArgs([]any{key, val})
+		if len(got) != 2 {
+			t.Fatalf("expected 2 elements, got %d", len(got))
+		}
+		if got[0] != key {
+			t.Errorf("expected key untouched %q, got %q", key, got[0])
+		}
+		gotVal, ok := got[1].(string)
+		if !ok {
+			t.Fatalf("expected string value, got %T", got[1])
+		}
+		if strings.Contains(gotVal, "\n") {
+			t.Errorf("expected newlines removed from value, got %q", gotVal)
+		}
+	})
+
+	t.Run("non-string values are stringified and sanitized", func(t *testing.T) {
+		got := sanitizeLogArgs([]any{"count", 42, "err", struct{ S string }{S: "x\ny"}})
+		if len(got) != 4 {
+			t.Fatalf("expected 4 elements, got %d", len(got))
+		}
+		if got[0] != "count" || got[2] != "err" {
+			t.Errorf("expected keys preserved, got %+v", got)
+		}
+		countStr, ok := got[1].(string)
+		if !ok {
+			t.Fatalf("expected count value stringified, got %T", got[1])
+		}
+		if countStr != "42" {
+			t.Errorf("expected %q, got %q", "42", countStr)
+		}
+		errStr, ok := got[3].(string)
+		if !ok {
+			t.Fatalf("expected struct value stringified, got %T", got[3])
+		}
+		if strings.Contains(errStr, "\n") {
+			t.Errorf("expected newlines removed from stringified struct, got %q", errStr)
+		}
+	})
+
+	t.Run("odd length: trailing key is not sanitized", func(t *testing.T) {
+		// Real slog usage always passes an even count; this is a defensive check
+		// that a trailing element at an even index passes through untouched.
+		got := sanitizeLogArgs([]any{"only-key"})
+		if len(got) != 1 || got[0] != "only-key" {
+			t.Errorf("expected trailing key preserved, got %v", got)
+		}
+	})
+
+	t.Run("does not mutate input slice", func(t *testing.T) {
+		orig := []any{"k", "v\nwith-newline"}
+		snapshot := []any{orig[0], orig[1]}
+		_ = sanitizeLogArgs(orig)
+		if orig[0] != snapshot[0] || orig[1] != snapshot[1] {
+			t.Errorf("input mutated: got %v, expected %v", orig, snapshot)
+		}
+	})
+}


### PR DESCRIPTION
## Test Improvement

Adds coverage for **four pure helpers in `pkg/agent`** that were previously at **0% coverage**. All four are now at **100%**.

| Function | File | Why it matters |
|---|---|---|
| `sanitizeLogArgs` | `websocket_deadline.go` | Log-injection defense used by every WebSocket log call. Untested = a regression could allow user-controlled newlines/control chars into structured logs. |
| `formatMixedModeRejectedCommands` | `server_ai_mixed_security.go` | User-facing formatter for blocked LLM-generated commands — the primary UX surface for mixed-mode security decisions. |
| `sseWriteError` | `server_events_stream.go` | SSE error-frame writer. Tests confirm JSON escaping prevents raw newlines or quotes from injecting additional SSE events. |
| `ptrInt64` | `server_events_stream.go` | Trivial int64 pointer helper. Cheap to test; confirms successive calls return distinct pointers. |

### Test highlights

- `sanitizeLogArgs`: empty input, key/value index alternation, non-string stringification, odd-length defense, non-mutation
- `formatMixedModeRejectedCommands`: empty input, single blocked, `RequiresApproval=true` vs `false` status distinction, multi-command ordering
- `sseWriteError`: RFC-compliant framing (`event: error\ndata: <json>\n\n`), plus a JSON-escape assertion that a message containing a newline and quote does **not** produce a second SSE frame
- `ptrInt64`: zero/positive/negative/64-bit values, distinct-pointer guarantee

Refs #20957

---
*Filed by quality agent (ACMM L4/L6 — full mode)*