### PR TITLE
[ci-maintainer] fix(workflows): correct malformed `permissions: read-all` YAML in 5 workflows (fixes #21058)

### DIFF
--- a/.github/workflows/console-live-promote-failure-issue.yml
+++ b/.github/workflows/console-live-promote-failure-issue.yml
@@ -14,7 +14,8 @@ on:
         required: true
         type: string
 
-permissions: read-all
+permissions:
+  contents: read
   actions: read
   issues: write
 

--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -23,7 +23,8 @@ on:
   schedule:
     - cron: '17 */12 * * *'
 
-permissions: read-all
+permissions:
+  contents: read
   packages: read
 
 concurrency:

--- a/.github/workflows/feedback.yml
+++ b/.github/workflows/feedback.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [closed]
 
-permissions: read-all
+permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/hive-trust-gate.yml
+++ b/.github/workflows/hive-trust-gate.yml
@@ -35,7 +35,8 @@ on:
         description: Why the actor passed or failed the gate
         value: ${{ jobs.evaluate.outputs.trust-reason }}
 
-permissions: read-all
+permissions:
+  contents: read
   issues: write
 jobs:
   evaluate:

--- a/.github/workflows/label-helper.yml
+++ b/.github/workflows/label-helper.yml
@@ -4,7 +4,8 @@ on:
   issue_comment:
     types: [created]
 
-permissions: read-all
+permissions:
+  contents: read
   issues: write
   pull-requests: write
 


### PR DESCRIPTION
## CI Fix

Five workflows on `main` were hitting `startup_failure` on every run because their top-level `permissions:` block had `read-all` as a scalar value **and** child scope keys underneath — invalid YAML that the Actions runner rejects before creating any jobs (all failing runs showed `total_jobs: 0` in <1 second).

Each affected file has been rewritten to use an explicit `permissions:` block with `contents: read` as the baseline plus the intended write scopes.

### Files changed

| File | Before | After |
|---|---|---|
| `.github/workflows/feedback.yml` | `permissions: read-all` + `pull-requests: write` | `permissions:` block w/ `contents: read`, `pull-requests: write` |
| `.github/workflows/label-helper.yml` | `permissions: read-all` + `issues: write`, `pull-requests: write` | explicit block w/ `contents: read` + writes |
| `.github/workflows/hive-trust-gate.yml` | `permissions: read-all` + `issues: write` | explicit block w/ `contents: read`, `issues: write` |
| `.github/workflows/console-live-promote.yml` | `permissions: read-all` + `packages: read` | explicit block w/ `contents: read`, `packages: read` |
| `.github/workflows/console-live-promote-failure-issue.yml` | `permissions: read-all` + `actions: read`, `issues: write` | explicit block w/ `contents: read`, `actions: read`, `issues: write` |

All 5 files validated with `python3 -c "import yaml; yaml.safe_load(open(f))"` locally before push.

Behavior is preserved: `contents: read` is the effective default granted by `read-all` for these workflows (which do not read any other scope), and the explicit write scopes match what the pre-break files declared.

Fixes #21058

---
*Filed by ci-maintainer agent (ACMM L6 — full mode). Do not self-merge.*