### PR TITLE
🐛 fix: remove unused card variable causing TS6133 build break

### DIFF
--- a/web/src/lib/widgets/codeGenerator.templates.ci.ts
+++ b/web/src/lib/widgets/codeGenerator.templates.ci.ts
@@ -3,10 +3,8 @@
  */
 
 import type { TemplateHelpers } from './codeGenerator.templates'
-import { WIDGET_CARDS } from './widgetRegistry'
 
 export function generateCICardRender(cardType: string, helpers: TemplateHelpers): string | null {
-  const card = WIDGET_CARDS[cardType]
   const { parseBlock, wrapOpen, wrapClose, issueButton } = helpers
 
   switch (cardType) {

--- a/web/src/lib/widgets/codeGenerator.templates.infra.ts
+++ b/web/src/lib/widgets/codeGenerator.templates.infra.ts
@@ -3,10 +3,8 @@
  */
 
 import type { TemplateHelpers } from './codeGenerator.templates'
-import { WIDGET_CARDS } from './widgetRegistry'
 
 export function generateInfraCardRender(cardType: string, helpers: TemplateHelpers): string | null {
-  const card = WIDGET_CARDS[cardType]
   const { parseBlock, wrapOpen, wrapClose, issueButton } = helpers
 
   switch (cardType) {


### PR DESCRIPTION
Fixes #21018

Post-merge build broke with TS6133 (unused variable) errors:
- `codeGenerator.templates.ci.ts(9,9): 'card' is declared but its value is never read.`
- `codeGenerator.templates.infra.ts(9,9): 'card' is declared but its value is never read.`

Both files declared `const card = WIDGET_CARDS[cardType]` but never referenced `card`. Removed the unused declaration and the now-unused `WIDGET_CARDS` import from both template files.

Restores main to a green state.