### PR TITLE
[scanner] fix: operators hook token-guard test failures (run #4260)

### DIFF
--- a/web/src/hooks/mcp/__tests__/operators.test.ts
+++ b/web/src/hooks/mcp/__tests__/operators.test.ts
@@ -441,7 +441,9 @@ describe('useOperators – SSE unavailable when no token', () => {
     // Neither SSE nor REST should be attempted without a token (#9957)
     expect(mockFetchSSE).not.toHaveBeenCalled()
     expect(mockApiGet).not.toHaveBeenCalled()
-    expect(result.current.operators.length).toBe(0)
+    // PR #21082: no-token path now returns demo data so the UI isn't empty
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.operators.length).toBeGreaterThan(0)
   })
 
   it('falls back to REST when token is demo-token', async () => {
@@ -644,7 +646,9 @@ describe('useOperatorSubscriptions – SSE unavailable when no token', () => {
     // Neither SSE nor REST should be attempted without a token (#9957)
     expect(mockFetchSSE).not.toHaveBeenCalled()
     expect(mockApiGet).not.toHaveBeenCalled()
-    expect(result.current.subscriptions.length).toBe(0)
+    // PR #21082: no-token path now returns demo data so the UI isn't empty
+    expect(result.current.isDemoData).toBe(true)
+    expect(result.current.subscriptions.length).toBeGreaterThan(0)
   })
 })
 


### PR DESCRIPTION
Fixes #21085

PR #21082 changed the no-token fallback path in `useOperators` and `useOperatorSubscriptions` to return demo data instead of an empty state (so the UI shows content rather than a blank card). This broke 2 tests that asserted `operators.length === 0` / `subscriptions.length === 0` when no token is present.

**Root cause:** The tests' length-zero assertions reflected the old behavior (empty state on no token). The new contract is: return demo data with `isDemoData=true` when there's no token, but still skip both SSE and REST calls.

**Fix:** Updated the two failing tests to:
- Keep the `mockFetchSSE` and `mockApiGet` not-called assertions (the token guard still prevents network calls)
- Replace `length === 0` with `isDemoData === true` + `length > 0` (matching the new demo-fallback contract)

No hook code was changed.