### PR TITLE
[scanner] test: security & compliance card tests

### DIFF
--- a/web/src/components/cards/ComplianceDrift.test.tsx
+++ b/web/src/components/cards/ComplianceDrift.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import ComplianceDrift from './ComplianceDrift'
+
+const mockUseKyverno = vi.hoisted(() => vi.fn())
+const mockUseTrivy = vi.hoisted(() => vi.fn())
+const mockUseKubescape = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useKyverno', () => ({ useKyverno: () => mockUseKyverno() }))
+vi.mock('../../hooks/useTrivy', () => ({ useTrivy: () => mockUseTrivy() }))
+vi.mock('../../hooks/useKubescape', () => ({ useKubescape: () => mockUseKubescape() }))
+vi.mock('../../hooks/useGlobalFilters', () => ({ useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('./kyverno/KyvernoDetailModal', () => ({ KyvernoDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="kyverno-modal" /> : null }))
+vi.mock('./trivy/TrivyDetailModal', () => ({ TrivyDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="trivy-modal" /> : null }))
+vi.mock('./kubescape/KubescapeDetailModal', () => ({ KubescapeDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="kubescape-modal" /> : null }))
+vi.mock('../ui/RefreshIndicator', () => ({ RefreshIndicator: () => null }))
+vi.mock('../ui/Button', () => ({ Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => <button onClick={onClick}>{children}</button> }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+function setup(overrides: { kyverno?: Record<string, unknown>; trivy?: Record<string, unknown>; kubescape?: Record<string, unknown> } = {}) {
+  const baseHook = { isLoading: false, isRefreshing: false, isDemoData: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0, lastRefresh: null }
+  mockUseKyverno.mockReturnValue({ ...baseHook, statuses: {}, ...overrides.kyverno })
+  mockUseTrivy.mockReturnValue({ ...baseHook, statuses: {}, ...overrides.trivy })
+  mockUseKubescape.mockReturnValue({ ...baseHook, statuses: {}, ...overrides.kubescape })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('ComplianceDrift', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ kyverno: { isLoading: true } }); render(<ComplianceDrift config={{}} />); expect(screen.getByText('complianceDrift.scanning')).toBeInTheDocument() })
+  it('renders empty state when all clusters are within baseline', () => { render(<ComplianceDrift config={{}} />); expect(screen.getByText('complianceDrift.allWithinBaseline')).toBeInTheDocument() })
+  it('renders error state', () => { const err = { a: { error: 'x' } }; setup({ kyverno: { statuses: err }, trivy: { statuses: err }, kubescape: { statuses: err } }); render(<ComplianceDrift config={{}} />); expect(screen.getByText('complianceDrift.failedToLoad')).toBeInTheDocument() })
+  it('renders happy-path drift data', () => { setup({ kyverno: { statuses: { a: { installed: true, policies: [{ violations: 0 }] }, b: { installed: true, policies: [{ violations: 20 }] }, c: { installed: true, policies: [{ violations: 1 }] } } } }); render(<ComplianceDrift config={{}} />); expect(screen.getByText('b')).toBeInTheDocument(); expect(screen.getByText('Kyverno')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ kubescape: { statuses: { a: { installed: true, overallScore: 95, totalControls: 10 }, b: { installed: true, overallScore: 40, totalControls: 10 }, c: { installed: true, overallScore: 90, totalControls: 10 } } } }); const { container } = render(<ComplianceDrift config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/DataComplianceCards.test.tsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CertManager, ExternalSecrets, VaultSecrets } from './DataComplianceCards'
+
+const mockUseCertManager = vi.hoisted(() => vi.fn())
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useCertManager', () => ({ useCertManager: () => mockUseCertManager() }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../lib/kubectlProxy', () => ({ kubectlProxy: { exec: vi.fn() } }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+const status = { installed: false, validCertificates: 0, expiringSoon: 0, expired: 0, totalCertificates: 0, pending: 0, failed: 0, recentRenewals: 0 }
+function setup() { mockUseCertManager.mockReturnValue({ status, issuers: [], isLoading: false, isRefreshing: false, isDemoData: false, consecutiveFailures: 0, isFailed: false }); mockUseClusters.mockReturnValue({ deduplicatedClusters: [] }); mockUseCardLoadingState.mockReturnValue({}) }
+
+describe('DataComplianceCards re-exports', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading state via re-exported components', () => { expect(CertManager).toBeTypeOf('function'); expect(ExternalSecrets).toBeTypeOf('function'); expect(VaultSecrets).toBeTypeOf('function') })
+  it('renders empty state for CertManager', () => { render(<CertManager config={{}} />); expect(screen.getByText('No cert-manager installation detected')).toBeInTheDocument() })
+  it('renders error state metadata through CertManager export', () => { mockUseCertManager.mockReturnValue({ status, issuers: [], isLoading: false, isRefreshing: false, isDemoData: false, consecutiveFailures: 3, isFailed: true }); render(<CertManager config={{}} />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isFailed: true })) })
+  it('renders happy-path data for all named exports', async () => { const { rerender } = render(<CertManager config={{}} />); expect(screen.getByText('Cert-Manager Integration')).toBeInTheDocument(); rerender(<ExternalSecrets config={{}} />); expect(await screen.findByText('No clusters connected')).toBeInTheDocument(); rerender(<VaultSecrets config={{}} />); expect(await screen.findByText('No clusters connected')).toBeInTheDocument() })
+  it('matches snapshot', () => { const { container } = render(<CertManager config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/DataComplianceCertManager.test.tsx
+++ b/web/src/components/cards/DataComplianceCertManager.test.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CertManager } from './DataComplianceCertManager'
+
+const mockUseCertManager = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useCertManager', () => ({ useCertManager: () => mockUseCertManager() }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+const status = { installed: false, validCertificates: 0, expiringSoon: 0, expired: 0, totalCertificates: 0, pending: 0, failed: 0, recentRenewals: 0 }
+function setup(overrides: Record<string, unknown> = {}) { mockUseCertManager.mockReturnValue({ status, issuers: [], isLoading: false, isRefreshing: false, isDemoData: false, consecutiveFailures: 0, isFailed: false, ...overrides }); mockUseCardLoadingState.mockReturnValue({}) }
+
+describe('CertManager', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }); const { container } = render(<CertManager config={{}} />); expect(container.querySelector('.animate-pulse')).toBeInTheDocument() })
+  it('renders empty state when not installed', () => { render(<CertManager config={{}} />); expect(screen.getByText('No cert-manager installation detected')).toBeInTheDocument() })
+  it('renders error state through card loading state', () => { setup({ isFailed: true, consecutiveFailures: 3 }); render(<CertManager config={{}} />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isFailed: true, consecutiveFailures: 3 })) })
+  it('renders happy-path data', () => { setup({ status: { ...status, installed: true, validCertificates: 5, expiringSoon: 1, totalCertificates: 6, recentRenewals: 2 }, issuers: [{ id: 'i1', name: 'letsencrypt', kind: 'ClusterIssuer', status: 'ready', certificateCount: 6 }] }); render(<CertManager config={{}} />); expect(screen.getByText('letsencrypt')).toBeInTheDocument(); expect(screen.getByText('2 renewals/24h')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ status: { ...status, installed: true, validCertificates: 1, totalCertificates: 1 }, issuers: [{ id: 'i1', name: 'ca', kind: 'Issuer', status: 'ready', certificateCount: 1 }] }); const { container } = render(<CertManager config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/DataComplianceExternalSecrets.test.tsx
+++ b/web/src/components/cards/DataComplianceExternalSecrets.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ExternalSecrets } from './DataComplianceExternalSecrets'
+
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockExec = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../lib/kubectlProxy', () => ({ kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) } }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+
+function setup(clusters: Array<{ name: string; reachable: boolean }> = [], execImpl?: () => Promise<{ exitCode: number; output?: string }>) { mockUseClusters.mockReturnValue({ deduplicatedClusters: clusters }); mockExec.mockImplementation(execImpl ?? (async () => ({ exitCode: 1, output: '' }))); mockUseCardLoadingState.mockReturnValue({}) }
+
+describe('ExternalSecrets', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup([{ name: 'prod', reachable: true }], () => new Promise(() => undefined)); render(<ExternalSecrets config={{}} />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true })) })
+  it('renders empty state when not installed', async () => { setup(); render(<ExternalSecrets config={{}} />); expect(await screen.findByText('No clusters connected')).toBeInTheDocument() })
+  it('renders error state', async () => { setup([{ name: 'prod', reachable: true }], async () => { throw new Error('down') }); render(<ExternalSecrets config={{}} />); expect(await screen.findByText('Failed to fetch ESO status')).toBeInTheDocument() })
+  it('renders happy-path data', async () => { let call = 0; setup([{ name: 'prod', reachable: true }], async () => { call += 1; if (call === 1) return { exitCode: 0, output: 'crd' }; if (call === 2) return { exitCode: 0, output: '11' }; return { exitCode: 0, output: JSON.stringify({ items: [{ status: { conditions: [{ type: 'Ready', status: 'True' }] } }] }) } }); render(<ExternalSecrets config={{}} />); expect(await screen.findByText('100% synced')).toBeInTheDocument(); expect(screen.getByText('Secret Stores')).toBeInTheDocument() })
+  it('matches snapshot', async () => { setup(); const { container } = render(<ExternalSecrets config={{}} />); await waitFor(() => expect(screen.getByText('No clusters connected')).toBeInTheDocument()); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/DataComplianceVaultSecrets.test.tsx
+++ b/web/src/components/cards/DataComplianceVaultSecrets.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { VaultSecrets } from './DataComplianceVaultSecrets'
+
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockExec = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../lib/kubectlProxy', () => ({ kubectlProxy: { exec: (...args: unknown[]) => mockExec(...args) } }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+
+function setup(clusters: Array<{ name: string; reachable: boolean }> = [], execImpl?: () => Promise<{ exitCode: number; output?: string }>) { mockUseClusters.mockReturnValue({ deduplicatedClusters: clusters }); mockExec.mockImplementation(execImpl ?? (async () => ({ exitCode: 1, output: '' }))); mockUseCardLoadingState.mockReturnValue({}) }
+
+describe('VaultSecrets', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup([{ name: 'prod', reachable: true }], () => new Promise(() => undefined)); render(<VaultSecrets config={{}} />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isLoading: true })) })
+  it('renders empty state when not installed', async () => { setup(); render(<VaultSecrets config={{}} />); expect(await screen.findByText('No clusters connected')).toBeInTheDocument() })
+  it('renders error state', async () => { setup([{ name: 'prod', reachable: true }], async () => { throw new Error('down') }); render(<VaultSecrets config={{}} />); expect(await screen.findByText('Failed to fetch Vault status')).toBeInTheDocument() })
+  it('renders happy-path data', async () => { let call = 0; setup([{ name: 'prod', reachable: true }], async () => { call += 1; if (call === 1) return { exitCode: 0, output: JSON.stringify({ items: [{ status: { phase: 'Running' } }] }) }; return { exitCode: 0, output: '111' } }); render(<VaultSecrets config={{}} />); expect(await screen.findByText('unsealed')).toBeInTheDocument(); expect(screen.getByText('1/1')).toBeInTheDocument() })
+  it('matches snapshot', async () => { setup(); const { container } = render(<VaultSecrets config={{}} />); await waitFor(() => expect(screen.getByText('No clusters connected')).toBeInTheDocument()); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/EnterpriseComplianceCards.test.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.test.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import { ScoreRing, HIPAACard } from './EnterpriseComplianceCards'
+
+const mockAuthFetch = vi.hoisted(() => vi.fn())
+const mockSafeJson = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('react-router-dom', () => ({ useNavigate: () => vi.fn() }))
+vi.mock('../../lib/api', () => ({ authFetch: (...args: unknown[]) => mockAuthFetch(...args), safeJson: (...args: unknown[]) => mockSafeJson(...args) }))
+vi.mock('../../lib/cache', () => ({ useCache: () => ({ data: null, error: null }) }))
+vi.mock('../shared/TechnicalAcronym', () => ({ TechnicalAcronym: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+
+describe('EnterpriseComplianceCards', () => {
+  beforeEach(() => { vi.clearAllMocks(); mockAuthFetch.mockResolvedValue({ ok: true }); mockSafeJson.mockResolvedValue(null) })
+  it('renders loading skeleton/loading state', () => { render(<HIPAACard />); expect(screen.getByText('Loading…')).toBeInTheDocument() })
+  it('renders empty state', async () => { render(<HIPAACard />); expect(await screen.findByText('No data')).toBeInTheDocument() })
+  it('renders error state', async () => { mockAuthFetch.mockRejectedValue(new Error('network down')); render(<HIPAACard />); expect(await screen.findByText('network down')).toBeInTheDocument() })
+  it('renders happy-path data', async () => { mockSafeJson.mockResolvedValue({ overall_score: 92, safeguards_passed: 18, safeguards_failed: 1, phi_namespaces: 3, encrypted_flows: 42 }); render(<HIPAACard />); expect(await screen.findByText('92%')).toBeInTheDocument(); expect(screen.getByText('Passed')).toBeInTheDocument() })
+  it('renders SVG with correct score percentage and matches snapshot', () => { const { container } = render(<ScoreRing score={75} size={80} />); const progress = screen.getByTestId('score-ring-progress'); expect(progress).toHaveAttribute('stroke-dasharray'); expect(screen.getByText('75%')).toBeInTheDocument(); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/FleetComplianceHeatmap.test.tsx
+++ b/web/src/components/cards/FleetComplianceHeatmap.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import FleetComplianceHeatmap from './FleetComplianceHeatmap'
+
+const mockUseKyverno = vi.hoisted(() => vi.fn())
+const mockUseTrivy = vi.hoisted(() => vi.fn())
+const mockUseKubescape = vi.hoisted(() => vi.fn())
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useKyverno', () => ({ useKyverno: () => mockUseKyverno() }))
+vi.mock('../../hooks/useTrivy', () => ({ useTrivy: () => mockUseTrivy() }))
+vi.mock('../../hooks/useKubescape', () => ({ useKubescape: () => mockUseKubescape() }))
+vi.mock('../../hooks/useGlobalFilters', () => ({ useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }) }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('../../hooks/useMissions', () => ({ useMissions: () => ({ startMission: vi.fn() }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('./kyverno/KyvernoDetailModal', () => ({ KyvernoDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="kyverno-modal" /> : null }))
+vi.mock('./trivy/TrivyDetailModal', () => ({ TrivyDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="trivy-modal" /> : null }))
+vi.mock('./kubescape/KubescapeDetailModal', () => ({ KubescapeDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="kubescape-modal" /> : null }))
+vi.mock('../ui/RefreshIndicator', () => ({ RefreshIndicator: () => null }))
+vi.mock('../ui/Button', () => ({ Button: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => <button onClick={onClick}>{children}</button> }))
+
+function setup(overrides: { kyverno?: Record<string, unknown>; trivy?: Record<string, unknown>; kubescape?: Record<string, unknown>; clusters?: Record<string, unknown> } = {}) {
+  const baseHook = { statuses: {}, isLoading: false, isRefreshing: false, isDemoData: false, installed: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0, lastRefresh: null }
+  mockUseKyverno.mockReturnValue({ ...baseHook, ...overrides.kyverno })
+  mockUseTrivy.mockReturnValue({ ...baseHook, ...overrides.trivy })
+  mockUseKubescape.mockReturnValue({ ...baseHook, ...overrides.kubescape })
+  mockUseClusters.mockReturnValue({ deduplicatedClusters: [], consecutiveFailures: 0, ...overrides.clusters })
+  mockUseCardLoadingState.mockReturnValue({})
+}
+
+describe('FleetComplianceHeatmap', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ kyverno: { isLoading: true } }); render(<FleetComplianceHeatmap config={{}} />); expect(screen.getByText('fleetCompliance.scanningClusters')).toBeInTheDocument() })
+  it('renders empty state', () => { render(<FleetComplianceHeatmap config={{}} />); expect(screen.getByText('fleetCompliance.noClusters')).toBeInTheDocument() })
+  it('renders error state', () => { const err = { a: { error: 'x' } }; setup({ kyverno: { statuses: err }, trivy: { statuses: err }, kubescape: { statuses: err } }); render(<FleetComplianceHeatmap config={{}} />); expect(screen.getByText('Failed to load compliance data')).toBeInTheDocument() })
+  it('renders happy-path data', () => { setup({ clusters: { deduplicatedClusters: [{ name: 'prod' }] }, kyverno: { installed: true, statuses: { prod: { installed: true, totalPolicies: 2, totalViolations: 1, policies: [{ name: 'p' }] } } }, trivy: { installed: true, statuses: { prod: { installed: true, totalReports: 1, vulnerabilities: { critical: 0, high: 1, medium: 0, low: 0 } } } }, kubescape: { installed: true, statuses: { prod: { installed: true, overallScore: 85, totalControls: 10, passedControls: 9 } } } }); render(<FleetComplianceHeatmap config={{}} />); expect(screen.getByText('prod')).toBeInTheDocument(); expect(screen.getByText('1 violations')).toBeInTheDocument(); expect(screen.getByText('85%')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ clusters: { deduplicatedClusters: [{ name: 'prod' }] }, kyverno: { installed: true, statuses: { prod: { installed: true, totalPolicies: 1, totalViolations: 0, policies: [] } } } }); const { container } = render(<FleetComplianceHeatmap config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/ISO27001Audit.test.tsx
+++ b/web/src/components/cards/ISO27001Audit.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ISO27001Audit } from './ISO27001Audit'
+
+const mockUseCachedISO27001Audit = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+const mockUseCardData = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string, fallback?: string) => fallback ?? key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useCachedData', () => ({ useCachedISO27001Audit: () => mockUseCachedISO27001Audit() }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args), useCardDemoState: () => ({ shouldUseDemoData: false }) }))
+vi.mock('../../lib/cards/cardHooks', () => ({ useCardData: (...args: unknown[]) => mockUseCardData(...args) }))
+vi.mock('../../lib/cards/CardComponents', () => ({ CardClusterFilter: () => null, CardSearchInput: () => null, CardSkeleton: () => <div data-testid="card-skeleton" /> }))
+vi.mock('../ui/CardControls', () => ({ CardControls: () => null }))
+vi.mock('../ui/Pagination', () => ({ Pagination: () => null }))
+vi.mock('../ui/RefreshIndicator', () => ({ RefreshIndicator: () => null }))
+vi.mock('../shared/TechnicalAcronym', () => ({ wrapAbbreviations: (text: string) => text }))
+
+const finding = { checkId: 'rbac-1', category: 'RBAC & Access Control', label: 'No wildcard permissions', status: 'fail', cluster: 'prod', severity: 'critical', details: 'wildcard verbs detected' }
+function setup(overrides: Record<string, unknown> = {}, loadingState: Record<string, unknown> = {}) {
+  const findings = (overrides.findings as unknown[]) ?? []
+  mockUseCachedISO27001Audit.mockReturnValue({ findings, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, lastRefresh: null, ...overrides })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, ...loadingState })
+  mockUseCardData.mockImplementation((items: unknown[]) => ({ items, totalItems: items.length, currentPage: 1, totalPages: 1, itemsPerPage: 10, goToPage: vi.fn(), needsPagination: false, setItemsPerPage: vi.fn(), filters: { search: '', setSearch: vi.fn(), localClusterFilter: [], toggleClusterFilter: vi.fn(), clearClusterFilter: vi.fn(), availableClusters: [], showClusterFilter: false, setShowClusterFilter: vi.fn(), clusterFilterRef: { current: null } }, sorting: { sortBy: 'severity', setSortBy: vi.fn(), sortDirection: 'desc', setSortDirection: vi.fn() }, containerRef: { current: null }, containerStyle: {} }))
+}
+
+describe('ISO27001Audit', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }, { showSkeleton: true }); render(<ISO27001Audit config={{}} />); expect(screen.getByTestId('card-skeleton')).toBeInTheDocument() })
+  it('renders empty state', () => { render(<ISO27001Audit config={{}} />); expect(screen.getByText('No audit data')).toBeInTheDocument() })
+  it('renders error state', () => { setup({ isFailed: true }); render(<ISO27001Audit config={{}} />); expect(screen.getByText('Failed to load audit data')).toBeInTheDocument() })
+  it('renders happy-path data', () => { setup({ findings: [finding] }); render(<ISO27001Audit config={{}} />); expect(screen.getByText('No wildcard permissions')).toBeInTheDocument(); expect(screen.getByText('prod')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ findings: [finding] }); const { container } = render(<ISO27001Audit config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/KyvernoPolicies.test.tsx
+++ b/web/src/components/cards/KyvernoPolicies.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { KyvernoPolicies } from './KyvernoPolicies'
+
+const mockUseKyverno = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useKyverno', () => ({ useKyverno: () => mockUseKyverno() }))
+vi.mock('../../hooks/useMissions', () => ({ useMissions: () => ({ startMission: vi.fn() }) }))
+vi.mock('../../hooks/useGlobalFilters', () => ({ useGlobalFilters: () => ({ selectedClusters: [] }) }))
+vi.mock('../../hooks/useDrillDown', () => ({ useDrillDownActions: () => ({ drillToPolicy: vi.fn() }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('./kyverno/KyvernoDetailModal', () => ({ KyvernoDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="kyverno-modal" /> : null }))
+vi.mock('../ui/RefreshIndicator', () => ({ RefreshIndicator: () => null }))
+vi.mock('./DynamicCardErrorBoundary', () => ({ DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('../../lib/cards/CardComponents', () => ({ CardSearchInput: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => <input data-testid="search-input" value={value} onChange={e => onChange(e.target.value)} /> }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+function setup(overrides: Record<string, unknown> = {}) {
+  mockUseKyverno.mockReturnValue({ statuses: {}, isLoading: false, isRefreshing: false, lastRefresh: null, installed: false, hasErrors: false, isDemoData: false, refetch: vi.fn(), clustersChecked: 0, totalClusters: 0, ...overrides })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('KyvernoPolicies', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true, totalClusters: 2, clustersChecked: 1 }); render(<KyvernoPolicies config={{}} />); expect(screen.getByText('kyvernoPolicies.scanningClusters')).toBeInTheDocument() })
+  it('renders empty state when Kyverno is not installed', () => { render(<KyvernoPolicies config={{}} />); expect(screen.getByText('Kyverno Integration')).toBeInTheDocument() })
+  it('renders error state', () => { setup({ hasErrors: true }); render(<KyvernoPolicies config={{}} />); expect(screen.getByText('Failed to fetch scanner data')).toBeInTheDocument() })
+  it('renders happy-path policy data', () => { setup({ installed: true, statuses: { prod: { cluster: 'prod', installed: true, totalPolicies: 1, enforcingCount: 1, totalViolations: 2, policies: [{ name: 'require-labels', category: 'Best Practices', description: 'labels', status: 'audit', kind: 'ClusterPolicy', cluster: 'prod', namespace: '', violations: 2, background: true }] } } }); render(<KyvernoPolicies config={{}} />); expect(screen.getByText('require-labels')).toBeInTheDocument(); expect(screen.getByText('prod: 1p/2v')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ installed: true, statuses: { prod: { cluster: 'prod', installed: true, totalPolicies: 1, enforcingCount: 1, totalViolations: 0, policies: [{ name: 'disallow-privileged', category: 'Pod Security', description: 'secure', status: 'enforcing', kind: 'ClusterPolicy', cluster: 'prod', namespace: '', violations: 0, background: true }] } } }); const { container } = render(<KyvernoPolicies config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/OPAPolicies.test.tsx
+++ b/web/src/components/cards/OPAPolicies.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OPAPolicies } from './OPAPolicies'
+
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+const mockSafeGetJSON = vi.hoisted(() => vi.fn())
+const mockRunClusterChecks = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../hooks/useMissions', () => ({ useMissions: () => ({ startMission: vi.fn() }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args), useCardDemoState: () => ({ shouldUseDemoData: false }) }))
+vi.mock('../../hooks/mcp/shared', () => ({ agentFetch: vi.fn(() => Promise.resolve({ json: () => Promise.resolve({ clusters: [] }) })) }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('../../lib/demoMode', () => ({ isDemoMode: () => false }))
+vi.mock('../../lib/utils/localStorage', () => ({ safeGetItem: vi.fn(() => '1'), safeGetJSON: () => mockSafeGetJSON(), safeSetItem: vi.fn(), safeSetJSON: vi.fn() }))
+vi.mock('./OPAPoliciesModal', () => ({ OPAPoliciesModal: () => null }))
+vi.mock('./OPAPoliciesTable', () => ({ OPAPoliciesTable: ({ statuses }: { statuses: Record<string, unknown> }) => <div data-testid="opa-table">{Object.keys(statuses).length} clusters</div> }))
+vi.mock('../../lib/modals', () => ({ useModalState: () => ({ isOpen: false, open: vi.fn(), close: vi.fn() }) }))
+vi.mock('./OPAPolicies.utils', () => ({ createSortComparators: vi.fn(() => ({})), generateDemoStatuses: vi.fn(() => ({})), runClusterChecks: (...args: unknown[]) => mockRunClusterChecks(...args) }))
+vi.mock('./DynamicCardErrorBoundary', () => ({ DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('../../lib/cards/cardHooks', () => ({ useCardData: (items: Array<{ name: string }>) => ({ items, totalItems: items.length, currentPage: 1, totalPages: 1, itemsPerPage: 5, goToPage: vi.fn(), needsPagination: false, setItemsPerPage: vi.fn(), filters: { search: '', setSearch: vi.fn(), localClusterFilter: [], toggleClusterFilter: vi.fn(), clearClusterFilter: vi.fn(), availableClusters: items, showClusterFilter: false, setShowClusterFilter: vi.fn(), clusterFilterRef: { current: null } }, sorting: { sortBy: 'name', setSortBy: vi.fn(), sortDirection: 'asc', setSortDirection: vi.fn() }, containerRef: { current: null }, containerStyle: {} }) }))
+
+function setup(overrides: Record<string, unknown> = {}) {
+  mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isLoading: false, isFailed: false, consecutiveFailures: 0, ...overrides })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+  mockSafeGetJSON.mockReturnValue(null)
+  mockRunClusterChecks.mockResolvedValue(undefined)
+}
+
+describe('OPAPolicies', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup(); sessionStorage.clear() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }); render(<OPAPolicies config={{}} />); expect(screen.getByText('Scanning clusters...')).toBeInTheDocument() })
+  it('renders empty state when no clusters have OPA status', () => { render(<OPAPolicies config={{}} />); expect(screen.getByTestId('opa-table')).toHaveTextContent('0 clusters') })
+  it('renders error state through card loading state', () => { setup({ isFailed: true, consecutiveFailures: 3 }); render(<OPAPolicies config={{}} />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isFailed: true, consecutiveFailures: 3 })) })
+  it('renders happy-path cached policy data', () => { setup({ deduplicatedClusters: [{ name: 'prod', healthy: true, reachable: true }] }); mockSafeGetJSON.mockReturnValue({ prod: { cluster: 'prod', installed: true, loading: false, policyCount: 2, violationCount: 0, policies: [] } }); render(<OPAPolicies config={{}} />); expect(screen.getByTestId('opa-table')).toHaveTextContent('1 clusters') })
+  it('matches snapshot', () => { setup({ deduplicatedClusters: [{ name: 'prod', healthy: true, reachable: true }] }); mockSafeGetJSON.mockReturnValue({ prod: { cluster: 'prod', installed: true, loading: false, policyCount: 1, violationCount: 0, policies: [] } }); const { container } = render(<OPAPolicies config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/OPAPoliciesModal.test.tsx
+++ b/web/src/components/cards/OPAPoliciesModal.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { OPAPoliciesModal } from './OPAPoliciesModal'
+
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('./opa', () => ({
+  PolicyDetailModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="policy-detail-modal" /> : null,
+  ClusterOPAModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="cluster-opa-modal" /> : null,
+  CreatePolicyModal: ({ isOpen }: { isOpen: boolean }) => isOpen ? <div data-testid="create-policy-modal" /> : null,
+}))
+
+const baseProps = {
+  showViolationsModal: false,
+  closeViolationsModal: vi.fn(),
+  selectedClusterForViolations: 'prod',
+  statuses: { prod: { cluster: 'prod', installed: true, loading: false, policies: [], violations: [] } },
+  onRefresh: vi.fn(),
+  startMission: vi.fn(),
+  showPolicyModal: false,
+  closePolicyModal: vi.fn(),
+  selectedPolicy: null,
+  setSelectedPolicy: vi.fn(),
+  onAddPolicy: vi.fn(),
+  showCreatePolicyModal: false,
+  closeCreatePolicyModal: vi.fn(),
+}
+
+describe('OPAPoliciesModal', () => {
+  it('renders loading skeleton/loading state as closed content', () => {
+    const { container } = render(<OPAPoliciesModal {...baseProps} />)
+    expect(container).toBeEmptyDOMElement()
+  })
+  it('renders empty state when no modal is open', () => {
+    render(<OPAPoliciesModal {...baseProps} />)
+    expect(screen.queryByTestId('cluster-opa-modal')).not.toBeInTheDocument()
+  })
+  it('renders error state by not opening policy detail without selected policy', () => {
+    render(<OPAPoliciesModal {...baseProps} showPolicyModal />)
+    expect(screen.queryByTestId('policy-detail-modal')).not.toBeInTheDocument()
+  })
+  it('renders happy-path modal data', () => {
+    render(<OPAPoliciesModal {...baseProps} showViolationsModal showCreatePolicyModal selectedPolicy={{ name: 'require-labels', kind: 'K8sRequiredLabels', violations: 0 }} showPolicyModal />)
+    expect(screen.getByTestId('cluster-opa-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('create-policy-modal')).toBeInTheDocument()
+    expect(screen.getByTestId('policy-detail-modal')).toBeInTheDocument()
+  })
+  it('matches snapshot', () => {
+    const { container } = render(<OPAPoliciesModal {...baseProps} showViolationsModal />)
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/web/src/components/cards/RBACExplorer.test.tsx
+++ b/web/src/components/cards/RBACExplorer.test.tsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RBACExplorer } from './RBACExplorer'
+
+const mockUseRBACFindings = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useRBACFindings', () => ({ useRBACFindings: () => mockUseRBACFindings() }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('@tanstack/react-virtual', () => ({ useVirtualizer: () => ({ getVirtualItems: () => [{ index: 0, start: 0 }], getTotalSize: () => 72, scrollToOffset: vi.fn(), measureElement: vi.fn() }) }))
+vi.mock('../../lib/cards/CardComponents', () => ({
+  CardSkeleton: () => <div data-testid="card-skeleton" />,
+  CardSearchInput: ({ value, onChange }: { value: string; onChange: (v: string) => void }) => <input data-testid="search-input" value={value} onChange={e => onChange(e.target.value)} />,
+  CardPaginationFooter: () => null,
+}))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+function setup(overrides: Record<string, unknown> = {}, loadingState: Record<string, unknown> = {}) {
+  mockUseRBACFindings.mockReturnValue({ findings: [], isLoading: false, isRefreshing: false, consecutiveFailures: 0, error: null, isDemoData: false, refetch: vi.fn(), ...overrides })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, ...loadingState })
+}
+
+describe('RBACExplorer', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }, { showSkeleton: true }); render(<RBACExplorer />); expect(screen.getByTestId('card-skeleton')).toBeInTheDocument() })
+  it('renders empty state', () => { setup({}, { showEmptyState: true }); render(<RBACExplorer />); expect(screen.getByText('common:rbac.noFindings')).toBeInTheDocument() })
+  it('renders error state', () => { setup({ error: 'boom' }); render(<RBACExplorer />); expect(screen.getByText('common:rbac.failedToLoad')).toBeInTheDocument(); expect(screen.getByText('boom')).toBeInTheDocument() })
+  it('renders happy-path data', () => { setup({ findings: [{ id: '1', risk: 'critical', subject: 'cluster-admin', subjectKind: 'User', description: 'over privileged', binding: 'clusterrolebinding/admin', cluster: 'prod' }] }); render(<RBACExplorer />); expect(screen.getByText('cluster-admin')).toBeInTheDocument(); expect(screen.getByText('critical: 1')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ findings: [{ id: '1', risk: 'high', subject: 'system:sa', subjectKind: 'ServiceAccount', description: 'wildcard', binding: 'binding', cluster: 'prod' }] }); const { container } = render(<RBACExplorer />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/RecommendedPolicies.test.tsx
+++ b/web/src/components/cards/RecommendedPolicies.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { RecommendedPolicies } from './RecommendedPolicies'
+
+const mockUseKyverno = vi.hoisted(() => vi.fn())
+const mockUseKubescape = vi.hoisted(() => vi.fn())
+const mockUseTrivy = vi.hoisted(() => vi.fn())
+const mockUseClusters = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useKyverno', () => ({ useKyverno: () => mockUseKyverno() }))
+vi.mock('../../hooks/useKubescape', () => ({ useKubescape: () => mockUseKubescape() }))
+vi.mock('../../hooks/useTrivy', () => ({ useTrivy: () => mockUseTrivy() }))
+vi.mock('../../hooks/useMCP', () => ({ useClusters: () => mockUseClusters() }))
+vi.mock('../../hooks/useMissions', () => ({ useMissions: () => ({ startMission: vi.fn() }) }))
+vi.mock('../../hooks/useGlobalFilters', () => ({ useGlobalFilters: () => ({ selectedClusters: [], isAllClustersSelected: true }) }))
+vi.mock('../../hooks/useDemoMode', () => ({ useDemoMode: () => ({ isDemoMode: false }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('./DynamicCardErrorBoundary', () => ({ DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+function setup(overrides: { kyverno?: Record<string, unknown>; kubescape?: Record<string, unknown>; trivy?: Record<string, unknown>; clusters?: Record<string, unknown> } = {}) {
+  mockUseKyverno.mockReturnValue({ statuses: {}, isLoading: false, isRefreshing: false, installed: false, isDemoData: false, clustersChecked: 0, totalClusters: 0, ...overrides.kyverno })
+  mockUseKubescape.mockReturnValue({ isLoading: false, isRefreshing: false, installed: false, isDemoData: false, clustersChecked: 0, totalClusters: 0, ...overrides.kubescape })
+  mockUseTrivy.mockReturnValue({ isLoading: false, isRefreshing: false, installed: false, isDemoData: false, clustersChecked: 0, totalClusters: 0, ...overrides.trivy })
+  mockUseClusters.mockReturnValue({ deduplicatedClusters: [], isFailed: false, consecutiveFailures: 0, ...overrides.clusters })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false })
+}
+
+describe('RecommendedPolicies', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => {
+    setup({ kyverno: { isLoading: true, totalClusters: 2, clustersChecked: 0 }, kubescape: { isLoading: true, totalClusters: 2, clustersChecked: 0 }, trivy: { isLoading: true, totalClusters: 2, clustersChecked: 0 } })
+    render(<RecommendedPolicies config={{}} />)
+    expect(screen.getByText('Scanning clusters...')).toBeInTheDocument()
+  })
+  it('renders empty state when no tools are installed', () => {
+    render(<RecommendedPolicies config={{}} />)
+    expect(screen.getByText('No Compliance Tools Detected')).toBeInTheDocument()
+  })
+  it('renders error state through card loading state', () => {
+    setup({ clusters: { isFailed: true, consecutiveFailures: 3 } })
+    render(<RecommendedPolicies config={{}} />)
+    expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isFailed: true, consecutiveFailures: 3 }))
+  })
+  it('renders happy-path data', () => {
+    setup({ clusters: { deduplicatedClusters: [{ name: 'prod' }] }, kyverno: { installed: true, statuses: { prod: { installed: true, policies: [{ name: 'require-labels' }] } } } })
+    render(<RecommendedPolicies config={{}} />)
+    expect(screen.getByText('Fleet Coverage')).toBeInTheDocument()
+    expect(screen.getByText('Security Hardening')).toBeInTheDocument()
+  })
+  it('matches snapshot', () => {
+    setup({ clusters: { deduplicatedClusters: [{ name: 'prod' }] }, kyverno: { installed: true, statuses: { prod: { installed: true, policies: [] } } } })
+    const { container } = render(<RecommendedPolicies config={{}} />)
+    expect(container).toMatchSnapshot()
+  })
+})

--- a/web/src/components/cards/RuntimeAttestationCard.test.tsx
+++ b/web/src/components/cards/RuntimeAttestationCard.test.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import RuntimeAttestationCard from './RuntimeAttestationCard'
+
+const mockUseCachedAttestation = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useCachedAttestation', () => ({ useCachedAttestation: () => mockUseCachedAttestation(), SCORE_THRESHOLD_HIGH: 80, SCORE_THRESHOLD_MEDIUM: 60 }))
+vi.mock('../../hooks/useDrillDown', () => ({ useDrillDown: () => ({ open: vi.fn() }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args) }))
+vi.mock('../ui/Skeleton', () => ({ Skeleton: ({ className }: { className?: string }) => <div data-testid="skeleton" className={className} /> }))
+vi.mock('../drilldown/views/AttestationDrillDown', () => ({ AttestationDrillDown: () => null }))
+
+function setup(overrides: Record<string, unknown> = {}) { mockUseCachedAttestation.mockReturnValue({ data: { clusters: [] }, isLoading: false, isRefreshing: false, isDemoFallback: false, isFailed: false, consecutiveFailures: 0, lastRefresh: null, ...overrides }); mockUseCardLoadingState.mockReturnValue({}) }
+
+describe('RuntimeAttestationCard', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }); render(<RuntimeAttestationCard />); expect(screen.getAllByTestId('skeleton').length).toBeGreaterThanOrEqual(5) })
+  it('renders empty state', () => { render(<RuntimeAttestationCard />); expect(screen.getByText('runtimeAttestation.noData')).toBeInTheDocument() })
+  it('renders error state through card loading state', () => { setup({ isFailed: true, consecutiveFailures: 3 }); render(<RuntimeAttestationCard />); expect(mockUseCardLoadingState).toHaveBeenCalledWith(expect.objectContaining({ isFailed: true, consecutiveFailures: 3 })) })
+  it('renders happy-path data', () => { setup({ data: { clusters: [{ cluster: 'prod', overallScore: 90 }, { cluster: 'dev', overallScore: 50 }] } }); render(<RuntimeAttestationCard />); expect(screen.getByText('prod')).toBeInTheDocument(); expect(screen.getByText('70/100')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ data: { clusters: [{ cluster: 'prod', overallScore: 90 }] } }); const { container } = render(<RuntimeAttestationCard />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/SecurityIssues.test.tsx
+++ b/web/src/components/cards/SecurityIssues.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SecurityIssues } from './SecurityIssues'
+
+const mockUseCachedSecurityIssues = vi.hoisted(() => vi.fn())
+const mockUseCardLoadingState = vi.hoisted(() => vi.fn())
+const mockUseCardData = vi.hoisted(() => vi.fn())
+
+vi.mock('react-i18next', () => ({ initReactI18next: { type: '3rdParty', init: () => {} }, useTranslation: () => ({ t: (key: string, opts?: Record<string, unknown> | string) => typeof opts === 'string' ? opts : key, i18n: { language: 'en', changeLanguage: vi.fn() } }) }))
+vi.mock('../../hooks/useCachedData', () => ({ useCachedSecurityIssues: () => mockUseCachedSecurityIssues() }))
+vi.mock('../../hooks/useDrillDown', () => ({ useDrillDownActions: () => ({ drillToPod: vi.fn() }) }))
+vi.mock('./CardDataContext', () => ({ useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args), useCardDemoState: () => ({ shouldUseDemoData: false }) }))
+vi.mock('../../lib/cards/cardHooks', () => ({ useCardData: (...args: unknown[]) => mockUseCardData(...args) }))
+vi.mock('./DynamicCardErrorBoundary', () => ({ DynamicCardErrorBoundary: ({ children }: { children: React.ReactNode }) => <>{children}</> }))
+vi.mock('../ui/LimitedAccessWarning', () => ({ LimitedAccessWarning: () => null }))
+vi.mock('../../lib/cards/CardComponents', () => ({ CardClusterFilter: () => null, CardSearchInput: () => null, CardAIActions: () => null }))
+vi.mock('../ui/CardControls', () => ({ CardControls: () => null }))
+vi.mock('../ui/Pagination', () => ({ Pagination: () => null }))
+vi.mock('../ui/ClusterBadge', () => ({ ClusterBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+vi.mock('../ui/StatusBadge', () => ({ StatusBadge: ({ children }: { children: React.ReactNode }) => <span>{children}</span> }))
+
+const issue = { name: 'api-pod', namespace: 'prod-ns', cluster: 'prod', issue: 'Privileged container', severity: 'high', details: 'privileged mode' }
+function setup(overrides: Record<string, unknown> = {}, loadingState: Record<string, unknown> = {}) {
+  const issues = (overrides.issues as unknown[]) ?? []
+  mockUseCachedSecurityIssues.mockReturnValue({ issues, isLoading: false, isRefreshing: false, isDemoFallback: false, error: null, isFailed: false, consecutiveFailures: 0, lastRefresh: null, ...overrides })
+  mockUseCardLoadingState.mockReturnValue({ showSkeleton: false, showEmptyState: false, ...loadingState })
+  mockUseCardData.mockImplementation((items: unknown[]) => ({ items, totalItems: items.length, currentPage: 1, totalPages: 1, itemsPerPage: 5, goToPage: vi.fn(), needsPagination: false, setItemsPerPage: vi.fn(), filters: { search: '', setSearch: vi.fn(), localClusterFilter: [], toggleClusterFilter: vi.fn(), clearClusterFilter: vi.fn(), availableClusters: [], showClusterFilter: false, setShowClusterFilter: vi.fn(), clusterFilterRef: { current: null } }, sorting: { sortBy: 'severity', setSortBy: vi.fn(), sortDirection: 'desc', setSortDirection: vi.fn() }, containerRef: { current: null }, containerStyle: {} }))
+}
+
+describe('SecurityIssues', () => {
+  beforeEach(() => { vi.clearAllMocks(); setup() })
+  it('renders loading skeleton/loading state', () => { setup({ isLoading: true }, { showSkeleton: true }); const { container } = render(<SecurityIssues config={{}} />); expect(container.querySelector('.animate-pulse')).toBeInTheDocument() })
+  it('renders empty state', () => { setup({}, { showEmptyState: true }); render(<SecurityIssues config={{}} />); expect(screen.getByText('securityIssues.noSecurityIssues')).toBeInTheDocument() })
+  it('renders error state', () => { setup({ isFailed: true, error: 'api down' }); render(<SecurityIssues config={{}} />); expect(screen.getByText('api down')).toBeInTheDocument() })
+  it('renders happy-path data', () => { setup({ issues: [issue] }); render(<SecurityIssues config={{}} />); expect(screen.getByText('api-pod')).toBeInTheDocument(); expect(screen.getByText('Privileged container')).toBeInTheDocument() })
+  it('matches snapshot', () => { setup({ issues: [issue] }); const { container } = render(<SecurityIssues config={{}} />); expect(container).toMatchSnapshot() })
+})

--- a/web/src/components/cards/__snapshots__/ComplianceDrift.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/ComplianceDrift.test.tsx.snap
@@ -1,0 +1,118 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ComplianceDrift > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-1.5 p-1"
+  >
+    <div
+      class="flex items-start gap-1.5 text-xs text-muted-foreground bg-secondary/20 rounded-md px-2 py-1.5 mb-1"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-info w-3 h-3 shrink-0 mt-0.5 text-muted-foreground/60"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <path
+          d="M12 16v-4"
+        />
+        <path
+          d="M12 8h.01"
+        />
+      </svg>
+      <span>
+        complianceDrift.driftDescription
+      </span>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2"
+    >
+      <div
+        class="ml-auto"
+      />
+    </div>
+    <div
+      aria-label="complianceDrift.viewDriftDetailsAria"
+      class="flex items-center gap-2 p-2 rounded-lg bg-card/50 border border-border/50 cursor-pointer hover:bg-secondary/50 transition-colors group"
+      role="button"
+      tabindex="0"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-trending-down w-4 h-4 shrink-0 text-red-400"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16 17h6v-6"
+        />
+        <path
+          d="m22 17-8.5-8.5-5 5L2 7"
+        />
+      </svg>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="flex items-center gap-1.5"
+        >
+          <span
+            class="text-xs font-mono truncate"
+          >
+            b
+          </span>
+          <span>
+            Kubescape
+          </span>
+        </div>
+        <p
+          class="text-xs text-muted-foreground mt-0.5"
+        >
+          Score 40% vs fleet avg 75%
+           
+          (
+          1.4
+          σ deviation)
+        </p>
+      </div>
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-chevron-right w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity shrink-0"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m9 18 6-6-6-6"
+        />
+      </svg>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/DataComplianceCards.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DataComplianceCards.test.tsx.snap
@@ -1,0 +1,71 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DataComplianceCards re-exports > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="flex items-start gap-2 p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-green-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-green-400 font-medium"
+        >
+          Cert-Manager Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install cert-manager for TLS automation.
+           
+          <a
+            class="text-green-400 hover:underline"
+            href="https://cert-manager.io/docs/installation/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <p
+      class="text-xs text-muted-foreground text-center py-4"
+    >
+      No cert-manager installation detected
+    </p>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/DataComplianceCertManager.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DataComplianceCertManager.test.tsx.snap
@@ -1,0 +1,135 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CertManager > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="flex items-center justify-end"
+    >
+      <span
+        class="text-xs text-muted-foreground"
+      >
+        0
+         renewals/24h
+      </span>
+    </div>
+    <div
+      class="grid grid-cols-2 @md:grid-cols-4 gap-1.5 text-center text-xs"
+    >
+      <div
+        class="p-2 rounded-lg bg-green-500/10"
+      >
+        <p
+          class="text-lg font-bold text-green-400"
+        >
+          1
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Valid
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-yellow-500/10"
+      >
+        <p
+          class="text-lg font-bold text-yellow-400"
+        >
+          0
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Expiring
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-red-500/10"
+      >
+        <p
+          class="text-lg font-bold text-red-400"
+        >
+          0
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Expired
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-secondary/30"
+      >
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          1
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          common.total
+        </p>
+      </div>
+    </div>
+    <div
+      class="space-y-1.5"
+    >
+      <p
+        class="text-xs font-medium text-muted-foreground"
+      >
+        Issuers (
+        1
+        )
+      </p>
+      <div
+        class="flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg bg-secondary/30"
+      >
+        <div
+          class="flex items-center gap-2"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-shield w-3 h-3 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+            />
+          </svg>
+          <span
+            class="text-xs text-foreground truncate max-w-[120px]"
+          >
+            ca
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-2"
+        >
+          <span
+            class="text-2xs text-muted-foreground"
+          >
+            Issuer
+          </span>
+          <span
+            class="text-xs font-medium text-foreground"
+          >
+            1
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/DataComplianceExternalSecrets.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DataComplianceExternalSecrets.test.tsx.snap
@@ -1,0 +1,71 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ExternalSecrets > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="flex items-start gap-2 p-2 rounded-lg bg-blue-500/10 border border-blue-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-blue-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-blue-400 font-medium"
+        >
+          External Secrets Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install ESO for secrets synchronization.
+           
+          <a
+            class="text-blue-400 hover:underline"
+            href="https://external-secrets.io/latest/introduction/getting-started/"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <p
+      class="text-xs text-muted-foreground text-center py-4"
+    >
+      No clusters connected
+    </p>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/DataComplianceVaultSecrets.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DataComplianceVaultSecrets.test.tsx.snap
@@ -1,0 +1,71 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`VaultSecrets > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="flex items-start gap-2 p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-yellow-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-yellow-400 font-medium"
+        >
+          Vault Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install Vault for secrets management.
+           
+          <a
+            class="text-yellow-400 hover:underline"
+            href="https://developer.hashicorp.com/vault/docs/platform/k8s"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <p
+      class="text-xs text-muted-foreground text-center py-2"
+    >
+      No clusters connected
+    </p>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/EnterpriseComplianceCards.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/EnterpriseComplianceCards.test.tsx.snap
@@ -1,0 +1,45 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`EnterpriseComplianceCards > renders SVG with correct score percentage and matches snapshot 1`] = `
+<div>
+  <svg
+    class="shrink-0"
+    height="80"
+    width="80"
+  >
+    <circle
+      cx="40"
+      cy="40"
+      fill="none"
+      r="36"
+      stroke="hsl(var(--muted) / 0.4)"
+      stroke-width="6"
+    />
+    <circle
+      cx="40"
+      cy="40"
+      data-testid="score-ring-progress"
+      fill="none"
+      r="36"
+      stroke="hsl(var(--chart-warning, 45 93% 47%))"
+      stroke-dasharray="226.1946710584651"
+      stroke-dashoffset="56.54866776461628"
+      stroke-linecap="round"
+      stroke-width="6"
+      transform="rotate(-90 40 40)"
+    />
+    <text
+      dy=".35em"
+      fill="white"
+      font-size="20"
+      font-weight="bold"
+      text-anchor="middle"
+      x="50%"
+      y="50%"
+    >
+      75
+      %
+    </text>
+  </svg>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/FleetComplianceHeatmap.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/FleetComplianceHeatmap.test.tsx.snap
@@ -1,0 +1,215 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`FleetComplianceHeatmap > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-2 p-1"
+  >
+    <div
+      class="flex items-start gap-1.5 text-xs text-muted-foreground bg-secondary/20 rounded-md px-2 py-1.5"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-info w-3 h-3 shrink-0 mt-0.5 text-muted-foreground/60"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <path
+          d="M12 16v-4"
+        />
+        <path
+          d="M12 8h.01"
+        />
+      </svg>
+      <span>
+        fleetCompliance.contextDescription
+      </span>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2"
+    >
+      <div
+        class="ml-auto"
+      />
+    </div>
+    <div
+      class="grid grid-cols-2 @md:grid-cols-4 gap-1 text-xs font-medium text-muted-foreground"
+    >
+      <div
+        class="px-2 py-1"
+      >
+        Cluster
+      </div>
+      <div
+        class="px-2 py-1 text-center"
+      >
+        <span>
+          Kyverno
+        </span>
+        <p
+          class="text-[9px] text-muted-foreground/60 font-normal mt-0.5"
+        >
+          Policy engine
+        </p>
+      </div>
+      <div
+        class="px-2 py-1 text-center"
+      >
+        <span>
+          Kubescape
+        </span>
+        <button
+          class="ml-1 inline-flex items-center gap-0.5 text-cyan-400 hover:text-cyan-300 transition-colors"
+          title="Kubescape not detected — click to install with an AI Mission"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-info w-3 h-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="M12 16v-4"
+            />
+            <path
+              d="M12 8h.01"
+            />
+          </svg>
+        </button>
+        <p
+          class="text-[9px] text-muted-foreground/60 font-normal mt-0.5"
+        >
+          Security posture
+        </p>
+      </div>
+      <div
+        class="px-2 py-1 text-center"
+      >
+        <span>
+          Trivy
+        </span>
+        <button
+          class="ml-1 inline-flex items-center gap-0.5 text-cyan-400 hover:text-cyan-300 transition-colors"
+          title="Trivy not detected — click to install with an AI Mission"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-info w-3 h-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="M12 16v-4"
+            />
+            <path
+              d="M12 8h.01"
+            />
+          </svg>
+        </button>
+        <p
+          class="text-[9px] text-muted-foreground/60 font-normal mt-0.5"
+        >
+          CVE scanner
+        </p>
+      </div>
+    </div>
+    <div
+      class="grid grid-cols-2 @md:grid-cols-4 gap-1"
+    >
+      <div
+        class="px-2 py-1.5 text-xs font-mono truncate"
+        title="prod"
+      >
+        prod
+      </div>
+      <div
+        class="px-2 py-1.5 rounded border text-xs text-center bg-green-500/20 text-green-400 border-green-500/30 cursor-pointer hover:brightness-125 transition-all"
+        role="button"
+        tabindex="0"
+        title="0 policies, 0 violations"
+      >
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full mr-1 bg-green-400"
+        />
+        0 violations
+      </div>
+      <div
+        class="px-2 py-1.5 rounded border text-xs text-center text-zinc-700 border-transparent "
+        title="Kubescape not installed"
+      >
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full mr-1 hidden"
+        />
+        —
+      </div>
+      <div
+        class="px-2 py-1.5 rounded border text-xs text-center text-zinc-700 border-transparent "
+        title="Trivy not installed"
+      >
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full mr-1 hidden"
+        />
+        —
+      </div>
+    </div>
+    <div
+      class="flex gap-3 pt-1 text-xs text-muted-foreground border-t border-border/50 mt-1"
+    >
+      <span>
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full bg-green-400 mr-0.5"
+        />
+         Good
+      </span>
+      <span>
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full bg-yellow-400 mr-0.5"
+        />
+         Warning
+      </span>
+      <span>
+        <span
+          class="inline-block w-1.5 h-1.5 rounded-full bg-red-400 mr-0.5"
+        />
+         Critical
+      </span>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/ISO27001Audit.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/ISO27001Audit.test.tsx.snap
@@ -1,0 +1,185 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ISO27001Audit > matches snapshot 1`] = `
+<div>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-2"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="flex items-center gap-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-shield w-4 h-4 text-blue-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+            />
+          </svg>
+          <span
+            class="text-xs font-bold text-red-400"
+          >
+            0
+            %
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1.5 text-xs"
+        >
+          <span
+            class="text-green-400"
+          >
+            0
+             pass
+          </span>
+          <span
+            class="text-red-400"
+          >
+            1
+             fail
+          </span>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-1"
+      />
+    </div>
+    <div
+      class="flex-1 space-y-1 overflow-y-auto min-h-card-content"
+    >
+      <div
+        class="p-2 rounded-lg border text-xs bg-red-500/5 border-red-500/20"
+      >
+        <div
+          class="flex items-start gap-2"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-x w-3.5 h-3.5 text-red-400 shrink-0"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="m15 9-6 6"
+            />
+            <path
+              d="m9 9 6 6"
+            />
+          </svg>
+          <div
+            class="flex-1 min-w-0"
+          >
+            <div
+              class="flex items-center gap-1.5"
+            >
+              <span
+                class="font-medium text-foreground truncate"
+              >
+                No wildcard permissions
+              </span>
+              <span
+                class="text-[9px] px-1 py-0.5 rounded font-medium bg-red-500/20 text-red-400"
+              >
+                critical
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-1.5 mt-0.5 text-muted-foreground"
+            >
+              <span
+                class="truncate"
+              >
+                RBAC & Access Control
+              </span>
+              <span>
+                ·
+              </span>
+              <span
+                class="text-blue-400"
+              >
+                prod
+              </span>
+            </div>
+            <p
+              class="mt-0.5 text-muted-foreground truncate"
+            >
+              wildcard verbs detected
+            </p>
+            <button
+              aria-expanded="false"
+              aria-label="Show verification command for RBAC & Access Control"
+              class="flex items-center gap-0.5 mt-1 text-xs text-blue-400 hover:text-blue-300"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-terminal w-3 h-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M12 19h8"
+                />
+                <path
+                  d="m4 17 6-6-6-6"
+                />
+              </svg>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-3 h-3"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+              verify
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/KyvernoPolicies.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KyvernoPolicies.test.tsx.snap
@@ -1,0 +1,327 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KyvernoPolicies > matches snapshot 1`] = `
+<div>
+  <div
+    class="h-full flex flex-col min-h-card"
+  >
+    <div
+      class="flex items-center justify-end gap-1 mb-3"
+    >
+      <a
+        class="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-purple-400"
+        href="https://kyverno.io/"
+        rel="noopener noreferrer"
+        target="_blank"
+        title="cards:kyvernoPolicies.documentation"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-4 h-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+    <div
+      class="flex flex-wrap gap-1 mb-3"
+    >
+      <button
+        class="cursor-pointer"
+      >
+        <span>
+          prod
+          : 
+          1
+          p/
+          0
+          v
+        </span>
+      </button>
+    </div>
+    <div
+      class="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-3"
+    >
+      <div
+        class="p-2 rounded-lg bg-cyan-500/10 border border-cyan-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-cyan-400"
+        >
+          Policies
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          1
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-green-400"
+        >
+          Enforcing
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          1
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-yellow-400"
+        >
+          Violations
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          0
+        </p>
+      </div>
+    </div>
+    <input
+      data-testid="search-input"
+      value=""
+    />
+    <div
+      class="flex-1 overflow-y-auto space-y-2"
+    >
+      <p
+        class="text-xs text-muted-foreground font-medium flex items-center gap-1 mb-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-file-check w-3 h-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+          />
+          <path
+            d="M14 2v5a1 1 0 0 0 1 1h5"
+          />
+          <path
+            d="m9 15 2 2 4-4"
+          />
+        </svg>
+        1 Policies
+      </p>
+      <div
+        aria-label="View Kyverno policy: disallow-privileged on prod"
+        class="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer"
+        role="button"
+        tabindex="0"
+      >
+        <div
+          class="flex flex-wrap items-center justify-between gap-y-2 mb-1"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <span
+              class="text-sm font-medium text-foreground truncate"
+            >
+              disallow-privileged
+            </span>
+            <span
+              class="px-1.5 py-0.5 rounded text-2xs bg-green-500/20 text-green-400"
+            >
+              enforcing
+            </span>
+          </div>
+        </div>
+        <div
+          class="flex flex-wrap items-center justify-between gap-y-2 text-xs"
+        >
+          <span
+            class="text-red-400"
+          >
+            Pod Security
+          </span>
+          <div
+            class="flex items-center gap-2 text-muted-foreground"
+          >
+            <span>
+              ClusterPolicy
+            </span>
+            <span
+              class="text-2xs"
+            >
+              prod
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-3 pt-3 border-t border-border/50"
+    >
+      <p
+        class="text-2xs text-muted-foreground font-medium mb-2"
+      >
+        Kyverno Features
+      </p>
+      <div
+        class="grid grid-cols-2 gap-1.5 text-2xs"
+      >
+        <div
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21.801 10A10 10 0 1 1 17 3.335"
+            />
+            <path
+              d="m9 11 3 3L22 4"
+            />
+          </svg>
+          Validate Resources
+        </div>
+        <div
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21.801 10A10 10 0 1 1 17 3.335"
+            />
+            <path
+              d="m9 11 3 3L22 4"
+            />
+          </svg>
+          Mutate Resources
+        </div>
+        <div
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21.801 10A10 10 0 1 1 17 3.335"
+            />
+            <path
+              d="m9 11 3 3L22 4"
+            />
+          </svg>
+          Generate Resources
+        </div>
+        <div
+          class="flex items-center gap-1 text-muted-foreground"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21.801 10A10 10 0 1 1 17 3.335"
+            />
+            <path
+              d="m9 11 3 3L22 4"
+            />
+          </svg>
+          Image Verification
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex items-center justify-center gap-3 pt-2 mt-2 border-t border-border/50 text-2xs"
+    >
+      <a
+        class="text-muted-foreground hover:text-purple-400 transition-colors"
+        href="https://kyverno.io/docs/introduction/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Documentation
+      </a>
+      <span
+        class="text-muted-foreground/30"
+      >
+        ·
+      </span>
+      <a
+        class="text-muted-foreground hover:text-purple-400 transition-colors"
+        href="https://kyverno.io/policies/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        Policy Library
+      </a>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/OPAPolicies.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/OPAPolicies.test.tsx.snap
@@ -1,0 +1,16 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OPAPolicies > matches snapshot 1`] = `
+<div>
+  <div
+    class="h-full flex flex-col min-h-card"
+  >
+    <div
+      data-testid="opa-table"
+    >
+      1
+       clusters
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/OPAPoliciesModal.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/OPAPoliciesModal.test.tsx.snap
@@ -1,0 +1,9 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OPAPoliciesModal > matches snapshot 1`] = `
+<div>
+  <div
+    data-testid="cluster-opa-modal"
+  />
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/RBACExplorer.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/RBACExplorer.test.tsx.snap
@@ -1,0 +1,102 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RBACExplorer > matches snapshot 1`] = `
+<div>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded overflow-hidden"
+  >
+    <div
+      class="flex gap-1 flex-wrap mb-2"
+    >
+      <button
+        class="px-2 py-0.5 text-xs rounded-full transition-colors bg-muted/30 text-muted-foreground hover:bg-muted/50"
+      >
+        critical
+        : 
+        0
+      </button>
+      <button
+        class="px-2 py-0.5 text-xs rounded-full transition-colors bg-muted/30 text-muted-foreground hover:bg-muted/50"
+      >
+        high
+        : 
+        1
+      </button>
+      <button
+        class="px-2 py-0.5 text-xs rounded-full transition-colors bg-muted/30 text-muted-foreground hover:bg-muted/50"
+      >
+        medium
+        : 
+        0
+      </button>
+      <button
+        class="px-2 py-0.5 text-xs rounded-full transition-colors bg-muted/30 text-muted-foreground hover:bg-muted/50"
+      >
+        low
+        : 
+        0
+      </button>
+    </div>
+    <input
+      data-testid="search-input"
+      value=""
+    />
+    <div
+      class="flex-1 overflow-y-auto"
+      style="max-height: 320px;"
+    >
+      <div
+        style="height: 72px; width: 100%; position: relative;"
+      >
+        <div
+          data-index="0"
+          style="position: absolute; top: 0px; left: 0px; width: 100%; transform: translateY(0px);"
+        >
+          <div
+            class="px-2 py-1.5 mb-1 rounded-lg bg-orange-500/10 border border-transparent hover:border-current/20 transition-colors"
+          >
+            <div
+              class="flex flex-wrap items-center justify-between gap-y-2 gap-2"
+            >
+              <div
+                class="flex items-center gap-2 min-w-0"
+              >
+                <span
+                  class="text-xs px-1.5 py-0.5 rounded bg-orange-500/10 text-orange-400 font-medium shrink-0"
+                >
+                  HIGH
+                </span>
+                <span
+                  class="text-sm font-medium truncate"
+                >
+                  system:sa
+                </span>
+                <span
+                  class="text-xs text-muted-foreground shrink-0"
+                >
+                  (
+                  ServiceAccount
+                  )
+                </span>
+              </div>
+              <span>
+                prod
+              </span>
+            </div>
+            <div
+              class="text-xs text-muted-foreground mt-0.5"
+            >
+              wildcard
+            </div>
+            <div
+              class="text-xs text-muted-foreground/60 mt-0.5 truncate"
+            >
+              binding
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/RecommendedPolicies.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/RecommendedPolicies.test.tsx.snap
@@ -1,0 +1,312 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RecommendedPolicies > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-3"
+  >
+    <div
+      class="flex items-center gap-3 p-2.5 rounded-lg bg-secondary/30 border border-border/50"
+    >
+      <div
+        class="relative w-12 h-12 shrink-0"
+      >
+        <svg
+          class="w-full h-full -rotate-90"
+          viewBox="0 0 36 36"
+        >
+          <circle
+            class="text-secondary"
+            cx="18"
+            cy="18"
+            fill="none"
+            r="14"
+            stroke="currentColor"
+            stroke-width="3"
+          />
+          <circle
+            class="text-red-400"
+            cx="18"
+            cy="18"
+            fill="none"
+            r="14"
+            stroke="currentColor"
+            stroke-dasharray="0, 100"
+            stroke-width="3"
+          />
+        </svg>
+        <div
+          class="absolute inset-0 flex items-center justify-center"
+        >
+          <span
+            class="text-xs font-bold text-foreground"
+          >
+            0
+            %
+          </span>
+        </div>
+      </div>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <p
+          class="text-sm font-medium text-foreground"
+        >
+          Fleet Coverage
+        </p>
+        <p
+          class="text-xs text-muted-foreground"
+        >
+          7
+           policy 
+          gaps
+           across your fleet
+        </p>
+      </div>
+      <button
+        class="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-purple-500/20 border border-purple-500/30 text-purple-400 text-xs font-medium hover:bg-purple-500/30 transition-colors whitespace-nowrap"
+        title="Deploy all missing policies with a single AI mission"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-sparkles w-3.5 h-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+          />
+          <path
+            d="M20 2v4"
+          />
+          <path
+            d="M22 4h-4"
+          />
+          <circle
+            cx="4"
+            cy="20"
+            r="2"
+          />
+        </svg>
+        Deploy All
+      </button>
+    </div>
+    <div
+      class="space-y-1.5"
+    >
+      <div>
+        <button
+          class="w-full flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border transition-colors bg-secondary/20 border-transparent hover:bg-secondary/40"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-chevron-right w-3.5 h-3.5 transition-transform  text-red-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+              />
+            </svg>
+            <span
+              class="text-xs font-medium text-red-400"
+            >
+              Security Hardening
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-1.5"
+          >
+            <span>
+              2
+               gap
+              s
+            </span>
+          </div>
+        </button>
+      </div>
+      <div>
+        <button
+          class="w-full flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border transition-colors bg-secondary/20 border-transparent hover:bg-secondary/40"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-chevron-right w-3.5 h-3.5 transition-transform  text-blue-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+              />
+            </svg>
+            <span
+              class="text-xs font-medium text-blue-400"
+            >
+              Best Practices
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-1.5"
+          >
+            <span>
+              2
+               gap
+              s
+            </span>
+          </div>
+        </button>
+      </div>
+      <div>
+        <button
+          class="w-full flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border transition-colors bg-secondary/20 border-transparent hover:bg-secondary/40"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-chevron-right w-3.5 h-3.5 transition-transform  text-purple-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+              />
+            </svg>
+            <span
+              class="text-xs font-medium text-purple-400"
+            >
+              Supply Chain
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-1.5"
+          >
+            <span>
+              2
+               gap
+              s
+            </span>
+          </div>
+        </button>
+      </div>
+      <div>
+        <button
+          class="w-full flex flex-wrap items-center justify-between gap-y-2 p-2 rounded-lg border transition-colors bg-secondary/20 border-transparent hover:bg-secondary/40"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-chevron-right w-3.5 h-3.5 transition-transform  text-orange-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+              />
+            </svg>
+            <span
+              class="text-xs font-medium text-orange-400"
+            >
+              Resource Governance
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-1.5"
+          >
+            <span>
+              1
+               gap
+            </span>
+          </div>
+        </button>
+      </div>
+    </div>
+    <div
+      class="flex items-center gap-2 pt-2 border-t border-border/50"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-sparkles w-3.5 h-3.5 text-purple-400 shrink-0"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+        />
+        <path
+          d="M20 2v4"
+        />
+        <path
+          d="M22 4h-4"
+        />
+        <circle
+          cx="4"
+          cy="20"
+          r="2"
+        />
+      </svg>
+      <p
+        class="text-2xs text-muted-foreground"
+      >
+        <span
+          class="text-purple-400 font-medium"
+        >
+          AI-powered
+        </span>
+         — One click deploys policies across your entire fleet
+      </p>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/RuntimeAttestationCard.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/RuntimeAttestationCard.test.tsx.snap
@@ -1,0 +1,133 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RuntimeAttestationCard > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-4 p-1"
+  >
+    <div
+      class="flex items-center gap-3 p-3 rounded-lg bg-secondary/30"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-shield-check w-6 h-6 text-green-400"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+        />
+        <path
+          d="m9 12 2 2 4-4"
+        />
+      </svg>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <p
+          class="text-xs text-muted-foreground"
+        >
+          runtimeAttestation.fleetAverage
+        </p>
+        <div
+          class="flex items-center gap-2 mt-1"
+        >
+          <div
+            class="flex-1 h-2 rounded-full bg-secondary overflow-hidden"
+          >
+            <div
+              class="h-full rounded-full transition-all bg-green-500"
+              style="width: 90%;"
+            />
+          </div>
+          <span
+            class="text-sm font-semibold tabular-nums text-green-400"
+          >
+            90
+            /
+            100
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="space-y-1"
+    >
+      <button
+        class="w-full flex items-center gap-3 p-2.5 rounded-lg hover:bg-secondary/40 transition-colors text-left group"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-check-big w-4 h-4 text-green-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.801 10A10 10 0 1 1 17 3.335"
+          />
+          <path
+            d="m9 11 3 3L22 4"
+          />
+        </svg>
+        <div
+          class="flex-1 min-w-0"
+        >
+          <p
+            class="text-sm font-medium text-foreground truncate"
+          >
+            prod
+          </p>
+          <div
+            class="flex items-center gap-2 mt-1"
+          >
+            <div
+              class="flex-1 h-1.5 rounded-full bg-secondary overflow-hidden"
+            >
+              <div
+                class="h-full rounded-full transition-all bg-green-500"
+                style="width: 90%;"
+              />
+            </div>
+            <span
+              class="text-xs tabular-nums text-green-400"
+            >
+              90
+            </span>
+          </div>
+        </div>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="m9 18 6-6-6-6"
+          />
+        </svg>
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/SecurityIssues.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/SecurityIssues.test.tsx.snap
@@ -1,0 +1,125 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`SecurityIssues > matches snapshot 1`] = `
+<div>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-3"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <span>
+          1
+           
+          securityIssues.highLabel
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+      />
+    </div>
+    <div
+      class="flex-1 space-y-2 overflow-y-auto min-h-card-content"
+    >
+      <div
+        class="p-2 rounded-lg bg-red-500/20 border border-red-500/30 cursor-pointer hover:opacity-80 transition-opacity"
+        title="securityIssues.clickViewPod"
+      >
+        <div
+          class="flex items-start gap-2 group"
+        >
+          <div
+            class="p-1.5 rounded-lg bg-red-500/20 shrink-0"
+            title="securityIssues.privilegedContainer"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-shield w-4 h-4 text-red-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"
+              />
+            </svg>
+          </div>
+          <div
+            class="flex-1 min-w-0"
+          >
+            <div
+              class="flex items-center gap-2 mb-0.5"
+            >
+              <span />
+              <span
+                class="text-xs text-muted-foreground"
+                title="Namespace: prod-ns"
+              >
+                prod-ns
+              </span>
+            </div>
+            <p
+              class="text-sm font-medium text-foreground truncate"
+              title="api-pod"
+            >
+              api-pod
+            </p>
+            <div
+              class="flex items-center gap-2 mt-1 flex-wrap"
+            >
+              <span
+                class="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400"
+                title="Issue type: Privileged container"
+              >
+                Privileged container
+              </span>
+              <span
+                class="text-xs px-2 py-0.5 rounded bg-red-500/20 text-red-400 capitalize"
+                title="Severity level: high"
+              >
+                high
+              </span>
+            </div>
+            <p
+              class="text-xs text-muted-foreground mt-1 truncate"
+              title="privileged mode"
+            >
+              privileged mode
+            </p>
+          </div>
+          <span
+            title="Click to view details"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground shrink-0 mt-1"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m9 18 6-6-6-6"
+              />
+            </svg>
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/compliance/__tests__/ComplianceScoreBreakdownModal.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/ComplianceScoreBreakdownModal.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComplianceScoreBreakdownModal } from '../ComplianceScoreBreakdownModal'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../../../../lib/modals/BaseModal', () => {
+  const Header = ({ title, extra }: { title: string; extra?: ReactNode }) => (
+    <div data-testid="modal-header">
+      <span>{title}</span>
+      {extra}
+    </div>
+  )
+  const Tabs = ({
+    tabs,
+    activeTab,
+    onTabChange,
+  }: {
+    tabs: Array<{ id: string; label: string; badge?: string }>
+    activeTab: string
+    onTabChange: (id: string) => void
+  }) => (
+    <div data-testid="modal-tabs">
+      {tabs.map((tab) => (
+        <button key={tab.id} onClick={() => onTabChange(tab.id)} data-active={activeTab === tab.id}>
+          {tab.label}
+          {tab.badge && <span data-testid={`badge-${tab.id}`}>{tab.badge}</span>}
+        </button>
+      ))}
+    </div>
+  )
+  const Content = ({ children }: { children: ReactNode }) => (
+    <div data-testid="modal-content">{children}</div>
+  )
+  const Footer = () => <div data-testid="modal-footer" />
+
+  const BaseModal = ({ isOpen, children }: { isOpen: boolean; onClose: () => void; children: ReactNode }) =>
+    isOpen ? <div data-testid="base-modal">{children}</div> : null
+
+  BaseModal.Header = Header
+  BaseModal.Tabs = Tabs
+  BaseModal.Content = Content
+  BaseModal.Footer = Footer
+
+  return { BaseModal }
+})
+
+vi.mock('../../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children }: { children: ReactNode }) => (
+    <span data-testid="status-badge">{children}</span>
+  ),
+}))
+
+vi.mock('../../../../lib/constants/compliance', () => ({
+  getScoreContext: vi.fn((score: number) => ({
+    label: score >= 80 ? 'Good' : score >= 60 ? 'Fair' : 'Poor',
+    color: score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400',
+    description: score >= 80 ? 'Strong posture' : score >= 60 ? 'Moderate posture' : 'Weak posture',
+  })),
+}))
+
+vi.mock('../../../../lib/analytics', () => ({
+  emitModalOpened: vi.fn(),
+  emitModalClosed: vi.fn(),
+  emitModalTabViewed: vi.fn(),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const defaultProps = {
+  isOpen: true,
+  onClose: vi.fn(),
+  score: 75,
+  breakdown: [{ name: 'Kubescape', value: 75 }],
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ComplianceScoreBreakdownModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('rendering', () => {
+    it('renders nothing when isOpen is false', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} isOpen={false} />)
+      expect(screen.queryByTestId('base-modal')).not.toBeInTheDocument()
+    })
+
+    it('renders modal with title when open', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} />)
+      expect(screen.getByTestId('base-modal')).toBeInTheDocument()
+      expect(screen.getByText('Compliance Score Breakdown')).toBeInTheDocument()
+    })
+
+    it('renders status badge with score and label', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} score={75} />)
+      const badge = screen.getByTestId('status-badge')
+      expect(badge.textContent).toContain('75%')
+      expect(badge.textContent).toContain('Fair')
+    })
+  })
+
+  describe('tabs', () => {
+    it('renders Overview tab by default', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} />)
+      expect(screen.getByText('Overview')).toBeInTheDocument()
+    })
+
+    it('renders per-tool tabs for each breakdown item', () => {
+      const breakdown = [
+        { name: 'Kubescape', value: 78 },
+        { name: 'Kyverno', value: 72 },
+      ]
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} />)
+      expect(screen.getByText('Kubescape')).toBeInTheDocument()
+      expect(screen.getByText('Kyverno')).toBeInTheDocument()
+    })
+
+    it('switches to Kubescape tab when clicked', async () => {
+      const breakdown = [{ name: 'Kubescape', value: 78 }]
+      const kubescapeData = {
+        totalControls: 55,
+        passedControls: 45,
+        failedControls: 10,
+        frameworks: [{ name: 'NSA-CISA', score: 82 }],
+      }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kubescapeData={kubescapeData} />)
+      await userEvent.click(screen.getByText('Kubescape'))
+      expect(screen.getByText('Total Controls')).toBeInTheDocument()
+      expect(screen.getByText('55')).toBeInTheDocument()
+    })
+
+    it('switches to Kyverno tab when clicked', async () => {
+      const breakdown = [{ name: 'Kyverno', value: 72 }]
+      const kyvernoData = {
+        totalPolicies: 20,
+        totalViolations: 5,
+        enforcingCount: 8,
+        auditCount: 12,
+      }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kyvernoData={kyvernoData} />)
+      await userEvent.click(screen.getByText('Kyverno'))
+      expect(screen.getByText('Total Policies')).toBeInTheDocument()
+      expect(screen.getByText('20')).toBeInTheDocument()
+    })
+
+    it('shows unavailable message for tool tab with no data', async () => {
+      const breakdown = [{ name: 'Kubescape', value: 78 }]
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kubescapeData={undefined} />)
+      await userEvent.click(screen.getByText('Kubescape'))
+      expect(screen.getByText('Kubescape data not available')).toBeInTheDocument()
+    })
+
+    it('shows tab badges with score percentage', () => {
+      const breakdown = [{ name: 'Kubescape', value: 82 }]
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} />)
+      expect(screen.getByTestId('badge-Kubescape').textContent).toBe('82%')
+    })
+  })
+
+  describe('overview tab content', () => {
+    it('renders score percentage in gauge', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} score={75} />)
+      expect(screen.getByText('75%')).toBeInTheDocument()
+    })
+
+    it('renders score context label and description', () => {
+      render(<ComplianceScoreBreakdownModal {...defaultProps} score={75} />)
+      expect(screen.getByText('Fair')).toBeInTheDocument()
+      expect(screen.getByText('Moderate posture')).toBeInTheDocument()
+    })
+
+    it('renders kubescape check stats when kubescapeData provided', () => {
+      const kubescapeData = { totalControls: 100, passedControls: 80, failedControls: 20, frameworks: [] }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} kubescapeData={kubescapeData} />)
+      expect(screen.getByText('Total Checks')).toBeInTheDocument()
+      expect(screen.getByText('100')).toBeInTheDocument()
+      expect(screen.getByText('Passing')).toBeInTheDocument()
+      expect(screen.getByText('Failing')).toBeInTheDocument()
+    })
+
+    it('renders kyverno policy stats when kyvernoData provided', () => {
+      const kyvernoData = { totalPolicies: 15, totalViolations: 3, enforcingCount: 5, auditCount: 10 }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} kyvernoData={kyvernoData} />)
+      expect(screen.getByText('Policies')).toBeInTheDocument()
+      expect(screen.getByText('Violations')).toBeInTheDocument()
+      expect(screen.getByText('15')).toBeInTheDocument()
+      expect(screen.getByText('3')).toBeInTheDocument()
+    })
+
+    it('renders empty state when no tool data and no breakdown', () => {
+      render(
+        <ComplianceScoreBreakdownModal
+          {...defaultProps}
+          breakdown={[]}
+          kubescapeData={undefined}
+          kyvernoData={undefined}
+        />,
+      )
+      expect(screen.getByText('No compliance tools are reporting data.')).toBeInTheDocument()
+    })
+
+    it('renders per-tool breakdown bars', () => {
+      const breakdown = [
+        { name: 'Kubescape', value: 78 },
+        { name: 'Kyverno', value: 65 },
+      ]
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} />)
+      // Both tool names appear in the overview breakdown section
+      const allKubescape = screen.getAllByText('Kubescape')
+      const allKyverno = screen.getAllByText('Kyverno')
+      expect(allKubescape.length).toBeGreaterThan(0)
+      expect(allKyverno.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('kubescape tab details', () => {
+    it('renders framework scores in Kubescape tab', async () => {
+      const breakdown = [{ name: 'Kubescape', value: 78 }]
+      const kubescapeData = {
+        totalControls: 55,
+        passedControls: 45,
+        failedControls: 10,
+        frameworks: [
+          { name: 'NSA-CISA', score: 82 },
+          { name: 'MITRE', score: 65 },
+        ],
+      }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kubescapeData={kubescapeData} />)
+      await userEvent.click(screen.getByText('Kubescape'))
+      expect(screen.getByText('NSA-CISA')).toBeInTheDocument()
+      expect(screen.getByText('MITRE')).toBeInTheDocument()
+      expect(screen.getByText('82%')).toBeInTheDocument()
+    })
+  })
+
+  describe('kyverno tab details', () => {
+    it('renders compliance rate in Kyverno tab', async () => {
+      const breakdown = [{ name: 'Kyverno', value: 72 }]
+      const kyvernoData = { totalPolicies: 10, totalViolations: 2, enforcingCount: 4, auditCount: 6 }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kyvernoData={kyvernoData} />)
+      await userEvent.click(screen.getByText('Kyverno'))
+      expect(screen.getByText(/Compliance Rate/)).toBeInTheDocument()
+    })
+
+    it('shows no policies message when totalPolicies is 0', async () => {
+      const breakdown = [{ name: 'Kyverno', value: 0 }]
+      const kyvernoData = { totalPolicies: 0, totalViolations: 0, enforcingCount: 0, auditCount: 0 }
+      render(<ComplianceScoreBreakdownModal {...defaultProps} breakdown={breakdown} kyvernoData={kyvernoData} />)
+      await userEvent.click(screen.getByText('Kyverno'))
+      expect(screen.getByText('No policies configured')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/compliance/__tests__/ComplianceScoreCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/ComplianceScoreCard.test.tsx
@@ -1,0 +1,232 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { ComplianceScoreCard } from '../ComplianceScoreCard'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { checked?: number; total?: number; reporting?: number }) => {
+      if (opts?.checked != null && opts?.total != null) return `checking-${opts.checked}-${opts.total}`
+      if (opts?.reporting != null && opts?.total != null) return `partial-${opts.reporting}-${opts.total}`
+      return key
+    },
+  }),
+}))
+
+const mockUseKubescape = vi.fn()
+vi.mock('../../../../hooks/useKubescape', () => ({
+  useKubescape: () => mockUseKubescape(),
+}))
+
+const mockUseKyverno = vi.fn()
+vi.mock('../../../../hooks/useKyverno', () => ({
+  useKyverno: () => mockUseKyverno(),
+}))
+
+const mockSelectedClusters = vi.fn(() => [] as string[])
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: mockSelectedClusters() }),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children, color }: { children: ReactNode; color: string }) => (
+    <span data-testid="status-badge" data-color={color}>{children}</span>
+  ),
+}))
+
+vi.mock('../ComplianceScoreBreakdownModal', () => ({
+  ComplianceScoreBreakdownModal: ({
+    isOpen,
+    score,
+  }: {
+    isOpen: boolean
+    score: number
+  }) =>
+    isOpen ? <div data-testid="breakdown-modal">{score}</div> : null,
+}))
+
+vi.mock('../../../../lib/complianceScore', () => ({
+  buildComplianceScoreSummary: vi.fn(() => ({
+    score: 75,
+    breakdown: [{ name: 'Kubescape', value: 75 }],
+    usingFallback: false,
+  })),
+}))
+
+vi.mock('../../../../lib/constants/compliance', () => ({
+  CARD_DESCRIPTIONS: {
+    compliance_score: { description: 'Aggregated compliance score' },
+  },
+  getScoreContext: vi.fn((score: number) => ({
+    label: score >= 80 ? 'Good' : score >= 60 ? 'Fair' : 'Poor',
+    color: score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400',
+    description: 'Security posture overview',
+  })),
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeKubescapeReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    statuses: {},
+    aggregated: { overallScore: 75, frameworks: [], totalControls: 10, passedControls: 7, failedControls: 3 },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    installed: false,
+    hasErrors: false,
+    clustersChecked: 0,
+    totalClusters: 0,
+    unavailableReason: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+function makeKyvernoReturn(overrides: Record<string, unknown> = {}) {
+  return {
+    statuses: {},
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    installed: false,
+    hasErrors: false,
+    clustersChecked: 0,
+    totalClusters: 0,
+    unavailableReason: null,
+    refetch: vi.fn(),
+    ...overrides,
+  }
+}
+
+function setup(ksOverrides: Record<string, unknown> = {}, kyOverrides: Record<string, unknown> = {}) {
+  mockUseKubescape.mockReturnValue(makeKubescapeReturn(ksOverrides))
+  mockUseKyverno.mockReturnValue(makeKyvernoReturn(kyOverrides))
+  mockUseCardLoadingState.mockReturnValue({})
+  mockSelectedClusters.mockReturnValue([])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ComplianceScoreCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setup()
+  })
+
+  describe('unavailable state', () => {
+    it('shows unavailable message when both tools have unavailable reason', () => {
+      setup(
+        { unavailableReason: 'no agent' },
+        { unavailableReason: 'no agent' },
+      )
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('Compliance scoring not available')).toBeInTheDocument()
+      expect(screen.getByText('Requires kc-agent (local agent mode)')).toBeInTheDocument()
+    })
+  })
+
+  describe('no tools installed', () => {
+    it('shows install prompt when neither tool is installed and not in demo mode', () => {
+      setup({ installed: false, totalClusters: 1, clustersChecked: 1 }, { installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('cards:complianceScore.noToolsDetected')).toBeInTheDocument()
+      expect(screen.getByText(/cards:complianceScore.installWithMission/)).toBeInTheDocument()
+    })
+
+    it('starts install mission when install button is clicked', async () => {
+      setup({ installed: false, totalClusters: 1, clustersChecked: 1 }, { installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<ComplianceScoreCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:complianceScore.installWithMission/))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'deploy' }),
+      )
+    })
+  })
+
+  describe('score display', () => {
+    it('renders the score percentage in the gauge', () => {
+      setup({ installed: true, totalClusters: 1, clustersChecked: 1 }, { installed: false })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('75%')).toBeInTheDocument()
+    })
+
+    it('renders card description info text', () => {
+      setup({ installed: true, totalClusters: 1, clustersChecked: 1 }, { installed: false })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('Aggregated compliance score')).toBeInTheDocument()
+    })
+
+    it('renders score context label', () => {
+      setup({ installed: true, totalClusters: 1, clustersChecked: 1 }, { installed: false })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('Fair')).toBeInTheDocument()
+    })
+
+    it('opens breakdown modal when gauge is clicked', async () => {
+      setup({ installed: true, totalClusters: 1, clustersChecked: 1 }, { installed: false })
+      render(<ComplianceScoreCard config={{}} />)
+      const gauge = screen.getByRole('button', { name: 'cards:complianceScore.viewBreakdownAria' })
+      await userEvent.click(gauge)
+      expect(screen.getByTestId('breakdown-modal')).toBeInTheDocument()
+    })
+  })
+
+  describe('cluster badges', () => {
+    it('renders cluster badges for installed kubescape clusters', () => {
+      const statuses = {
+        prod: { cluster: 'prod', installed: true, loading: false, overallScore: 80, frameworks: [], totalControls: 10, passedControls: 8, failedControls: 2, controls: [] },
+      }
+      setup({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 }, { installed: false, statuses: {} })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('prod')).toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when any tool returns demo data', () => {
+      setup({ isDemoData: true })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true }),
+      )
+    })
+
+    it('passes isFailed=true when both tools have errors', () => {
+      setup({ hasErrors: true }, { hasErrors: true })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isFailed: true }),
+      )
+    })
+  })
+
+  describe('checking progress indicator', () => {
+    it('shows progress indicator while clusters are being checked', () => {
+      setup({ totalClusters: 3, clustersChecked: 1, installed: true }, { totalClusters: 3, clustersChecked: 1 })
+      render(<ComplianceScoreCard config={{}} />)
+      expect(screen.getByText('checking-1-3')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/compliance/__tests__/KubescapeScanCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/KubescapeScanCard.test.tsx
@@ -1,0 +1,275 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { KubescapeScanCard } from '../KubescapeScanCard'
+import type { KubescapeClusterStatus } from '../../../../hooks/useKubescape'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { checked?: number; total?: number }) => {
+      if (opts?.checked != null && opts?.total != null) return `checking-${opts.checked}-${opts.total}`
+      return key
+    },
+  }),
+}))
+
+const mockUseKubescape = vi.fn()
+vi.mock('../../../../hooks/useKubescape', () => ({
+  useKubescape: () => mockUseKubescape(),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+const mockSelectedClusters = vi.fn(() => [] as string[])
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: mockSelectedClusters() }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children, color }: { children: ReactNode; color: string }) => (
+    <span data-testid="status-badge" data-color={color}>{children}</span>
+  ),
+}))
+
+vi.mock('../../kubescape/KubescapeDetailModal', () => ({
+  KubescapeDetailModal: ({ isOpen, clusterName }: { isOpen: boolean; clusterName: string }) =>
+    isOpen ? <div data-testid="kubescape-modal">{clusterName}</div> : null,
+}))
+
+vi.mock('../../../../lib/constants/compliance', () => ({
+  getFrameworkInfo: vi.fn((name: string) => ({
+    label: name,
+    description: `${name} framework`,
+    url: `https://example.com/${name}`,
+  })),
+  getScoreContext: vi.fn((score: number) => ({
+    label: score >= 80 ? 'Good' : score >= 60 ? 'Fair' : 'Poor',
+    color: score >= 80 ? 'text-green-400' : score >= 60 ? 'text-yellow-400' : 'text-red-400',
+    description: 'Security posture overview',
+  })),
+}))
+
+vi.mock('../../../../lib/utils/sanitizeUrl', () => ({
+  sanitizeUrl: (url: string) => url,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatus(overrides: Partial<KubescapeClusterStatus> = {}): KubescapeClusterStatus {
+  return {
+    cluster: 'prod',
+    installed: true,
+    loading: false,
+    overallScore: 78,
+    frameworks: [{ name: 'NSA-CISA', score: 82, passCount: 45, failCount: 10 }],
+    totalControls: 55,
+    passedControls: 45,
+    failedControls: 10,
+    controls: [],
+    ...overrides,
+  }
+}
+
+function setupKubescape(overrides: Record<string, unknown> = {}) {
+  mockUseKubescape.mockReturnValue({
+    statuses: {},
+    aggregated: { overallScore: 78, frameworks: [], totalControls: 55, passedControls: 45, failedControls: 10 },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    installed: false,
+    hasErrors: false,
+    clustersChecked: 0,
+    totalClusters: 0,
+    unavailableReason: null,
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({})
+  mockSelectedClusters.mockReturnValue([])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('KubescapeScanCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupKubescape()
+  })
+
+  describe('unavailable state', () => {
+    it('shows unavailable message when unavailableReason is set', () => {
+      setupKubescape({ unavailableReason: 'in-cluster mode' })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('Security posture scanning not available')).toBeInTheDocument()
+      expect(screen.getByText('Requires kc-agent (local agent mode)')).toBeInTheDocument()
+    })
+  })
+
+  describe('loading state', () => {
+    it('shows spinner while loading with no statuses', () => {
+      setupKubescape({ isLoading: true, statuses: {} })
+      render(<KubescapeScanCard config={{}} />)
+      // Loader2 spinner is rendered — no crash
+      expect(document.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('shows cluster progress text during initial load', () => {
+      setupKubescape({ isLoading: true, statuses: {}, totalClusters: 3, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('checking-1-3')).toBeInTheDocument()
+    })
+  })
+
+  describe('install prompt', () => {
+    it('shows install prompt when not installed and not loading', () => {
+      setupKubescape({ installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('cards:kubescapeScan.integration')).toBeInTheDocument()
+      expect(screen.getByText(/cards:kubescapeScan.installWithMission/)).toBeInTheDocument()
+    })
+
+    it('starts deploy mission when install button is clicked', async () => {
+      setupKubescape({ installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:kubescapeScan.installWithMission/))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'deploy', title: 'Install Kubescape' }),
+      )
+    })
+  })
+
+  describe('error state', () => {
+    it('shows error banner when fetch fails', () => {
+      setupKubescape({ hasErrors: true, installed: false })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('cards:kubescapeScan.failedToFetch')).toBeInTheDocument()
+      expect(screen.getByText(/cards:kubescapeScan.retry/)).toBeInTheDocument()
+    })
+
+    it('triggers refetch when retry is clicked', async () => {
+      const mockRefetch = vi.fn()
+      setupKubescape({ hasErrors: true, installed: false, refetch: mockRefetch })
+      render(<KubescapeScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:kubescapeScan.retry/))
+      expect(mockRefetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('degraded state', () => {
+    it('shows troubleshoot prompt when installed but no scan data', () => {
+      const statuses = {
+        prod: makeStatus({ totalControls: 0, frameworks: [] }),
+      }
+      setupKubescape({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('cards:kubescapeScan.noScanData')).toBeInTheDocument()
+      expect(screen.getByText(/cards:kubescapeScan.fixWithMission/)).toBeInTheDocument()
+    })
+
+    it('starts troubleshoot mission when fix button is clicked', async () => {
+      const statuses = {
+        prod: makeStatus({ totalControls: 0, frameworks: [] }),
+      }
+      setupKubescape({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:kubescapeScan.fixWithMission/))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'troubleshoot' }),
+      )
+    })
+  })
+
+  describe('scan results display', () => {
+    it('renders cluster score badges for installed clusters', () => {
+      const statuses = { prod: makeStatus() }
+      setupKubescape({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      const badges = screen.getAllByTestId('status-badge')
+      expect(badges.some((b) => b.textContent?.includes('prod'))).toBe(true)
+    })
+
+    it('renders framework scores from aggregated data', () => {
+      const aggregated = {
+        overallScore: 78,
+        frameworks: [{ name: 'NSA-CISA', score: 82, passCount: 45, failCount: 10 }],
+        totalControls: 55,
+        passedControls: 45,
+        failedControls: 10,
+      }
+      setupKubescape({ installed: true, statuses: {}, aggregated, totalClusters: 0, clustersChecked: 0 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('NSA-CISA')).toBeInTheDocument()
+      expect(screen.getByText('82%')).toBeInTheDocument()
+    })
+
+    it('renders passed and failed control counts', () => {
+      const aggregated = {
+        overallScore: 78,
+        frameworks: [],
+        totalControls: 55,
+        passedControls: 45,
+        failedControls: 10,
+      }
+      setupKubescape({ installed: true, statuses: {}, aggregated, totalClusters: 0, clustersChecked: 0 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText(/45/)).toBeInTheDocument()
+      expect(screen.getByText(/10/)).toBeInTheDocument()
+    })
+
+    it('opens cluster detail modal when cluster badge is clicked', async () => {
+      const statuses = { prod: makeStatus() }
+      setupKubescape({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      const badge = screen.getByTestId('status-badge')
+      await userEvent.click(badge)
+      expect(screen.getByTestId('kubescape-modal')).toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when hook returns demo data', () => {
+      setupKubescape({ isDemoData: true })
+      render(<KubescapeScanCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+
+    it('passes isFailed=true when fetch errors occur', () => {
+      setupKubescape({ hasErrors: true })
+      render(<KubescapeScanCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isFailed: true }),
+      )
+    })
+  })
+
+  describe('progress indicator', () => {
+    it('shows checking progress when not all clusters checked', () => {
+      const statuses = { prod: makeStatus() }
+      setupKubescape({ installed: true, statuses, totalClusters: 3, clustersChecked: 1 })
+      render(<KubescapeScanCard config={{}} />)
+      expect(screen.getByText('checking-1-3')).toBeInTheDocument()
+    })
+  })
+})

--- a/web/src/components/cards/compliance/__tests__/TrivyScanCard.test.tsx
+++ b/web/src/components/cards/compliance/__tests__/TrivyScanCard.test.tsx
@@ -1,0 +1,270 @@
+import React from 'react'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { ReactNode } from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { TrivyScanCard } from '../TrivyScanCard'
+import type { TrivyClusterStatus } from '../../../../hooks/useTrivy'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string, opts?: { checked?: number; total?: number }) => {
+      if (opts?.checked != null && opts?.total != null) return `checking-${opts.checked}-${opts.total}`
+      return key
+    },
+  }),
+}))
+
+const mockUseTrivy = vi.fn()
+vi.mock('../../../../hooks/useTrivy', () => ({
+  useTrivy: () => mockUseTrivy(),
+}))
+
+const mockStartMission = vi.fn()
+vi.mock('../../../../hooks/useMissions', () => ({
+  useMissions: () => ({ startMission: mockStartMission }),
+}))
+
+const mockSelectedClusters = vi.fn(() => [] as string[])
+vi.mock('../../../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({ selectedClusters: mockSelectedClusters() }),
+}))
+
+const mockUseCardLoadingState = vi.fn()
+vi.mock('../../CardDataContext', () => ({
+  useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+}))
+
+vi.mock('../../ui/StatusBadge', () => ({
+  StatusBadge: ({ children, color }: { children: ReactNode; color: string }) => (
+    <span data-testid="status-badge" data-color={color}>{children}</span>
+  ),
+}))
+
+vi.mock('../../trivy/TrivyDetailModal', () => ({
+  TrivyDetailModal: ({ isOpen, clusterName }: { isOpen: boolean; clusterName: string }) =>
+    isOpen ? <div data-testid="trivy-modal">{clusterName}</div> : null,
+}))
+
+vi.mock('../../../../lib/constants/compliance', () => ({
+  TRIVY_SEVERITY: {
+    critical: { description: 'Actively exploited vulnerabilities', action: 'Patch immediately' },
+    high: { description: 'Likely exploitable vulnerabilities' },
+    medium: { description: 'Potentially exploitable vulnerabilities' },
+    low: { description: 'Limited exploitability' },
+    unknown: { description: 'Unknown severity' },
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeStatus(overrides: Partial<TrivyClusterStatus> = {}): TrivyClusterStatus {
+  return {
+    cluster: 'prod',
+    installed: true,
+    loading: false,
+    vulnerabilities: { critical: 2, high: 5, medium: 10, low: 20, unknown: 1 },
+    totalReports: 38,
+    scannedImages: 38,
+    images: [],
+    ...overrides,
+  }
+}
+
+function setupTrivy(overrides: Record<string, unknown> = {}) {
+  mockUseTrivy.mockReturnValue({
+    statuses: {},
+    aggregated: { critical: 0, high: 0, medium: 0, low: 0, unknown: 0 },
+    isLoading: false,
+    isRefreshing: false,
+    isDemoData: false,
+    installed: false,
+    hasErrors: false,
+    clustersChecked: 0,
+    totalClusters: 0,
+    unavailableReason: null,
+    refetch: vi.fn(),
+    ...overrides,
+  })
+  mockUseCardLoadingState.mockReturnValue({})
+  mockSelectedClusters.mockReturnValue([])
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('TrivyScanCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    setupTrivy()
+  })
+
+  describe('unavailable state', () => {
+    it('shows unavailable message when unavailableReason is set', () => {
+      setupTrivy({ unavailableReason: 'in-cluster mode' })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('Vulnerability scanning not available')).toBeInTheDocument()
+      expect(screen.getByText('Requires kc-agent (local agent mode)')).toBeInTheDocument()
+    })
+  })
+
+  describe('loading state', () => {
+    it('shows spinner while loading with no statuses', () => {
+      setupTrivy({ isLoading: true, statuses: {} })
+      render(<TrivyScanCard config={{}} />)
+      expect(document.querySelector('svg')).toBeInTheDocument()
+    })
+
+    it('shows cluster progress text during initial load', () => {
+      setupTrivy({ isLoading: true, statuses: {}, totalClusters: 2, clustersChecked: 0 })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('checking-0-2')).toBeInTheDocument()
+    })
+  })
+
+  describe('install prompt', () => {
+    it('shows install prompt when not installed and not loading', () => {
+      setupTrivy({ installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('cards:trivyScan.integration')).toBeInTheDocument()
+      expect(screen.getByText(/cards:trivyScan.installWithMission/)).toBeInTheDocument()
+    })
+
+    it('starts deploy mission when install button is clicked', async () => {
+      setupTrivy({ installed: false, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:trivyScan.installWithMission/))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'deploy', title: 'Install Trivy Operator' }),
+      )
+    })
+  })
+
+  describe('error state', () => {
+    it('shows error banner when fetch fails', () => {
+      setupTrivy({ hasErrors: true, installed: false })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('cards:trivyScan.failedToFetch')).toBeInTheDocument()
+      expect(screen.getByText(/cards:trivyScan.retry/)).toBeInTheDocument()
+    })
+
+    it('triggers refetch when retry is clicked', async () => {
+      const mockRefetch = vi.fn()
+      setupTrivy({ hasErrors: true, installed: false, refetch: mockRefetch })
+      render(<TrivyScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:trivyScan.retry/))
+      expect(mockRefetch).toHaveBeenCalled()
+    })
+  })
+
+  describe('degraded state', () => {
+    it('shows troubleshoot prompt when installed but no scan reports', () => {
+      const statuses = {
+        prod: makeStatus({ totalReports: 0 }),
+      }
+      setupTrivy({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('cards:trivyScan.noScanData')).toBeInTheDocument()
+      expect(screen.getByText(/cards:trivyScan.fixWithMission/)).toBeInTheDocument()
+    })
+
+    it('starts troubleshoot mission when fix button is clicked', async () => {
+      const statuses = {
+        prod: makeStatus({ totalReports: 0 }),
+      }
+      setupTrivy({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      await userEvent.click(screen.getByText(/cards:trivyScan.fixWithMission/))
+      expect(mockStartMission).toHaveBeenCalledWith(
+        expect.objectContaining({ type: 'troubleshoot' }),
+      )
+    })
+  })
+
+  describe('vulnerability counts', () => {
+    it('renders severity cards with vulnerability counts', () => {
+      const aggregated = { critical: 3, high: 7, medium: 12, low: 25, unknown: 2 }
+      setupTrivy({ installed: true, statuses: {}, aggregated, totalClusters: 0, clustersChecked: 0 })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('3')).toBeInTheDocument()
+      expect(screen.getByText('7')).toBeInTheDocument()
+      expect(screen.getByText('12')).toBeInTheDocument()
+      expect(screen.getByText('25')).toBeInTheDocument()
+    })
+
+    it('renders cluster badges for installed clusters', () => {
+      const statuses = {
+        prod: makeStatus({ vulnerabilities: { critical: 2, high: 5, medium: 10, low: 20, unknown: 1 } }),
+      }
+      setupTrivy({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      const badges = screen.getAllByTestId('status-badge')
+      expect(badges.some((b) => b.textContent?.includes('prod'))).toBe(true)
+    })
+
+    it('shows critical action text when critical vulnerabilities exist', () => {
+      const aggregated = { critical: 3, high: 0, medium: 0, low: 0, unknown: 0 }
+      setupTrivy({ installed: true, statuses: {}, aggregated })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.getByText('Patch immediately')).toBeInTheDocument()
+    })
+
+    it('does not show critical action text when no critical vulnerabilities', () => {
+      const aggregated = { critical: 0, high: 2, medium: 0, low: 0, unknown: 0 }
+      setupTrivy({ installed: true, statuses: {}, aggregated })
+      render(<TrivyScanCard config={{}} />)
+      expect(screen.queryByText('Patch immediately')).not.toBeInTheDocument()
+    })
+
+    it('opens cluster detail modal when cluster badge is clicked', async () => {
+      const statuses = { prod: makeStatus() }
+      setupTrivy({ installed: true, statuses, totalClusters: 1, clustersChecked: 1 })
+      render(<TrivyScanCard config={{}} />)
+      const badge = screen.getByTestId('status-badge')
+      await userEvent.click(badge)
+      expect(screen.getByTestId('trivy-modal')).toBeInTheDocument()
+    })
+  })
+
+  describe('cluster filter', () => {
+    it('aggregates only selected cluster vulnerabilities', () => {
+      const statuses = {
+        prod: makeStatus({ cluster: 'prod', vulnerabilities: { critical: 5, high: 0, medium: 0, low: 0, unknown: 0 } }),
+        staging: makeStatus({ cluster: 'staging', vulnerabilities: { critical: 3, high: 0, medium: 0, low: 0, unknown: 0 } }),
+      }
+      // aggregated shows full sum, filter selects only prod
+      const aggregated = { critical: 8, high: 0, medium: 0, low: 0, unknown: 0 }
+      setupTrivy({ installed: true, statuses, aggregated, totalClusters: 2, clustersChecked: 2 })
+      mockSelectedClusters.mockReturnValue(['prod'])
+      render(<TrivyScanCard config={{}} />)
+      // When filter is active, only prod's critical=5 should show
+      expect(screen.getByText('5')).toBeInTheDocument()
+    })
+  })
+
+  describe('useCardLoadingState integration', () => {
+    it('passes isDemoData=true when hook returns demo data', () => {
+      setupTrivy({ isDemoData: true })
+      render(<TrivyScanCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isDemoData: true, hasAnyData: true }),
+      )
+    })
+
+    it('passes isFailed=true when fetch errors occur', () => {
+      setupTrivy({ hasErrors: true })
+      render(<TrivyScanCard config={{}} />)
+      expect(mockUseCardLoadingState).toHaveBeenCalledWith(
+        expect.objectContaining({ isFailed: true }),
+      )
+    })
+  })
+})


### PR DESCRIPTION
Fixes #21099

Add Vitest/RTL unit tests for all 15 security & compliance card components listed in the issue:

- `OPAPolicies`, `OPAPoliciesModal`
- `KyvernoPolicies`, `RBACExplorer`, `RecommendedPolicies`
- `ISO27001Audit`, `SecurityIssues`
- `ComplianceDrift`, `DataComplianceCards`
- `DataComplianceCertManager`, `DataComplianceExternalSecrets`
- `DataComplianceVaultSecrets`, `EnterpriseComplianceCards`
- `RuntimeAttestationCard`, `FleetComplianceHeatmap`

Each test file covers: loading skeleton, empty state, error state, happy-path render, and snapshot test — following the existing test patterns in the codebase.