### PR TITLE
[scanner] fix: restore JSX in CardRuntime test setup and drop empty worker.handlers stub

### DIFF
--- a/web/src/lib/cache/__tests__/worker.handlers.test.ts
+++ b/web/src/lib/cache/__tests__/worker.handlers.test.ts
@@ -1,3 +1,0 @@
-/**
- * Cache worker handler tests are split across worker.handlers.*.test.ts files.
- */

--- a/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
+++ b/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
@@ -1,5 +1,4 @@
 import { vi, beforeEach } from 'vitest'
-import React from 'react'
 import type { CardDefinition } from '../types'
 
 type SkeletonProps = {

--- a/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
+++ b/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import { vi, beforeEach } from 'vitest'
 import type { CardDefinition } from '../types'
 

--- a/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
+++ b/web/src/lib/cards/__tests__/CardRuntime.setup.tsx
@@ -1,4 +1,5 @@
 import { vi, beforeEach } from 'vitest'
+import React from 'react'
 import type { CardDefinition } from '../types'
 
 type SkeletonProps = {
@@ -57,45 +58,64 @@ vi.mock('../../../components/cards/console-missions/shared', () => ({
 
 // Mock ClusterStatusBadge
 vi.mock('../../../components/ui/ClusterStatusBadge', () => ({
-  ClusterStatusDot: ({ state }: { state: string }) => 
-    ({ default: `<span data-testid="status-dot">${state}</span>` }),
+  ClusterStatusDot: ({ state }: { state: string }) => (
+    <span data-testid="status-dot">{state}</span>
+  ),
   getClusterState: () => 'healthy',
 }))
 
 // Mock Skeleton
 vi.mock('../../../components/ui/Skeleton', () => ({
-  Skeleton: ({ height, width, variant, className }: SkeletonProps) =>
-    ({ default: `<div data-testid="skeleton" data-variant=${variant} data-height=${height} data-width=${width} className=${className} />` }),
-  SkeletonCardWithRefresh: () => ({ default: `<div data-testid="skeleton-card-with-refresh" />` }),
+  Skeleton: ({ height, width, variant, className }: SkeletonProps) => (
+    <div
+      data-testid="skeleton"
+      data-variant={variant}
+      data-height={height}
+      data-width={width}
+      className={className}
+    />
+  ),
+  SkeletonCardWithRefresh: () => <div data-testid="skeleton-card-with-refresh" />,
 }))
 
 // Mock Pagination
 vi.mock('../../../components/ui/Pagination', () => ({
-  Pagination: ({ currentPage, totalPages }: PaginationProps) =>
-    ({ default: `<div data-testid="pagination" data-current=${currentPage} data-total=${totalPages} />` }),
+  Pagination: ({ currentPage, totalPages }: PaginationProps) => (
+    <div data-testid="pagination" data-current={currentPage} data-total={totalPages} />
+  ),
 }))
 
 // Mock CardControls
 vi.mock('../../../components/ui/CardControls', () => ({
-  CardControls: () => ({ default: `<div data-testid="card-controls" />` }),
+  CardControls: () => <div data-testid="card-controls" />,
 }))
 
 // Mock RefreshIndicator
 vi.mock('../../../components/ui/RefreshIndicator', () => ({
-  RefreshButton: ({ onRefresh, isRefreshing }: RefreshButtonProps) =>
-    ({ default: `<button data-testid="refresh-btn" data-refreshing=${isRefreshing} onClick=${onRefresh}>Refresh</button>` }),
+  RefreshButton: ({ onRefresh, isRefreshing }: RefreshButtonProps) => (
+    <button
+      data-testid="refresh-btn"
+      data-refreshing={isRefreshing}
+      onClick={onRefresh}
+    >
+      Refresh
+    </button>
+  ),
 }))
 
 // Mock ClusterBadge
 vi.mock('../../../components/ui/ClusterBadge', () => ({
-  ClusterBadge: ({ cluster }: ClusterBadgeProps) =>
-    ({ default: `<span data-testid="cluster-badge">${cluster}</span>` }),
+  ClusterBadge: ({ cluster }: ClusterBadgeProps) => (
+    <span data-testid="cluster-badge">{cluster}</span>
+  ),
 }))
 
 // Mock icons module
 vi.mock('../../icons', () => ({
   getIcon: (name: string) => {
-    return () => ({ default: `<span data-testid="icon-${name}">${name}</span>` })
+    const Icon = () => <span data-testid={`icon-${name}`}>{name}</span>
+    Icon.displayName = name
+    return Icon
   },
 }))
 


### PR DESCRIPTION
Fixes #21043

## Root cause

Two independent regressions were causing the 37 Coverage Suite failures reported in #21043.

### 1. `CardRuntime.setup.ts` — broken JSX (28+ failures)

PR #21010 split `CardRuntime-coverage.test.tsx` into per-concern files plus a shared `CardRuntime.setup.ts`. During the split the file lost its `.tsx` extension, so all JSX in the mock module factories was replaced with template-literal strings wrapped in `({ default: ... })` objects, e.g.:

```ts
Skeleton: (props) => ({ default: `<div data-testid="skeleton" ... />` })
```

The mocked components therefore returned plain objects, not React elements. Any test that rendered `<CardRuntime />` (`CardRuntime.features.test.tsx`, `CardRuntime.registry.test.tsx`, `CardRuntime.states.test.tsx`) failed as soon as React tried to reconcile those object children.

**Fix:** Rename to `CardRuntime.setup.tsx` and restore genuine JSX in the `Skeleton`, `Pagination`, `RefreshButton`, `ClusterBadge`, `ClusterStatusDot`, `CardControls`, and `getIcon` mocks, matching the pre-split file. Existing test files import via extension-less path (`./CardRuntime.setup`) so they continue to resolve.

### 2. `src/lib/cache/__tests__/worker.handlers.test.ts` — empty test file

The file contains only a 3-line JSDoc pointing readers to the split siblings (`worker.handlers.advanced/crud/dispatch.test.ts`). Vitest's `include: ['src/**/*.{test,spec}.{ts,tsx}']` still picks it up and reports "failed to load" because no tests are defined.

**Fix:** Delete the placeholder — actual coverage lives in the split files.

## Not addressed (separate/timing issues)

The two `useStackDiscovery.advanced.test.ts` failures (`clears interval on unmount…`, `exposes a refetch function…`) look like fake-timer/act flakiness independent of the root cause above and should be triaged separately if they recur after CI reruns.

## Testing

CI validates. Not running `npm run build/lint/tsc/vitest` locally per task instructions.