### PR TITLE
🐛 fix: prevent kc-live PVC-immutable rollback deadlock on RWO storage

### DIFF
--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -484,11 +484,24 @@ jobs:
 
           prod_values="$RUNNER_TEMP/console-live/prod-values.yaml"
           promote_timestamp="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          # ReadWriteOnce block storage cannot support RollingUpdate on a
+          # single-replica deployment: the new pod cannot mount the PVC
+          # while the old pod still holds it, causing a "Pending
+          # termination" deadlock and a subsequent Helm rollback that
+          # fails on PVC-immutability (see #21087, #21088).
+          if [ "$LIVE_PERSISTENCE_ACCESS_MODE" = "ReadWriteOnce" ]; then
+            deployment_strategy_type="Recreate"
+          else
+            deployment_strategy_type="RollingUpdate"
+          fi
           cat > "$prod_values" <<EOF
           image:
             repository: "$IMAGE_REPOSITORY"
             tag: "${{ steps.candidate.outputs.tag }}"
             pullPolicy: Always
+          deployment:
+            strategy:
+              type: "$deployment_strategy_type"
           podAnnotations:
             console-live.kubestellar.io/promote-run-id: "${{ github.run_id }}"
             console-live.kubestellar.io/promote-candidate-tag: "${{ steps.candidate.outputs.tag }}"

--- a/deploy/helm/kubestellar-console/templates/deployment.yaml
+++ b/deploy/helm/kubestellar-console/templates/deployment.yaml
@@ -11,10 +11,12 @@ spec:
     matchLabels:
       {{- include "kubestellar-console.selectorLabels" . | nindent 6 }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.deployment.strategy.type }}
+    {{- if eq .Values.deployment.strategy.type "RollingUpdate" }}
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+      maxSurge: {{ .Values.deployment.strategy.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.deployment.strategy.rollingUpdate.maxUnavailable }}
+    {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -119,6 +119,16 @@ resources:
 # an early "Progress deadline exceeded" rollback before Helm times out.
 deployment:
   progressDeadlineSeconds: 900
+  # Deployment rollout strategy. Use Recreate for single-replica deployments
+  # backed by a ReadWriteOnce PVC (e.g. kc-live on block storage) to avoid
+  # the RollingUpdate deadlock where the new pod cannot mount the RWO volume
+  # while the old pod still holds it.
+  # Values: RollingUpdate | Recreate
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
 
 # GitHub OAuth configuration
 github:


### PR DESCRIPTION
Fixes #21087
Fixes #21088

## Root cause

The `kc-live-kubestellar-console` Deployment uses the default `RollingUpdate` strategy against a ReadWriteOnce PVC. On every upgrade two failures cascade:

1. **RollingUpdate deadlock** (#21087): with `maxSurge=1` / `maxUnavailable=0`, Kubernetes schedules the new pod before terminating the old one. The new pod cannot mount the RWO PVC while the old pod holds it → pod stays `Pending` → Helm times out and auto-rolls back.
2. **PVC immutability error** (#21088): during rollback Helm attempts to patch `spec.volumeName` back to empty string on the already-bound PVC, which Kubernetes rejects as an immutable field.

## Changes

### 1. Configurable deployment strategy (`values.yaml` + `deployment.yaml`)

Added `deployment.strategy` to `values.yaml` (default: `RollingUpdate` — no behaviour change for existing deployments). Updated `deployment.yaml` to render the strategy block from values; the `rollingUpdate` sub-block is omitted when `type: Recreate`.

The `kc-live` Helm release must be updated to set:
```
--set deployment.strategy.type=Recreate
```
This ensures the old pod terminates and releases the RWO PVC before the new pod is scheduled, breaking the deadlock.

### 2. PVC keep annotation (already in `pvc.yaml` from #20982)

`helm.sh/resource-policy: keep` prevents Helm from touching the PVC during rollback. The `{{- if not $existingPVC }}` guard skips re-rendering the PVC on upgrade so Helm never diffs/patches the bound `spec.volumeName`.

## Verification

- Default values unchanged: `RollingUpdate` with `maxSurge: 1` / `maxUnavailable: 0`
- `Recreate` path omits the `rollingUpdate` block (required by Kubernetes API)
- No other deployments inherit `Recreate` unintentionally — it must be opted-in per release

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>