### PR TITLE
🐛 fix: add isDemoData to helm cache reset listener (unbreak main)

### DIFF
--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -799,6 +799,7 @@ if (typeof window !== 'undefined') {
     helmReleasesCache.timestamp = 0
     helmReleasesCache.consecutiveFailures = 0
     helmReleasesCache.lastError = null
+    helmReleasesCache.isDemoData = false
 
     // Notify all listeners with isLoading: true to trigger skeleton display
     helmReleasesCache.listeners.forEach(listener => {
@@ -808,7 +809,8 @@ if (typeof window !== 'undefined') {
         isRefreshing: false,
         consecutiveFailures: 0,
         lastError: null,
-        lastRefresh: null
+        lastRefresh: null,
+        isDemoData: false
       })
     })
   })


### PR DESCRIPTION
Fixes #21077
Fixes #21078
Fixes #21079

## Problem

`main` is red. PR #21076 added `isDemoData` as a required field of `HelmReleasesCacheState`, but missed the cache-reset listener notification at `web/src/hooks/mcp/helm.ts:805`, which still constructs the state literal without it.

```
src/hooks/mcp/helm.ts(805,16): error TS2345: ...
  Property 'isDemoData' is missing in type '...' but required in type 'HelmReleasesCacheState'.
```

## Fix

- Add `isDemoData: false` to the listener notification payload in the cache-reset path.
- Also reset `helmReleasesCache.isDemoData = false` on the module-level cache so it stays consistent with the notified state (matching the surrounding reset of `data`, `timestamp`, `consecutiveFailures`, `lastError`).

Scoped to a single hook file; CI will validate the tsc build.