### PR TITLE
[scanner] fix: coverage suite test failures

### DIFF
--- a/web/src/hooks/__tests__/useStackDiscovery.advanced.test.ts
+++ b/web/src/hooks/__tests__/useStackDiscovery.advanced.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach, act } from 'vitest'
-import { renderHook, waitFor } from '@testing-library/react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 

--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -269,15 +269,18 @@ export function useHelmReleases(cluster?: string) {
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails and no cached data is available
-      const demoReleases = getDemoHelmReleases()
-      if (!cluster) {
-        // Update cache so notifyListeners in finally reflects demo data
-        helmReleasesCache.data = demoReleases
-        helmReleasesCache.timestamp = Date.now()
+      // Fall back to demo data when API fails — only in demo mode so real users
+      // keep whatever cached data they had (tests assert this preservation).
+      if (isDemoMode()) {
+        const demoReleases = getDemoHelmReleases()
+        if (!cluster) {
+          // Update cache so notifyListeners in finally reflects demo data
+          helmReleasesCache.data = demoReleases
+          helmReleasesCache.timestamp = Date.now()
+        }
+        setReleases(demoReleases)
+        setLastRefresh(Date.now())
       }
-      setReleases(demoReleases)
-      setLastRefresh(Date.now())
     } finally {
       setIsLoading(false)
       setIsRefreshing(false)
@@ -444,10 +447,13 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails and no cached data is available
-      const demoHistory = getDemoHelmHistory()
-      setHistory(demoHistory)
-      setLastRefresh(Date.now())
+      // Fall back to demo data when API fails — only in demo mode so real users
+      // keep their cached history (tests assert this preservation).
+      if (isDemoMode()) {
+        const demoHistory = getDemoHelmHistory()
+        setHistory(demoHistory)
+        setLastRefresh(Date.now())
+      }
 
       // Update cache failure count on error and persist
       if (cluster && release) {
@@ -604,10 +610,13 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails and no cached data is available
-      const demoVals = getDemoHelmValues()
-      setValues(demoVals)
-      setLastRefresh(Date.now())
+      // Fall back to demo data when API fails — only in demo mode so real users
+      // keep their cached values (tests assert this preservation).
+      if (isDemoMode()) {
+        const demoVals = getDemoHelmValues()
+        setValues(demoVals)
+        setLastRefresh(Date.now())
+      }
 
       // Update cache failure count - read from cache directly
       if (cluster && release && namespace) {
@@ -719,10 +728,13 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
           setError(errorMessage)
           setConsecutiveFailures(prev => prev + 1)
 
-          // Fall back to demo data when API fails and no cached data is available
-          const demoVals = getDemoHelmValues()
-          setValues(demoVals)
-          setLastRefresh(Date.now())
+          // Fall back to demo data when API fails — only in demo mode so real
+          // users keep their cached values.
+          if (isDemoMode()) {
+            const demoVals = getDemoHelmValues()
+            setValues(demoVals)
+            setLastRefresh(Date.now())
+          }
         } finally {
           setIsLoading(false)
           setIsRefreshing(false)

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -192,9 +192,13 @@ export function useOperators(cluster?: string) {
 
       // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
       if (!token) {
-        // Fall back to demo data so the UI shows placeholder content without a token
-        const effectiveClusters = cluster ? [cluster] : ['demo']
-        setOperators(effectiveClusters.flatMap(c => getDemoOperators(c)))
+        // In demo mode, populate placeholder operators so the UI shows content.
+        // Outside demo mode we intentionally leave `operators` untouched so the
+        // hook doesn't fabricate data when the caller simply lacks a token.
+        if (isDemoMode()) {
+          const effectiveClusters = cluster ? [cluster] : ['demo']
+          setOperators(effectiveClusters.flatMap(c => getDemoOperators(c)))
+        }
         setIsLoading(false)
         setIsRefreshing(false)
         fetchInProgressRef.current = false
@@ -367,9 +371,12 @@ export function useOperatorSubscriptions(cluster?: string) {
 
       // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
       if (!token) {
-        // Fall back to demo data so the UI shows placeholder content without a token
-        const effectiveClusters = cluster ? [cluster] : ['demo']
-        setSubscriptions(effectiveClusters.flatMap(c => getDemoOperatorSubscriptions(c)))
+        // In demo mode, populate placeholder subscriptions so the UI shows content.
+        // Outside demo mode we intentionally leave `subscriptions` untouched.
+        if (isDemoMode()) {
+          const effectiveClusters = cluster ? [cluster] : ['demo']
+          setSubscriptions(effectiveClusters.flatMap(c => getDemoOperatorSubscriptions(c)))
+        }
         setIsLoading(false)
         setIsRefreshing(false)
         fetchInProgressRef.current = false


### PR DESCRIPTION
Fixes #21066

Coverage Suite run #4256 shows 8 failures introduced by PR #21062, which changed helm.ts / operators.ts to overwrite cached state with demo data in error / no-token paths and mis-imported `act` in the stack-discovery test.

## Fixes

**`useStackDiscovery.advanced.test.ts` (2 tests)**
- `act` was imported from `'vitest'`, but vitest does not export `act`. Moved it to the `@testing-library/react` import so the two tests that call `act()` — *clears interval on unmount to prevent worker hangs* and *exposes a refetch function that triggers a non-silent refetch* — actually execute.

**`helm.ts` (4 tests)**
- `useHelmReleases`, `useHelmHistory`, and `useHelmValues` previously overwrote cached state with demo data in every catch branch. That broke the *keeps cached data on subsequent fetch failure* / *preserves cached history / values on subsequent fetch failure* / *updates cache failure count on error when cache entry exists* tests, which assert the last-successful state is preserved on error. Guarded the demo fallback with `isDemoMode()` so real users keep their cache while demo-mode tests (which set `mockIsDemoMode(true)`) still see the placeholder data.

**`operators.ts` (2 tests)**
- `useOperators` / `useOperatorSubscriptions` unconditionally seeded demo operators/subscriptions in the no-token early-return path, which broke *skips REST call when no token in localStorage (prevents GA4 auth errors)* (asserts `operators.length === 0`). Now only seeds demo data when `isDemoMode()` is `true`.

3 files changed, 47 insertions(+), 28 deletions(-).