### PR TITLE
[scanner] chore(security): add explicit top-level permissions to workflows

### DIFF
--- a/.github/workflows/ai-fix.yml
+++ b/.github/workflows/ai-fix.yml
@@ -13,12 +13,14 @@ on:
     types: [opened]
 
 permissions:
-  contents: write
-  issues: write
-  pull-requests: write
+  contents: read
 
 jobs:
   ai-fix:
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
     uses: kubestellar/infra/.github/workflows/reusable-ai-fix.yml@main
     with:
       issue_number: ${{ github.event.inputs.issue_number || '' }}


### PR DESCRIPTION
Fixes #20973

Adds explicit `permissions: contents: read` at the top level to workflows flagged by OpenSSF Scorecard Token-Permissions. Write scopes moved to job level where the reusable workflow calls them.

**Partial fix** — `ai-fix.yml` updated. `copilot-automation.yml` could not be updated (see issue comment).

Job-level permissions preserved.

Signed-off-by: scanner <scanner@kubestellar.local>

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>