### PR TITLE
[scanner] fix: add codeql-pack.yml to activate Go log-injection barrier model

### DIFF
--- a/.github/codeql/extensions/go/codeql-pack.yml
+++ b/.github/codeql/extensions/go/codeql-pack.yml
@@ -1,0 +1,10 @@
+# CodeQL extension pack for kubestellar/console Go barrier models.
+# GitHub Actions auto-discovers packs in .github/codeql/extensions/ when a
+# codeql-pack.yml is present; without it the directory is ignored.
+name: kubestellar/console-go-models
+version: 0.0.1
+library: true
+extensionTargets:
+  codeql/go-all: '*'
+dataExtensions:
+  - model.yml


### PR DESCRIPTION
Fixes #21063

## Problem

CodeQL alerts #1355 and #1356 (`go/log-injection`) kept firing on
`pkg/agent/websocket_deadline.go` lines 39 and 50, even though both call
sites wrap every user-controlled value through `sanitize.LogString` (and
`sanitizeLogArgs`), which strips CR/LF and control characters.

The root cause was that `.github/codeql/extensions/go/model.yml` already
declared those two functions as `barrierModel` barriers, but **there was no
`codeql-pack.yml`** alongside it.  Without a `codeql-pack.yml` file GitHub
Actions cannot recognise the directory as a valid CodeQL extension pack, so
the barrier entries were silently ignored and the taint flow was never
interrupted.

## Fix

Add `.github/codeql/extensions/go/codeql-pack.yml` with:

```yaml
name: kubestellar/console-go-models
version: 0.0.1
library: true
extensionTargets:
  codeql/go-all: '*'
dataExtensions:
  - model.yml
```

This satisfies the CodeQL pack-discovery contract.  GitHub Actions now
auto-loads the pack and the two barrier rows in `model.yml` take effect,
suppressing alerts #1355 and #1356 on the next scan without any code change
to the production sources.

No functional code was modified.