### PR TITLE
🐛 fix: nightly unit-test regression

### DIFF
--- a/web/src/hooks/mcp/helm.ts
+++ b/web/src/hooks/mcp/helm.ts
@@ -281,9 +281,9 @@ export function useHelmReleases(cluster?: string) {
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails — only in demo mode so real users
-      // keep whatever cached data they had (tests assert this preservation).
-      if (isDemoMode()) {
+      // Fall back to demo data when API fails and no cached data is available,
+      // or when in demo mode for the forced-demo-preview experience.
+      if (isDemoMode() || helmReleasesCache.data.length === 0) {
         const demoReleases = getDemoHelmReleases()
         if (!cluster) {
           // Update cache so notifyListeners in finally reflects demo data
@@ -464,9 +464,9 @@ export function useHelmHistory(cluster?: string, release?: string, namespace?: s
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails — only in demo mode so real users
-      // keep their cached history (tests assert this preservation).
-      if (isDemoMode()) {
+      // Fall back to demo data when API fails and no history is available,
+      // or when in demo mode for the forced-demo-preview experience.
+      if (isDemoMode() || history.length === 0) {
         const demoHistory = getDemoHelmHistory()
         setHistory(demoHistory)
         setLastRefresh(Date.now())
@@ -631,9 +631,9 @@ export function useHelmValues(cluster?: string, release?: string, namespace?: st
       setError(errorMessage)
       setConsecutiveFailures(prev => prev + 1)
 
-      // Fall back to demo data when API fails — only in demo mode so real users
-      // keep their cached values (tests assert this preservation).
-      if (isDemoMode()) {
+      // Fall back to demo data when API fails and no values are available,
+      // or when in demo mode for the forced-demo-preview experience.
+      if (isDemoMode() || values === null) {
         const demoVals = getDemoHelmValues()
         setValues(demoVals)
         setLastRefresh(Date.now())

--- a/web/src/hooks/mcp/operators.ts
+++ b/web/src/hooks/mcp/operators.ts
@@ -194,10 +194,8 @@ export function useOperators(cluster?: string) {
 
       // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
       if (!token) {
-        // In demo mode, populate placeholder operators so the UI shows content.
-        // Outside demo mode we intentionally leave `operators` untouched so the
-        // hook doesn't fabricate data when the caller simply lacks a token.
-        if (isDemoMode()) {
+        // Fall back to demo data when there is no live data to show (empty cache or demo mode).
+        if (isDemoMode() || operators.length === 0) {
           const effectiveClusters = cluster ? [cluster] : ['demo']
           setOperators(effectiveClusters.flatMap(c => getDemoOperators(c)))
           setIsDemoData(true)
@@ -378,9 +376,8 @@ export function useOperatorSubscriptions(cluster?: string) {
 
       // REST fallback — skip entirely if no token to prevent GA4 auth errors (#9957)
       if (!token) {
-        // In demo mode, populate placeholder subscriptions so the UI shows content.
-        // Outside demo mode we intentionally leave `subscriptions` untouched.
-        if (isDemoMode()) {
+        // Fall back to demo data when there is no live data to show (empty cache or demo mode).
+        if (isDemoMode() || subscriptions.length === 0) {
           const effectiveClusters = cluster ? [cluster] : ['demo']
           setSubscriptions(effectiveClusters.flatMap(c => getDemoOperatorSubscriptions(c)))
           setIsDemoData(true)


### PR DESCRIPTION
Fixes #21083

Restores demo data fallback in `useOperators`, `useOperatorSubscriptions`, `useHelmReleases`, `useHelmHistory`, and `useHelmValues` when the API is unavailable and no cached data exists. PR #21076 narrowed the fallback to only trigger when `isDemoMode()` is true, breaking 5 unit tests that assert non-empty results for unauthenticated/API-down scenarios.

Fix: also trigger demo fallback when the local cache is empty (`operators.length === 0`, `helmReleasesCache.data.length === 0`, etc.), preserving cached live data for authenticated users during transient failures.