### PR TITLE
[scanner] 🌱 test: fix coverage suite test failures (arcade, selectors)

### DIFF
--- a/web/src/components/cards/ArcadeGames.test.tsx
+++ b/web/src/components/cards/ArcadeGames.test.tsx
@@ -25,21 +25,16 @@ const mockAnalytics = {
   emitGameEnded: vi.fn(),
 }
 
-const mockLocalStorage = {
-  safeGet: vi.fn(() => null),
-  safeGetItem: vi.fn(() => null),
-  safeSet: vi.fn(),
-  safeSetItem: vi.fn(),
-}
-
 vi.mock('./CardWrapper', () => mockCardExpanded)
 vi.mock('./CardDataContext', () => mockCardDataContext)
 vi.mock('../../lib/analytics', () => mockAnalytics)
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
 }))
-vi.mock('../../lib/safeLocalStorage', () => mockLocalStorage)
-vi.mock('@/lib/utils/localStorage', () => mockLocalStorage)
+vi.mock('@/lib/utils/localStorage', () => ({
+  safeGetItem: vi.fn(() => null),
+  safeSetItem: vi.fn(),
+}))
 
 describe('Checkers', () => {
   beforeEach(() => {

--- a/web/src/components/cards/ArgoCDSyncStatus.test.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.test.tsx
@@ -156,10 +156,11 @@ describe('ArgoCDSyncStatus', () => {
     })
 
     it('renders synced and outOfSync counts in legend', async () => {
-      setupMocks({ total: 10, stats: { synced: 8, outOfSync: 1, unknown: 1 }, syncedPercent: 80 })
+      setupMocks({ total: 10, stats: { synced: 8, outOfSync: 2, unknown: 1 }, syncedPercent: 80 })
       const { ArgoCDSyncStatus } = await import('./ArgoCDSyncStatus')
       render(<ArgoCDSyncStatus />)
       expect(screen.getByText('8')).toBeInTheDocument()
+      expect(screen.getByText('2')).toBeInTheDocument()
       expect(screen.getByText('1')).toBeInTheDocument()
     })
 

--- a/web/src/components/cards/ClusterGroupsForms.test.tsx
+++ b/web/src/components/cards/ClusterGroupsForms.test.tsx
@@ -79,7 +79,8 @@ describe('CreateGroupForm', () => {
         onCancel={onCancel}
       />
     )
-    fireEvent.click(screen.getByTitle(/cancel/i))
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 
@@ -155,7 +156,8 @@ describe('EditGroupForm', () => {
         onCancel={onCancel}
       />
     )
-    fireEvent.click(screen.getByTitle(/cancel/i))
+    const cancelBtn = screen.getByRole('button', { name: /cancel/i })
+    fireEvent.click(cancelBtn)
     expect(onCancel).toHaveBeenCalledTimes(1)
   })
 

--- a/web/src/components/cards/ClusterGroupsForms.test.tsx
+++ b/web/src/components/cards/ClusterGroupsForms.test.tsx
@@ -67,7 +67,7 @@ describe('CreateGroupForm', () => {
         onCancel={onCancel}
       />
     )
-    expect(screen.getByPlaceholderText(/cards:clusterGroupsForms/i)).toBeInTheDocument()
+    expect(screen.getByPlaceholderText('cards:clusterGroups.groupNamePlaceholder')).toBeInTheDocument()
   })
 
   it('calls onCancel when cancel is clicked', () => {
@@ -142,8 +142,8 @@ describe('EditGroupForm', () => {
         onCancel={onCancel}
       />
     )
-    const input = screen.getByDisplayValue('production')
-    expect(input).toBeInTheDocument()
+    // Group name shown in the form header (not an editable input)
+    expect(screen.getByText(/production/)).toBeInTheDocument()
   })
 
   it('calls onCancel when cancel is clicked', () => {

--- a/web/src/components/cards/ClusterHealth.test.tsx
+++ b/web/src/components/cards/ClusterHealth.test.tsx
@@ -5,6 +5,7 @@ import { ClusterHealth } from './ClusterHealth'
 vi.mock('./CardDataContext', () => ({
   useCardLoadingState: vi.fn(),
   useReportCardDataState: vi.fn(),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../hooks/useMCP', () => ({
@@ -26,6 +27,8 @@ vi.mock('../ui/RefreshIndicator', () => ({
 
 vi.mock('../ui/Skeleton', () => ({
   Skeleton: () => <div data-testid="skeleton" />,
+  SkeletonStats: () => <div data-testid="skeleton-stats" />,
+  SkeletonList: () => <div data-testid="skeleton-list" />,
 }))
 
 import { useCardLoadingState } from './CardDataContext'

--- a/web/src/components/cards/HelmReleaseStatus.test.tsx
+++ b/web/src/components/cards/HelmReleaseStatus.test.tsx
@@ -129,7 +129,7 @@ const defaultCardData = {
     localClusterFilter: [] as string[],
     toggleClusterFilter: vi.fn(),
     clearClusterFilter: vi.fn(),
-    availableClusters: [] as Array<{ name: string }>,
+    availableClusters: [{ name: 'cluster-1' }] as Array<{ name: string }>,
     showClusterFilter: false,
     setShowClusterFilter: vi.fn(),
     clusterFilterRef: { current: null },

--- a/web/src/components/cards/HelmValuesDiff.test.tsx
+++ b/web/src/components/cards/HelmValuesDiff.test.tsx
@@ -247,7 +247,8 @@ describe('HelmValuesDiff', () => {
       })
       const { HelmValuesDiff } = await import('./HelmValuesDiff')
       render(<HelmValuesDiff config={{ cluster: 'prod', release: 'nginx' }} />)
-      const scopeBadge = screen.getByText('nginx').closest('[class*="cursor-pointer"]')!
+      const nginxElements = screen.getAllByText('nginx')
+      const scopeBadge = nginxElements[0].closest('[class*="cursor-pointer"]')!
       await userEvent.click(scopeBadge)
       expect(mockDrillToHelm).toHaveBeenCalledWith('prod', 'default', 'nginx', expect.any(Object))
     })

--- a/web/src/components/cards/MaintenanceWindows.test.tsx
+++ b/web/src/components/cards/MaintenanceWindows.test.tsx
@@ -136,7 +136,7 @@ describe('MaintenanceWindows', () => {
       await userEvent.click(screen.getByText('+ Schedule'))
 
       // Set cluster via text input (falls back when no clusters with combobox)
-      const clusterSelect = screen.getByRole('combobox')
+      const clusterSelect = screen.getAllByRole('combobox')[0]
       await userEvent.selectOptions(clusterSelect, 'prod')
 
       const startInput = screen.getAllByDisplayValue('')[0]
@@ -212,11 +212,11 @@ describe('MaintenanceWindows', () => {
       expect(screen.getByText('test-cluster')).toBeInTheDocument()
 
       // First delete click
-      const deleteBtn = screen.getByLabelText('deleteAria')
+      const deleteBtn = screen.getByLabelText(/delete/i)
       await userEvent.click(deleteBtn)
 
       // Should now show confirm label
-      const confirmBtn = screen.getByLabelText('confirmDeleteAria')
+      const confirmBtn = screen.getByLabelText(/confirm/i)
       expect(confirmBtn).toBeInTheDocument()
 
       // Second click confirms deletion

--- a/web/src/components/cards/__tests__/NotificationVerifyIndicator.test.tsx
+++ b/web/src/components/cards/__tests__/NotificationVerifyIndicator.test.tsx
@@ -22,7 +22,7 @@ vi.mock('react-i18next', () => ({
 const isBrowserNotifVerified = vi.fn()
 const setBrowserNotifVerified = vi.fn()
 
-vi.mock('../../lib/notificationStatus', () => ({
+vi.mock('../../../lib/notificationStatus', () => ({
   isBrowserNotifVerified: (...args: unknown[]) => isBrowserNotifVerified(...args),
   setBrowserNotifVerified: (...args: unknown[]) => setBrowserNotifVerified(...args),
 }))


### PR DESCRIPTION
Fixes #21125 (partial)
Fixes #21123 (partial)

Grouped fixes for Coverage Suite run #4271 test failures across three related card-test issues.

## Changes

### Issue #21125 (failed to load tests)
- **ArcadeGames.test.tsx**: Fixed duplicate localStorage mock pattern — removed `../../lib/safeLocalStorage` mock and kept only `@/lib/utils/localStorage`, matching the pattern from PR #21127 (Game2048, FlappyPod fixes).
- **ClusterMetrics.test.tsx**: Already has correct mocks; may pass after ArcadeGames fix. If not, requires separate investigation.

### Issue #21123 (selector/assertion failures)
- **MaintenanceWindows.test.tsx**: 
  - Fixed `Found multiple elements with the role "combobox"` → use `getAllByRole('combobox')[0]`
  - Fixed `Unable to find a label with the text of: deleteAria` → use regex matcher `/delete/i` instead of literal i18n key
- **ClusterGroupsForms.test.tsx**: 
  - Fixed `Unable to find an element with the title: /cancel/i` → use `getByRole('button', { name: /cancel/i })` instead of `getByTitle`
- **HelmValuesDiff.test.tsx**: 
  - Fixed `Found multiple elements with the text: nginx` → use `getAllByText('nginx')[0]`

### Issue #21124 (snapshot drift) — Deferred
Inline snapshot regeneration requires running tests with `-u` flag. Since the instruction is "DO NOT run npm build/lint/test", this issue is deferred. CI will catch any remaining snapshot drift. The ~20 affected tests use `toMatchInlineSnapshot()` and need vitest to regenerate them.

## Testing Notes
- Did not run tests locally per instructions — CI will validate.
- Followed existing card-test patterns from PR #21127 and recently merged tests.
- All changes are surgical fixes to RTL selectors and mock patterns.