### PR TITLE
[scanner] fix(security): sanitize user input before logging

### DIFF
--- a/.github/codeql/extensions/go/model.yml
+++ b/.github/codeql/extensions/go/model.yml
@@ -4,3 +4,8 @@ extensions:
       extensible: barrierModel
     data:
       - ["github.com/kubestellar/console/pkg/sanitize", "", false, "LogString", "", "", "ReturnValue", "log-injection", "manual"]
+      # Internal helper in pkg/agent that applies sanitize.LogString to
+      # user-controlled slog attribute values via a type switch. CodeQL's
+      # taint tracking does not propagate the sanitization through the
+      # []any return, so mark the return value as a barrier explicitly.
+      - ["github.com/kubestellar/console/pkg/agent", "", false, "sanitizeLogArgs", "", "", "ReturnValue", "log-injection", "manual"]

--- a/pkg/agent/kagent/kagent.go
+++ b/pkg/agent/kagent/kagent.go
@@ -299,7 +299,7 @@ func (h *Handlers) HandleCRDAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagent agents for cluster", "error", err)
+		slog.Warn("error fetching kagent agents for cluster", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
@@ -382,7 +382,7 @@ func (h *Handlers) HandleCRDTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagent tools for cluster", "error", err)
+		slog.Warn("error fetching kagent tools for cluster", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
@@ -478,7 +478,7 @@ func (h *Handlers) HandleCRDModels(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagent models for cluster", "error", err)
+		slog.Warn("error fetching kagent models for cluster", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"models": []any{}, "error": "internal server error"})
 		return
@@ -570,7 +570,7 @@ func (h *Handlers) HandleCRDMemories(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagent memories for cluster", "error", err)
+		slog.Warn("error fetching kagent memories for cluster", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"memories": []any{}, "error": "internal server error"})
 		return
@@ -633,7 +633,7 @@ func (h *Handlers) HandleCRDSummary(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagent CRD summary for cluster", "error", err)
+		slog.Warn("error fetching kagent CRD summary for cluster", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{
 			"agentCount": 0, "toolServerCount": 0, "remoteMCPServerCount": 0,
@@ -825,7 +825,7 @@ func (h *Handlers) HandleKagentiAgents(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching agents", "error", err)
+		slog.Warn("error fetching agents", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"agents": []any{}, "error": "internal server error"})
 		return
@@ -910,7 +910,7 @@ func (h *Handlers) HandleKagentiBuilds(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching builds", "error", err)
+		slog.Warn("error fetching builds", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"builds": []any{}, "error": "internal server error"})
 		return
@@ -990,7 +990,7 @@ func (h *Handlers) HandleKagentiCards(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching cards", "error", err)
+		slog.Warn("error fetching cards", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"cards": []any{}, "error": "internal server error"})
 		return
@@ -1063,7 +1063,7 @@ func (h *Handlers) HandleKagentiTools(w http.ResponseWriter, r *http.Request) {
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching tools", "error", err)
+		slog.Warn("error fetching tools", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{"tools": []any{}, "error": "internal server error"})
 		return
@@ -1136,7 +1136,7 @@ func (h *Handlers) HandleKagentiSummary(w http.ResponseWriter, r *http.Request) 
 
 	dynClient, err := h.Client.GetDynamicClient(cluster)
 	if err != nil {
-		slog.Warn("error fetching kagenti summary", "error", err)
+		slog.Warn("error fetching kagenti summary", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		httputil.WriteJSON(w, map[string]any{
 			"agentCount": 0, "readyAgents": 0, "buildCount": 0,

--- a/pkg/agent/prometheus.go
+++ b/pkg/agent/prometheus.go
@@ -87,12 +87,12 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	// SECURITY: Validate cluster and namespace against safe character sets to
 	// prevent SSRF and path-traversal via crafted query parameters (#7175).
 	if err := kube.ValidateKubeContext(cluster); err != nil {
-		slog.Error("[Prometheus] invalid cluster parameter", "error", err)
+		slog.Error("[Prometheus] invalid cluster parameter", "error", sanitize.LogString(err.Error()))
 		writePrometheusError(w, http.StatusBadRequest, "invalid cluster parameter")
 		return
 	}
 	if err := kube.ValidateDNS1123Label("namespace", namespace); err != nil {
-		slog.Error("[Prometheus] invalid namespace parameter", "error", err)
+		slog.Error("[Prometheus] invalid namespace parameter", "error", sanitize.LogString(err.Error()))
 		writePrometheusError(w, http.StatusBadRequest, "invalid namespace parameter")
 		return
 	}
@@ -114,7 +114,7 @@ func (s *Server) handlePrometheusQuery(w http.ResponseWriter, r *http.Request) {
 	}
 	// SECURITY: Validate service name to prevent path traversal (#7175).
 	if err := kube.ValidateDNS1123Label("service", serviceName); err != nil {
-		slog.Error("[Prometheus] invalid service parameter", "error", err)
+		slog.Error("[Prometheus] invalid service parameter", "error", sanitize.LogString(err.Error()))
 		writePrometheusError(w, http.StatusBadRequest, "invalid service parameter")
 		return
 	}

--- a/pkg/agent/server_federation.go
+++ b/pkg/agent/server_federation.go
@@ -90,7 +90,7 @@ func (s *Server) handleFederationDetect(w http.ResponseWriter, r *http.Request) 
 
 	contexts, err := s.resolveFederationContexts(ctx, r)
 	if err != nil {
-		slog.Warn("federation detect: failed to resolve contexts, returning empty", "error", err)
+		slog.Warn("federation detect: failed to resolve contexts, returning empty", "error", sanitize.LogString(err.Error()))
 		writeJSON(w, []federation.ProviderHubStatus{})
 		return
 	}

--- a/pkg/agent/server_gitops.go
+++ b/pkg/agent/server_gitops.go
@@ -452,7 +452,7 @@ func (s *Server) handleDetectDrift(w http.ResponseWriter, r *http.Request) {
 
 	tempDir, err := gitopsCloneRepo(ctx, req.RepoURL, req.Branch)
 	if err != nil {
-		slog.Warn("[agent] detect-drift: clone failed", "error", err)
+		slog.Warn("[agent] detect-drift: clone failed", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("clone repository", err), "source": "agent"})
 		return
@@ -575,7 +575,7 @@ func (s *Server) handleGitopsSync(w http.ResponseWriter, r *http.Request) {
 
 	tempDir, err := gitopsCloneRepo(ctx, req.RepoURL, req.Branch)
 	if err != nil {
-		slog.Warn("[agent] sync: clone failed", "error", err)
+		slog.Warn("[agent] sync: clone failed", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusInternalServerError)
 		writeJSON(w, map[string]string{"error": sanitizeAgentError("clone repository", err), "source": "agent"})
 		return

--- a/pkg/agent/server_http_kubeconfig.go
+++ b/pkg/agent/server_http_kubeconfig.go
@@ -260,7 +260,7 @@ func (s *Server) handleKubeconfigAddHTTP(w http.ResponseWriter, r *http.Request)
 	}
 
 	if err := s.kubectl.AddCluster(req); err != nil {
-		slog.Error("add cluster error", "error", err)
+		slog.Error("add cluster error", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, kubeconfigAddResponse{Success: false, Error: sanitizeAgentError("add cluster", err)})
 		return
@@ -300,7 +300,7 @@ func (s *Server) handleKubeconfigTestHTTP(w http.ResponseWriter, r *http.Request
 
 	result, err := s.kubectl.TestClusterConnection(req)
 	if err != nil {
-		slog.Error("test connection error", "error", err)
+		slog.Error("test connection error", "error", sanitize.LogString(err.Error()))
 		w.WriteHeader(http.StatusBadRequest)
 		writeJSON(w, kube.TestConnectionResult{Reachable: false, Error: "connection test failed"})
 		return

--- a/pkg/agent/server_http_resources.go
+++ b/pkg/agent/server_http_resources.go
@@ -264,7 +264,7 @@ func (s *Server) handleEventsHTTP(w http.ResponseWriter, r *http.Request) {
 	// Get events from the cluster
 	events, err := s.k8sClient.GetEvents(ctx, cluster, namespace, limit, fieldSelector)
 	if err != nil {
-		slog.Warn("error fetching events", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching events", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}

--- a/pkg/agent/server_http_resources_config.go
+++ b/pkg/agent/server_http_resources_config.go
@@ -35,7 +35,7 @@ func (s *Server) handleConfigMapsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	configmaps, err := s.k8sClient.GetConfigMaps(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching configmaps", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching configmaps", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -71,7 +71,7 @@ func (s *Server) handleSecretsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	secrets, err := s.k8sClient.GetSecrets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching secrets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching secrets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -120,7 +120,7 @@ func (s *Server) handleServiceAccountsHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	serviceaccounts, err := s.k8sClient.GetServiceAccounts(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching serviceaccounts", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching serviceaccounts", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -399,7 +399,7 @@ func (s *Server) handleJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	jobs, err := s.k8sClient.GetJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching jobs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching jobs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -433,7 +433,7 @@ func (s *Server) handleHPAsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	hpas, err := s.k8sClient.GetHPAs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching hpas", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching hpas", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}

--- a/pkg/agent/server_http_resources_rbac_storage.go
+++ b/pkg/agent/server_http_resources_rbac_storage.go
@@ -38,7 +38,7 @@ func (s *Server) handlePVCsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	pvcs, err := s.k8sClient.GetPVCs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching pvcs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching pvcs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -71,7 +71,7 @@ func (s *Server) handlePVsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	pvs, err := s.k8sClient.GetPVs(ctx, cluster)
 	if err != nil {
-		slog.Warn("error fetching pvs", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Warn("error fetching pvs", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -105,7 +105,7 @@ func (s *Server) handleRolesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	roles, err := s.k8sClient.ListRoles(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching roles", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching roles", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -154,7 +154,7 @@ func (s *Server) handleRoleBindingsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	bindings, err := s.k8sClient.ListRoleBindings(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching rolebindings", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching rolebindings", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}

--- a/pkg/agent/server_http_resources_workloads.go
+++ b/pkg/agent/server_http_resources_workloads.go
@@ -63,7 +63,7 @@ func (s *Server) handleNamespacesHTTP(w http.ResponseWriter, r *http.Request) {
 
 	namespaces, err := s.k8sClient.ListNamespacesWithDetails(ctx, cluster)
 	if err != nil {
-		slog.Warn("error fetching namespaces", "cluster", sanitize.LogString(cluster), "error", err)
+		slog.Warn("error fetching namespaces", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -192,7 +192,7 @@ func (s *Server) handleDeploymentsHTTP(w http.ResponseWriter, r *http.Request) {
 	// call, which lists deployments across all namespaces (#8121).
 	deployments, err := s.k8sClient.GetDeployments(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching deployments", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching deployments", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -227,7 +227,7 @@ func (s *Server) handleReplicaSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	replicasets, err := s.k8sClient.GetReplicaSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching replicasets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching replicasets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -261,7 +261,7 @@ func (s *Server) handleStatefulSetsHTTP(w http.ResponseWriter, r *http.Request) 
 	defer cancel()
 	statefulsets, err := s.k8sClient.GetStatefulSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching statefulsets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching statefulsets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -295,7 +295,7 @@ func (s *Server) handleDaemonSetsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	daemonsets, err := s.k8sClient.GetDaemonSets(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching daemonsets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching daemonsets", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -329,7 +329,7 @@ func (s *Server) handleCronJobsHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	cronjobs, err := s.k8sClient.GetCronJobs(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching cronjobs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching cronjobs", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -363,7 +363,7 @@ func (s *Server) handleIngressesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	ingresses, err := s.k8sClient.GetIngresses(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching ingresses", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching ingresses", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -397,7 +397,7 @@ func (s *Server) handleNetworkPoliciesHTTP(w http.ResponseWriter, r *http.Reques
 	defer cancel()
 	policies, err := s.k8sClient.GetNetworkPolicies(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching networkpolicies", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching networkpolicies", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}
@@ -431,7 +431,7 @@ func (s *Server) handleServicesHTTP(w http.ResponseWriter, r *http.Request) {
 	defer cancel()
 	services, err := s.k8sClient.GetServices(ctx, cluster, namespace)
 	if err != nil {
-		slog.Warn("error fetching services", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", err)
+		slog.Warn("error fetching services", "cluster", sanitize.LogString(cluster), "namespace", sanitize.LogString(namespace), "error", sanitize.LogString(err.Error()))
 		writeJSONError(w, http.StatusServiceUnavailable, "cluster temporarily unavailable")
 		return
 	}


### PR DESCRIPTION
Fixes #21030

Sanitizes user-controlled input flowing into `slog` structured logging under `pkg/agent` to close 39 CodeQL `go/log-injection` alerts (CWE-117).

## Approach

At each flagged call site the trailing `"error", err` attribute pair was wrapped with the existing `pkg/sanitize.LogString` helper:

```go
slog.Warn("...", "cluster", sanitize.LogString(cluster), "error", sanitize.LogString(err.Error()))
```

`err` values reflect namespace / cluster / context strings supplied by the caller in Kubernetes API errors, so they can carry `\n`, `\r`, or ANSI escapes.

## Files touched (10)

- `pkg/agent/server_http_resources_workloads.go` (9 alerts)
- `pkg/agent/server_http_resources_config.go` (5 alerts)
- `pkg/agent/server_http_resources_rbac_storage.go` (4 alerts)
- `pkg/agent/server_http_resources.go` (1 alert)
- `pkg/agent/server_http_kubeconfig.go` (2 alerts)
- `pkg/agent/server_gitops.go` (2 alerts)
- `pkg/agent/server_federation.go` (1 alert)
- `pkg/agent/prometheus.go` (3 alerts)
- `pkg/agent/kagent/kagent.go` (10 alerts)
- `.github/codeql/extensions/go/model.yml` — adds `sanitizeLogArgs` (pkg/agent) to the `log-injection` barrier list. This helper already applies `sanitize.LogString` at runtime, but CodeQL's taint tracker cannot follow the sanitization through its `[]any` return type, which was flagging `pkg/agent/websocket_deadline.go:38` and `:48` (alerts #1355, #1356).

## Verification

Per repository guidance CI validates build/lint. Sanitization uses only the already-present `sanitize` import in every touched file — no new imports required.