### PR TITLE
[scanner] 🌱 test: fix game-card RTL selector failures

### DIFF
--- a/web/src/components/cards/FlappyPod.test.tsx
+++ b/web/src/components/cards/FlappyPod.test.tsx
@@ -52,12 +52,12 @@ describe('FlappyPod', () => {
 
   it('displays high score section', () => {
     render(<FlappyPod />)
-    expect(screen.getByText(/high/i)).toBeInTheDocument()
+    expect(screen.getByText(/best/i)).toBeInTheDocument()
   })
 
   it('renders start/play button', () => {
     render(<FlappyPod />)
-    const playButton = screen.getByRole('button', { name: /play|start/i })
+    const playButton = screen.getByRole('button', { name: /new game/i })
     expect(playButton).toBeInTheDocument()
   })
 

--- a/web/src/components/cards/Game2048.test.tsx
+++ b/web/src/components/cards/Game2048.test.tsx
@@ -57,12 +57,12 @@ describe('Game2048', () => {
 
   it('displays new game button', () => {
     render(<Game2048 />)
-    const newGameButton = screen.getByRole('button', { name: /new|reset/i })
+    const newGameButton = screen.getByRole('button', { name: /new game/i })
     expect(newGameButton).toBeInTheDocument()
   })
 
   it('renders control instructions', () => {
     render(<Game2048 />)
-    expect(screen.getByText(/arrow|direction|use/i)).toBeInTheDocument()
+    expect(screen.getByText(/wasd|move/i)).toBeInTheDocument()
   })
 })

--- a/web/src/components/cards/Game2048.tsx
+++ b/web/src/components/cards/Game2048.tsx
@@ -324,6 +324,7 @@ export function Game2048(_props: CardComponentProps) {
           onClick={newGame}
           className="p-1.5 rounded hover:bg-secondary"
           title="New Game"
+          aria-label="New Game"
         >
           <RotateCcw className="w-4 h-4" />
         </button>


### PR DESCRIPTION
Fixes #21122

## Changes

Fixed RTL selector failures in game card tests:

**FlappyPod.test.tsx:**
- Updated high score test to match 'Best' instead of 'High' (component uses 'Best')
- Updated button selector to match 'New Game' aria-label

**Game2048.test.tsx:**
- Updated button selector to match 'New Game' aria-label
- Updated controls test to match 'WASD/move' text (component uses 'or WASD to move')

**Game2048.tsx:**
- Added aria-label="New Game" to button for accessibility (was missing, only had title)

All selectors now match the actual DOM output from the components.

## Testing
Tests will be validated by CI on this PR.