### PR TITLE
[scanner] chore(security): add top-level permissions to remaining workflows

### DIFF
--- a/.github/workflows/deploy-checksum.yml
+++ b/.github/workflows/deploy-checksum.yml
@@ -5,7 +5,8 @@ on:
     branches: [main]
     paths: [deploy.sh]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   update-checksum:

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -8,8 +8,9 @@ on:
         required: true
         default: '0.1.0'
 
-# Least-privilege: no default permissions; jobs declare scopes individually
-permissions: {}
+# Least-privilege: default to read-only; write scopes granted at job level
+permissions:
+  contents: read
 
 jobs:
   release-helm:

--- a/.github/workflows/hive-interactive.yml
+++ b/.github/workflows/hive-interactive.yml
@@ -8,7 +8,8 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}  # default none; specific scopes granted at job level
+permissions:
+  contents: read
 
 jobs:
   post-directions:

--- a/.github/workflows/process-screenshots.yml
+++ b/.github/workflows/process-screenshots.yml
@@ -14,7 +14,8 @@ on:
   issue_comment:
     types: [created]
 
-permissions: {}
+permissions:
+  contents: read
 
 jobs:
   process-screenshot:


### PR DESCRIPTION
Fixes #20973

Follow-up to PR #20977 — covers remaining workflows in the Scorecard Token-Permissions cluster.

**Summary:**
- Added `permissions: contents: read` at top level to 4 workflows
- Preserved existing job-level permissions for operations requiring write access
- Skipped `ai-fix.yml` (already handled in PR #20977)
- Skipped `copilot-automation.yml` (noted as unfixable in PR #20977 comments)

**Workflows updated:**
- `process-screenshots.yml` — added top-level read permissions
- `helm-release.yml` — changed empty permissions to `contents: read`
- `hive-interactive.yml` — changed empty permissions to `contents: read`
- `deploy-checksum.yml` — changed empty permissions to `contents: read`

Signed-off-by: Scanner &lt;scanner@kubestellar.io&gt;

Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;