### PR TITLE
[quality] add unit tests for CardMeta and CardFailureBanner

### DIFF
--- a/web/src/components/cards/__tests__/CardErrorFallback.test.tsx
+++ b/web/src/components/cards/__tests__/CardErrorFallback.test.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+/**
+ * Unit tests for CardFailureBanner (addresses #21094).
+ *
+ * CardFailureBanner is the inline error surface used by every card via
+ * CardWrapper when a refresh fails. Testing this shared infrastructure
+ * covers a large surface area with a small amount of test code.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { CardFailureBanner, type CardFailureBannerProps } from '../CardErrorFallback'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && 'count' in opts) return `${key}:${opts.count}`
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+function renderBanner(overrides: Partial<CardFailureBannerProps> = {}) {
+  const props: CardFailureBannerProps = {
+    cardType: 'cluster_health',
+    isFailed: true,
+    isCollapsed: false,
+    consecutiveFailures: 1,
+    isVisuallySpinning: false,
+    ...overrides,
+  }
+  return render(<CardFailureBanner {...props} />)
+}
+
+describe('CardFailureBanner', () => {
+  it('renders nothing when the card is not failed', () => {
+    const { container } = renderBanner({ isFailed: false })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing when the card is collapsed', () => {
+    const { container } = renderBanner({ isCollapsed: true })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders nothing for the events_timeline compact-failure card type', () => {
+    const { container } = renderBanner({ cardType: 'events_timeline' })
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the banner with a failure count when the card has failed', () => {
+    renderBanner({ consecutiveFailures: 3 })
+    expect(screen.getByTestId('card-failure-banner')).toBeTruthy()
+    expect(screen.getByText('cardWrapper.refreshFailedCount:3')).toBeTruthy()
+  })
+
+  it('shows the error message inline when provided', () => {
+    renderBanner({ errorMessage: 'boom: connection refused' })
+    expect(screen.getByText(/boom: connection refused/)).toBeTruthy()
+  })
+
+  it('does not render the view-logs toggle when there is no error message', () => {
+    renderBanner()
+    expect(screen.queryByLabelText('cardWrapper.viewLogs')).toBeNull()
+    expect(screen.queryByLabelText('cardWrapper.hideLogs')).toBeNull()
+  })
+
+  it('toggles the failure log details when view-logs is clicked', async () => {
+    const user = userEvent.setup()
+    renderBanner({ errorMessage: 'stack: EPIPE at socket' })
+    // Logs hidden by default
+    expect(screen.queryByTestId('card-failure-logs')).toBeNull()
+    await user.click(screen.getByLabelText('cardWrapper.viewLogs'))
+    expect(screen.getByTestId('card-failure-logs')).toBeTruthy()
+    // Now the button flips to hide-logs
+    await user.click(screen.getByLabelText('cardWrapper.hideLogs'))
+    expect(screen.queryByTestId('card-failure-logs')).toBeNull()
+  })
+
+  it('invokes onRefresh when the retry button is clicked', async () => {
+    const onRefresh = vi.fn()
+    const user = userEvent.setup()
+    renderBanner({ onRefresh })
+    await user.click(screen.getByLabelText('cardWrapper.failureRetry'))
+    expect(onRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render the retry button when no onRefresh is provided', () => {
+    renderBanner()
+    expect(screen.queryByLabelText('cardWrapper.failureRetry')).toBeNull()
+  })
+
+  it('hides the remove button below the failure threshold', () => {
+    renderBanner({ onRemove: vi.fn(), consecutiveFailures: 2 })
+    expect(screen.queryByTestId('card-remove-button')).toBeNull()
+  })
+
+  it('shows the remove button at or above the failure threshold and calls onRemove', async () => {
+    const onRemove = vi.fn()
+    const user = userEvent.setup()
+    renderBanner({ onRemove, consecutiveFailures: 3 })
+    const remove = screen.getByTestId('card-remove-button')
+    await user.click(remove)
+    expect(onRemove).toHaveBeenCalledTimes(1)
+  })
+
+  it('spins the retry icon when isRefreshing or isVisuallySpinning is true', () => {
+    const { container, rerender } = renderBanner({
+      onRefresh: vi.fn(),
+      isRefreshing: true,
+    })
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+    rerender(
+      <CardFailureBanner
+        cardType="cluster_health"
+        isFailed
+        isCollapsed={false}
+        consecutiveFailures={1}
+        isVisuallySpinning
+        onRefresh={vi.fn()}
+      />
+    )
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('resets the log-visibility toggle when the card recovers from failure', async () => {
+    const user = userEvent.setup()
+    const { rerender } = render(
+      <CardFailureBanner
+        cardType="cluster_health"
+        isFailed
+        isCollapsed={false}
+        consecutiveFailures={1}
+        isVisuallySpinning={false}
+        errorMessage="boom"
+      />
+    )
+    await user.click(screen.getByLabelText('cardWrapper.viewLogs'))
+    expect(screen.getByTestId('card-failure-logs')).toBeTruthy()
+    rerender(
+      <CardFailureBanner
+        cardType="cluster_health"
+        isFailed={false}
+        isCollapsed={false}
+        consecutiveFailures={0}
+        isVisuallySpinning={false}
+        errorMessage="boom"
+      />
+    )
+    // Banner unmounts entirely when not failed, so logs must be gone.
+    expect(screen.queryByTestId('card-failure-logs')).toBeNull()
+  })
+})

--- a/web/src/components/cards/__tests__/CardMeta.test.tsx
+++ b/web/src/components/cards/__tests__/CardMeta.test.tsx
@@ -1,0 +1,132 @@
+import React from 'react'
+/**
+ * Unit tests for CardMeta presentational badges (addresses #21094).
+ *
+ * CardMeta is used by every card via CardWrapper to render the demo /
+ * live / failure / refresh indicators. These are pure branch checks so
+ * we can mock i18n and formatters and assert directly on the DOM.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CardMeta, type CardMetaProps } from '../CardMeta'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && 'count' in opts) return `${key}:${opts.count}`
+      if (opts && 'time' in opts) return `${key}:${opts.time}`
+      return key
+    },
+    i18n: { language: 'en', changeLanguage: vi.fn() },
+  }),
+}))
+
+vi.mock('@/lib/formatters', () => ({
+  formatTimeAgo: (d: Date) => `ago:${d.toISOString()}`,
+}))
+
+function renderMeta(overrides: Partial<CardMetaProps> = {}) {
+  const props: CardMetaProps = {
+    showDemoIndicator: false,
+    isDemoData: false,
+    isLive: false,
+    isFailed: false,
+    consecutiveFailures: 0,
+    showRefreshIndicator: false,
+    isLoading: false,
+    isVisuallySpinning: false,
+    lastUpdated: null,
+    ...overrides,
+  }
+  return render(<CardMeta {...props} />)
+}
+
+describe('CardMeta', () => {
+  it('renders nothing when all indicators are off and no lastUpdated', () => {
+    const { container } = renderMeta()
+    expect(container.textContent).toBe('')
+  })
+
+  it('shows the demo badge when showDemoIndicator is true', () => {
+    renderMeta({ showDemoIndicator: true, isDemoData: true })
+    const badge = screen.getByTestId('demo-badge')
+    expect(badge).toBeTruthy()
+    expect(badge.getAttribute('title')).toBe('cardWrapper.demoBadgeTitle')
+  })
+
+  it('uses demoModeTitle when demo indicator is shown but data is not demo', () => {
+    renderMeta({ showDemoIndicator: true, isDemoData: false })
+    const badge = screen.getByTestId('demo-badge')
+    expect(badge.getAttribute('title')).toBe('cardWrapper.demoModeTitle')
+  })
+
+  it('shows the live badge only for healthy non-demo cards', () => {
+    renderMeta({ isLive: true })
+    expect(screen.getByTitle('cardWrapper.liveBadgeTitle')).toBeTruthy()
+  })
+
+  it('hides the live badge when the card is in demo mode', () => {
+    renderMeta({ isLive: true, showDemoIndicator: true })
+    expect(screen.queryByTitle('cardWrapper.liveBadgeTitle')).toBeNull()
+  })
+
+  it('hides the live badge when the card has failed', () => {
+    renderMeta({ isLive: true, isFailed: true, consecutiveFailures: 2 })
+    expect(screen.queryByTitle('cardWrapper.liveBadgeTitle')).toBeNull()
+  })
+
+  it('renders a failure indicator with consecutiveFailures tooltip when failed', () => {
+    renderMeta({ isFailed: true, consecutiveFailures: 4 })
+    const failed = screen.getByRole('alert')
+    expect(failed.getAttribute('title')).toBe('cardWrapper.refreshFailedCount:4')
+    expect(failed.textContent).toContain('cardWrapper.refreshFailed')
+  })
+
+  it('shows the spinning refresh icon only when not failed', () => {
+    const { container } = renderMeta({ showRefreshIndicator: true })
+    expect(container.querySelector('.animate-spin')).not.toBeNull()
+  })
+
+  it('does not show the spinning refresh icon when failed', () => {
+    const { container } = renderMeta({
+      showRefreshIndicator: true,
+      isFailed: true,
+      consecutiveFailures: 1,
+    })
+    expect(container.querySelector('.animate-spin')).toBeNull()
+  })
+
+  it('renders a lastUpdated timestamp when idle', () => {
+    const when = new Date('2024-01-02T03:04:05Z')
+    renderMeta({ lastUpdated: when })
+    expect(screen.getByText(`ago:${when.toISOString()}`)).toBeTruthy()
+  })
+
+  it('suppresses the lastUpdated timestamp while loading', () => {
+    const when = new Date('2024-01-02T03:04:05Z')
+    renderMeta({ lastUpdated: when, isLoading: true })
+    expect(screen.queryByText(`ago:${when.toISOString()}`)).toBeNull()
+  })
+
+  it('suppresses the lastUpdated timestamp while visually spinning', () => {
+    const when = new Date('2024-01-02T03:04:05Z')
+    renderMeta({ lastUpdated: when, isVisuallySpinning: true })
+    expect(screen.queryByText(`ago:${when.toISOString()}`)).toBeNull()
+  })
+
+  it('uses the stale tooltip label when failed', () => {
+    const when = new Date('2024-01-02T03:04:05Z')
+    renderMeta({ lastUpdated: when, isFailed: true, consecutiveFailures: 1 })
+    const stamp = screen.getByText(`ago:${when.toISOString()}`)
+    expect(stamp.getAttribute('title')).toContain('cardWrapper.lastRefreshedStale')
+  })
+
+  it('uses the fresh tooltip label when not failed', () => {
+    const when = new Date('2024-01-02T03:04:05Z')
+    renderMeta({ lastUpdated: when })
+    const stamp = screen.getByText(`ago:${when.toISOString()}`)
+    expect(stamp.getAttribute('title')).toContain('cardWrapper.lastRefreshed')
+    expect(stamp.getAttribute('title')).not.toContain('Stale')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds unit tests for two previously-untested shared card infrastructure files. Both are used by every card in `web/src/components/cards/` via `CardWrapper`, so tests here have high leverage against the coverage gap tracked in #21094.

### `CardMeta.test.tsx` (12 tests)

Covers every branch of the `CardMeta` presentational component:

- No indicators + no `lastUpdated` → renders nothing
- Demo badge visibility + `isDemoData` vs demo-mode tooltip switching
- Live badge only when healthy, non-demo, non-failed (matches `shouldShowLiveBadge`)
- Failure indicator with `consecutiveFailures` count in the tooltip
- Refresh spinner rendered only when not failed
- `lastUpdated` timestamp gated by `isLoading` / `isVisuallySpinning`
- Stale vs fresh `lastRefreshed` tooltip label based on `isFailed`

### `CardErrorFallback.test.tsx` (12 tests)

Covers `CardFailureBanner` (the inline failure surface exported from `CardErrorFallback.tsx`):

- Renders nothing when not failed, when collapsed, or for the `events_timeline` compact-failure card type (matches `shouldShowFailureBanner`)
- Displays the `refreshFailedCount` header and inline error message
- View-logs toggle shows/hides the `card-failure-logs` block, and no toggle is rendered when there is no error message
- `onRefresh` and `onRemove` callback wiring
- Remove button hidden below the `REMOVE_CARD_FAILURE_THRESHOLD` (3), shown at/above
- Retry icon spins when either `isRefreshing` or `isVisuallySpinning` is true
- Banner unmounts (and stops leaking log-visibility state) when the card recovers

### Mocking

Both suites follow the existing `CardToolbar` / `CardLoadingState` test pattern: mock `react-i18next` so translation keys pass through, and stub `@/lib/formatters#formatTimeAgo` for deterministic timestamp assertions in the `CardMeta` suite.

Fixes #21094

---
*Filed by quality agent (ACMM L4/L6 — full mode)*