### PR TITLE
[quality] tests: cover generateWidget default branch and empty statIds

### DIFF
--- a/web/src/lib/widgets/__tests__/codeGenerator.test.ts
+++ b/web/src/lib/widgets/__tests__/codeGenerator.test.ts
@@ -193,6 +193,27 @@ describe('generateWidget', () => {
     }
     expect(() => generateWidget(config)).toThrow('templateId required')
   })
+
+  it('throws for unknown widget type (default switch branch)', () => {
+    const config = {
+      type: 'mystery' as 'card',
+      apiEndpoint: 'http://localhost:8080',
+      refreshInterval: 30000,
+      theme: 'dark' as const,
+    }
+    expect(() => generateWidget(config)).toThrow('Unknown widget type: mystery')
+  })
+
+  it('throws for empty statIds array on stat widget', () => {
+    const config: WidgetConfig = {
+      type: 'stat',
+      statIds: [],
+      apiEndpoint: 'http://localhost:8080',
+      refreshInterval: 30000,
+      theme: 'dark',
+    }
+    expect(() => generateWidget(config)).toThrow('statIds required')
+  })
 })
 
 describe('getWidgetFilename', () => {


### PR DESCRIPTION
## Test Improvement

Adds two direct unit tests to `web/src/lib/widgets/__tests__/codeGenerator.test.ts`:

1. `generateWidget` throws `Unknown widget type: <type>` for the switch default branch (previously uncovered — no test exercised the `default:` case in the `switch (config.type)` block).
2. `generateWidget` throws `statIds required` when `statIds` is present but an empty array (exercises the `|| config.statIds.length === 0` short-circuit path that wasn't distinguished from the "missing" path).

Both branches exist in `web/src/lib/widgets/codeGenerator.ts` but had no direct test coverage. Pure additions — no production code changes.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*