### PR TITLE
[scanner] fix: sanitize CodeQL go/log-injection sinks

### DIFF
--- a/pkg/agent/websocket_deadline.go
+++ b/pkg/agent/websocket_deadline.go
@@ -35,6 +35,7 @@ func setWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) err
 	if err := conn.SetWriteDeadline(time.Now().Add(wsWriteTimeout)); err != nil {
 		attrs := sanitizeLogArgs(logArgs)
 		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", sanitize.LogString(err.Error()))
+		// codeql[go/log-injection]: logMsg and attrs are sanitized with sanitize.LogString, which neutralizes CR/LF and control chars.
 		slog.Error(sanitize.LogString(logMsg), attrs...)
 		return err
 	}
@@ -45,6 +46,7 @@ func clearWSWriteDeadline(conn *websocket.Conn, logMsg string, logArgs ...any) e
 	if err := conn.SetWriteDeadline(time.Time{}); err != nil {
 		attrs := sanitizeLogArgs(logArgs)
 		attrs = append(attrs, "client", sanitize.LogString(conn.RemoteAddr().String()), "error", sanitize.LogString(err.Error()))
+		// codeql[go/log-injection]: logMsg and attrs are sanitized with sanitize.LogString, which neutralizes CR/LF and control chars.
 		slog.Error(sanitize.LogString(logMsg), attrs...)
 		return err
 	}


### PR DESCRIPTION
Fixes #21052

Adds CodeQL suppression comments to the two websocket deadline slog sinks flagged by go/log-injection. The values passed to those sinks are already routed through sanitize.LogString, which removes ANSI/control characters and replaces CR/LF and Unicode line separators before logging, so the alerts are false positives from CodeQL not modeling the project sanitizer.

Validation: not run, per task instruction.