### PR TITLE
[scanner] 🌱 chore: refresh lint baseline to unblock build-gate

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -1,5 +1,12 @@
 [
   {
+    "file": "e2e/GPUOverview.spec.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 57,
+    "column": 16,
+    "message": "'skipIfGpuCardMissing' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "e2e/ai-agents-deep.spec.ts",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 9,
@@ -159,13 +166,6 @@
     "line": 26,
     "column": 7,
     "message": "'CI_TIMEOUT_MULTIPLIER' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "e2e/GPUOverview.spec.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 57,
-    "column": 16,
-    "message": "'skipIfGpuCardMissing' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "e2e/helpers/api-mocks.ts",
@@ -532,13 +532,6 @@
     "message": "Unused eslint-disable directive (no problems were reported)."
   },
   {
-    "file": "src/components/acmm/__tests__/ACMMIntroModal.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 26,
-    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/acmm/ACMMIntroModal.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 57,
@@ -574,18 +567,32 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/agent/__tests__/AgentApprovalDialog.test.tsx",
+    "file": "src/components/acmm/__tests__/ACMMIntroModal.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 3,
     "column": 26,
     "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/agent/__tests__/AgentApprovalDialog.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 31,
-    "column": 5,
-    "message": "'onClose' is defined but never used. Allowed unused args must match /^_/u."
+    "file": "src/components/agent/APIKeySettings.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 24,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/agent/APIKeySettings.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 521,
+    "column": 25,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/agent/APIKeySettings.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 621,
+    "column": 27,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/agent/AgentApprovalDialog.tsx",
@@ -637,25 +644,18 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/agent/APIKeySettings.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 24,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+    "file": "src/components/agent/__tests__/AgentApprovalDialog.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 26,
+    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/agent/APIKeySettings.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 521,
-    "column": 25,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/agent/APIKeySettings.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 621,
-    "column": 27,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+    "file": "src/components/agent/__tests__/AgentApprovalDialog.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 31,
+    "column": 5,
+    "message": "'onClose' is defined but never used. Allowed unused args must match /^_/u."
   },
   {
     "file": "src/components/aiml/AIML.test.tsx",
@@ -763,6 +763,13 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
+    "file": "src/components/animations/SimpleGlobe.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/components/animations/globe/Cluster.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -798,13 +805,6 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/animations/SimpleGlobe.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/arcade/Arcade.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -826,500 +826,10 @@
     "message": "'ReactNode' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/cards/__tests__/ActiveAlerts.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 93,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 32,
-    "column": 20,
-    "message": "'a' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 32,
-    "column": 32,
-    "message": "'b' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 44,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/AppStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 90,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/ArgoCDApplicationSets.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 79,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/CardChat.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 256,
-    "column": 13,
-    "message": "'sendBtn' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/CardChat.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 259,
-    "column": 13,
-    "message": "'sendButton' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/cardMetadata.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 14,
-    "column": 17,
-    "message": "'id' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/cardMetadata.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 46,
-    "column": 17,
-    "message": "'id' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 32,
-    "message": "'beforeEach' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 24,
-    "column": 17,
-    "message": "'key' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 46,
-    "column": 17,
-    "message": "'key' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/ClusterHealth.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 26,
-    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/ClusterHealth.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 144,
-    "column": 7,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetris.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 15,
-    "column": 32,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 80,
-    "column": 25,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 91,
-    "column": 30,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 91,
-    "column": 42,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 91,
-    "column": 50,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 91,
-    "column": 58,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/DataComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 2,
-    "column": 48,
-    "message": "'afterEach' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/DeploymentStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 109,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/DynamicCard.test.tsx",
-    "rule": "@typescript-eslint/no-require-imports",
-    "line": 15,
-    "column": 17,
-    "message": "A `require()` style import is forbidden."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 19,
-    "column": 18,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 53,
-    "column": 21,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 70,
-    "column": 21,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 71,
-    "column": 20,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 96,
-    "column": 21,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 113,
-    "column": 21,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 130,
-    "column": 20,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 142,
-    "column": 20,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 158,
-    "column": 20,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/__tests__/envoy_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 8,
-    "message": "'EnvoyClusterHealth' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/EventStream.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 89,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/failover_timeline.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'FailoverTimelineData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/flux_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 8,
-    "message": "'FluxResourceStatus' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/flux_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 7,
-    "column": 8,
-    "message": "'FluxResourceSummary' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/GitOpsDrift.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 90,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/GPUInventory.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 87,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/GPUOverview.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 101,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/GPUStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 96,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/GPUTaintFilter.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/harbor_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'HarborProjectStatus' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/HelmReleaseStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 91,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/k3s_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 2,
-    "column": 30,
-    "message": "'K3sStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/karmada_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 8,
-    "message": "'KarmadaBindingStatus' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/kubeflex_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'KubeFlexStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/kubevirt_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'KubevirtStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/kubevirt_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 5,
-    "column": 8,
-    "message": "'VmInfo' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/KustomizationStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 86,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/KyvernoPolicies.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 82,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/Missions.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 83,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/OPAPolicies.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 154,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/openkruise_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'OpenKruiseDemoCloneSet' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/openkruise_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 5,
-    "column": 8,
-    "message": "'OpenKruiseDemoAdvancedStatefulSet' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/OperatorStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 147,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/OperatorSubscriptions.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 74,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/ovn_status.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 2,
-    "column": 30,
-    "message": "'OvnStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/PodIssues.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 93,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/RecentEvents.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 128,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 40,
-    "column": 41,
-    "message": "'value' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 184,
-    "column": 13,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/ServiceStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 82,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/slo_compliance.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 2,
-    "column": 41,
-    "message": "'SLOComplianceData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/trino_gateway.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 8,
-    "message": "'TrinoGatewayData' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/__tests__/UserManagement.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 207,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/__tests__/weather.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 4,
-    "column": 3,
-    "message": "'WeatherCondition' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/cards/ACMMRecommendations.tsx",
     "rule": "no-restricted-syntax",
     "line": 113,
     "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/ActiveAlerts.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 122,
-    "column": 5,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
@@ -1337,9 +847,9 @@
     "message": "React Hook useEffect has a missing dependency: 'goToPage'. Either include it or remove the dependency array."
   },
   {
-    "file": "src/components/cards/AlertRules.test.tsx",
+    "file": "src/components/cards/AgenticDetectionRuns.test.tsx",
     "rule": "no-restricted-syntax",
-    "line": 78,
+    "line": 40,
     "column": 5,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -1347,13 +857,6 @@
     "file": "src/components/cards/AlertRules.test.tsx",
     "rule": "no-restricted-syntax",
     "line": 78,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/AppStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 60,
     "column": 5,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -1372,20 +875,6 @@
     "message": "The 'safeDeployments' logical expression could make the dependencies of useMemo Hook (at line 101) change on every render. To fix this, wrap the initialization of 'safeDeployments' in its own useMemo() Hook."
   },
   {
-    "file": "src/components/cards/ArgoCDApplications.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 111,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/ArgoCDApplications.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 111,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/cards/ArgoCDApplicationSets.test.tsx",
     "rule": "no-restricted-syntax",
     "line": 71,
@@ -1393,18 +882,25 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/cards/buildpacks-status/BuildpacksStatus.tsx",
+    "file": "src/components/cards/ArgoCDApplications.test.tsx",
     "rule": "no-restricted-syntax",
-    "line": 209,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+    "line": 111,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/cards/card-wrapper/CardActionMenu.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 408,
+    "file": "src/components/cards/CRDHealth.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 16,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/CRDHealth.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 206,
     "column": 13,
-    "message": "'configureItem' is assigned a value but never used. Allowed unused vars must match /^_/u."
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/cards/CardWrapper.tsx",
@@ -1428,20 +924,6 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/cards/change_timeline/ChangeTimeline.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 38,
-    "column": 10,
-    "message": "'setup' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/chaos_mesh_status/chaos_mesh_status.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 10,
-    "column": 20,
-    "message": "'ns' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
     "file": "src/components/cards/ChartVersions.test.tsx",
     "rule": "no-restricted-syntax",
     "line": 71,
@@ -1461,20 +943,6 @@
     "line": 718,
     "column": 11,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/cloud_custodian_status/cloud_custodian_status.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 31,
-    "column": 10,
-    "message": "'setup' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/ClusterCosts.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 55,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/cards/ClusterCosts.test.tsx",
@@ -1624,18 +1092,1635 @@
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
+    "file": "src/components/cards/ContainerTetris.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 141,
+    "column": 6,
+    "message": "React Hook useCallback has a missing dependency: 'score'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/DrasiPipelines.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 62,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/DynamicCard.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 325,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 105,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 144,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 187,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/EventSummary.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 62,
+    "column": 9,
+    "message": "The 'allEvents' logical expression could make the dependencies of useMemo Hook (at line 90) change on every render. To fix this, wrap the initialization of 'allEvents' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 141,
+    "column": 9,
+    "message": "The 'clusters' conditional could make the dependencies of useMemo Hook (at line 178) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'clusters' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 157,
+    "column": 9,
+    "message": "The 'selectedClusters' conditional could make the dependencies of useMemo Hook (at line 185) change on every render. To fix this, wrap the initialization of 'selectedClusters' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 157,
+    "column": 9,
+    "message": "The 'selectedClusters' conditional could make the dependencies of useMemo Hook (at line 223) change on every render. To fix this, wrap the initialization of 'selectedClusters' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 158,
+    "column": 9,
+    "message": "The 'clusterInfoMap' logical expression could make the dependencies of useMemo Hook (at line 223) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'clusterInfoMap' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 230,
+    "column": 9,
+    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 231) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 230,
+    "column": 9,
+    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 232) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 230,
+    "column": 9,
+    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 233) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 230,
+    "column": 9,
+    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 234) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 230,
+    "column": 9,
+    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 333) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/EventsTimeline.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 381,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 330,
+    "column": 3,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 330,
+    "column": 21,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 330,
+    "column": 44,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 330,
+    "column": 60,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUInventoryHistory.tsx",
+    "rule": "null",
+    "line": 1,
+    "column": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
+  },
+  {
+    "file": "src/components/cards/GPUOverview.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 246,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GPUStatus.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 219,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GPUTaintFilter.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 53,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUTaintFilter.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 62,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUTaintFilter.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 78,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUTaintFilter.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 108,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/GPUTaintFilter.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 284,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/GPUUsageTrend.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 441,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GPUUtilization.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 271,
+    "column": 15,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GPUUtilization.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 332,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/GatewayStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 16,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/GitHubActivity.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 102,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/GitHubActivity.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 438,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/GitHubActivity.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 582,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/GitHubActivity.utils.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 9,
+    "column": 32,
+    "message": "'vi' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/GitHubActivityItems.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 10,
+    "column": 36,
+    "message": "'beforeEach' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/GitOpsDrift.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 83,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/HelmHistory.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 299,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/HelmHistory.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 312,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/HelmReleaseStatus.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 247,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/HelmValuesDiff.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 297,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/HelmValuesDiff.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 310,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 11,
+    "column": 18,
+    "message": "'screen' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 12,
+    "column": 8,
+    "message": "'userEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.test.tsx",
+    "rule": "null",
+    "line": 75,
+    "column": 5,
+    "message": "Unused eslint-disable directive (no problems were reported from 'no-script-url')."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 278,
+    "column": 17,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 289,
+    "column": 17,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 301,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/IframeEmbed.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 313,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/KagentStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 67,
+    "column": 9,
+    "message": "The 'agentItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'agentItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 68,
+    "column": 9,
+    "message": "The 'toolItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'toolItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 69,
+    "column": 9,
+    "message": "The 'modelItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'modelItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentiStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 76,
+    "column": 9,
+    "message": "The 'agentItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'agentItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentiStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 77,
+    "column": 9,
+    "message": "The 'buildItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'buildItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentiStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 77,
+    "column": 9,
+    "message": "The 'buildItems' logical expression could make the dependencies of useMemo Hook (at line 124) change on every render. To fix this, wrap the initialization of 'buildItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KagentiStatusCard.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 78,
+    "column": 9,
+    "message": "The 'toolItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'toolItems' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/KubeDoom.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 300,
+    "column": 6,
+    "message": "React Hook useCallback has an unnecessary dependency: 'shoot'. Either exclude it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/KubeGalaga.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 95,
+    "column": 9,
+    "message": "The 'initStars' function makes the dependencies of useCallback Hook (at line 136) change on every render. Move it inside the useCallback callback. Alternatively, wrap the definition of 'initStars' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/cards/KubeGalaga.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 104,
+    "column": 9,
+    "message": "The 'initEnemies' function makes the dependencies of useCallback Hook (at line 136) change on every render. To fix this, wrap the definition of 'initEnemies' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/cards/KubeGalaga.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 364,
+    "column": 6,
+    "message": "React Hook useCallback has a missing dependency: 'level'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/KubeKong.tsx",
+    "rule": "null",
+    "line": 1,
+    "column": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
+  },
+  {
+    "file": "src/components/cards/KubePong.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 238,
+    "column": 6,
+    "message": "React Hook useCallback has a missing dependency: 'aiSettings'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/KubeSnake.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 75,
+    "column": 9,
+    "message": "The 'generateFood' function makes the dependencies of useCallback Hook (at line 98) change on every render. To fix this, wrap the definition of 'generateFood' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/cards/KubeSnake.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 75,
+    "column": 9,
+    "message": "The 'generateFood' function makes the dependencies of useCallback Hook (at line 161) change on every render. To fix this, wrap the definition of 'generateFood' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/cards/KubecostOverview.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 12,
+    "column": 8,
+    "message": "'userEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/Kubectl.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 380,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/Kubectl.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 520,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/KubectlAIPanel.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 29,
+    "column": 7,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/KubectlHistoryPanel.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 34,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/KubectlYAMLEditorPanel.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 104,
+    "column": 7,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/cards/KustomizationStatus.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 273,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/KustomizationStatus.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 286,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 12,
+    "column": 26,
+    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 69,
+    "column": 41,
+    "message": "React Hook useMemo has an unnecessary dependency: 'tick'. Either exclude it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 166,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 177,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 185,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 193,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 199,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/MaintenanceWindows.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 210,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/Missions.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 66,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/Missions.tsx",
+    "rule": "null",
+    "line": 1,
+    "column": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
+  },
+  {
+    "file": "src/components/cards/MobileBrowser.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 281,
+    "column": 17,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NamespaceEvents.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 221,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceEvents.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 231,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceOverview.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 30,
+    "column": 9,
+    "message": "The 'safeAllClusters' logical expression could make the dependencies of useMemo Hook (at line 63) change on every render. To fix this, wrap the initialization of 'safeAllClusters' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/NamespaceOverview.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 87,
+    "column": 9,
+    "message": "The 'safeNamespaces' logical expression could make the dependencies of useEffect Hook (at line 96) change on every render. To fix this, wrap the initialization of 'safeNamespaces' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/NamespaceOverview.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 213,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceOverview.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 227,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotas.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 320,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotas.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 331,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 119,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 135,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 151,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 204,
+    "column": 19,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 216,
+    "column": 21,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NamespaceQuotasModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 223,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NamespaceRBAC.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 64,
+    "column": 9,
+    "message": "The 'safeNamespaces' logical expression could make the dependencies of useEffect Hook (at line 102) change on every render. To fix this, wrap the initialization of 'safeNamespaces' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/NamespaceRBAC.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 255,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NamespaceRBAC.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 268,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NetworkUtils.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 401,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NetworkUtils.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 442,
+    "column": 15,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NetworkUtils.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 551,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NetworkUtils.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 558,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/NodeConditions.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 13,
+    "column": 26,
+    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/NodeDebug.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 198,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NodeDebug.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 206,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NodeDebug.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 269,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/NodeDebug.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 303,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/OPAPoliciesTable.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 15,
+    "message": "'Policy' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/OpenCostOverview.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 47,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/OverlayComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 150,
+    "column": 7,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/OverlayComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 180,
+    "column": 15,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/OverlayComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 193,
+    "column": 15,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/PodCrosser.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 485,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'time'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setScore' needs the current value of 'time'."
+  },
+  {
+    "file": "src/components/cards/PodHealthTrend.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 375,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/PodIssues.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 68,
+    "column": 11,
+    "message": "'Icon' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/PodIssues.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 89,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/PodPitfall.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 511,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'time'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setScore' needs the current value of 'time'."
+  },
+  {
+    "file": "src/components/cards/PodSweeper.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 320,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 269,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 278,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 289,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 335,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 622,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/RecentEvents.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 158,
+    "column": 89,
+    "message": "React Hook useCallback has a missing dependency: 'sorting'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/ResourceMarshall.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 68,
+    "column": 9,
+    "message": "The 'availableNamespaces' logical expression could make the dependencies of useEffect Hook (at line 106) change on every render. To fix this, wrap the initialization of 'availableNamespaces' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/ResourceMarshall.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 179,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/ResourceMarshall.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 204,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/ResourceTrend.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 290,
+    "column": 13,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/StockMarketTicker.tsx",
+    "rule": "null",
+    "line": 1,
+    "column": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
+  },
+  {
+    "file": "src/components/cards/StockMarketTicker.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 765,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/SudokuGame.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 279,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'gameState'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/cards/UserManagementList.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 220,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/UserManagementList.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 312,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/UserManagementList.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 330,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "null",
+    "line": 99,
+    "column": 5,
+    "message": "Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 105,
+    "column": 10,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "null",
+    "line": 123,
+    "column": 5,
+    "message": "Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 129,
+    "column": 10,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "null",
+    "line": 139,
+    "column": 5,
+    "message": "Unused eslint-disable directive (no problems were reported from '@typescript-eslint/no-explicit-any')."
+  },
+  {
+    "file": "src/components/cards/VClusterStatus.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 145,
+    "column": 10,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/WorkloadDeployment.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 259,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/WorkloadDeployment.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 270,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/WorkloadDeploymentItem.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 393,
+    "column": 21,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 37,
+    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 435,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 438,
+    "column": 7,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 483,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 492,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 501,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 510,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 520,
+    "column": 9,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 560,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 569,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/WorkloadImportDialog.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 609,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/ActiveAlerts.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 93,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 32,
+    "column": 20,
+    "message": "'a' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 32,
+    "column": 32,
+    "message": "'b' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/AppStatus.multicluster.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 44,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/AppStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 90,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/ArgoCDApplicationSets.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 79,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/CardChat.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 256,
+    "column": 13,
+    "message": "'sendBtn' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/CardChat.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 259,
+    "column": 13,
+    "message": "'sendButton' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ClusterHealth.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 26,
+    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ClusterHealth.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 144,
+    "column": 7,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetris.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 15,
+    "column": 32,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 80,
+    "column": 25,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 91,
+    "column": 30,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 91,
+    "column": 42,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 91,
+    "column": 50,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/ContainerTetrisComponent.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 91,
+    "column": 58,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/DataComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 2,
+    "column": 48,
+    "message": "'afterEach' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/DeploymentStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 109,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/DynamicCard.test.tsx",
+    "rule": "@typescript-eslint/no-require-imports",
+    "line": 15,
+    "column": 17,
+    "message": "A `require()` style import is forbidden."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 19,
+    "column": 18,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 53,
+    "column": 21,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 70,
+    "column": 21,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 71,
+    "column": 20,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 96,
+    "column": 21,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 113,
+    "column": 21,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 130,
+    "column": 20,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 142,
+    "column": 20,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 158,
+    "column": 20,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/__tests__/EventStream.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 89,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/GPUInventory.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 87,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/GPUOverview.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 101,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/GPUStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 96,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/GPUTaintFilter.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/GitOpsDrift.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 90,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/HelmReleaseStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 91,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/KustomizationStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 86,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/KyvernoPolicies.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 82,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/Missions.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 83,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/OPAPolicies.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 154,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/OperatorStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 147,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/OperatorSubscriptions.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 74,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/PodIssues.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 93,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/RecentEvents.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 128,
+    "column": 26,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 40,
+    "column": 41,
+    "message": "'value' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ResourceMarshall.namespaces.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 184,
+    "column": 13,
+    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ServiceStatus.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 82,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/UserManagement.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 207,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/__tests__/cardMetadata.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 14,
+    "column": 17,
+    "message": "'id' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/cardMetadata.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 46,
+    "column": 17,
+    "message": "'id' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 32,
+    "message": "'beforeEach' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 24,
+    "column": 17,
+    "message": "'key' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/cardRegistry.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 46,
+    "column": 17,
+    "message": "'key' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/envoy_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 8,
+    "message": "'EnvoyClusterHealth' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/failover_timeline.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'FailoverTimelineData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/flux_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 8,
+    "message": "'FluxResourceStatus' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/flux_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 7,
+    "column": 8,
+    "message": "'FluxResourceSummary' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/harbor_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'HarborProjectStatus' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/k3s_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 2,
+    "column": 30,
+    "message": "'K3sStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/karmada_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 8,
+    "message": "'KarmadaBindingStatus' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/kubeflex_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'KubeFlexStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/kubevirt_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'KubevirtStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/kubevirt_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 5,
+    "column": 8,
+    "message": "'VmInfo' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/openkruise_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'OpenKruiseDemoCloneSet' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/openkruise_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 5,
+    "column": 8,
+    "message": "'OpenKruiseDemoAdvancedStatefulSet' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/ovn_status.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 2,
+    "column": 30,
+    "message": "'OvnStatusDemoData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/slo_compliance.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 2,
+    "column": 41,
+    "message": "'SLOComplianceData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/trino_gateway.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 8,
+    "message": "'TrinoGatewayData' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/__tests__/weather.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 4,
+    "column": 3,
+    "message": "'WeatherCondition' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/buildpacks-status/BuildpacksStatus.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 209,
+    "column": 9,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/card-wrapper/CardActionMenu.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 408,
+    "column": 13,
+    "message": "'configureItem' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/change_timeline/ChangeTimeline.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 38,
+    "column": 10,
+    "message": "'setup' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/chaos_mesh_status/chaos_mesh_status.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 10,
+    "column": 20,
+    "message": "'ns' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/cloud_custodian_status/cloud_custodian_status.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 31,
+    "column": 10,
+    "message": "'setup' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/components/cards/compliance/ComplianceScoreBreakdownModal.tsx",
     "rule": "null",
     "line": 65,
     "column": 3,
     "message": "Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')."
-  },
-  {
-    "file": "src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 152,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx",
@@ -1645,32 +2730,18 @@
     "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
   },
   {
+    "file": "src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 152,
+    "column": 5,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
     "file": "src/components/cards/console-missions/shared.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 33,
     "column": 17,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/ContainerTetris.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 141,
-    "column": 6,
-    "message": "React Hook useCallback has a missing dependency: 'score'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/CRDHealth.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 16,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/CRDHealth.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 206,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/cards/drasi/DrasiFlowLine.tsx",
@@ -2114,312 +3185,11 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/cards/DynamicCard.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 325,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 105,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 144,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/EnterpriseComplianceCards.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 187,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 141,
-    "column": 9,
-    "message": "The 'clusters' conditional could make the dependencies of useMemo Hook (at line 178) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'clusters' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 157,
-    "column": 9,
-    "message": "The 'selectedClusters' conditional could make the dependencies of useMemo Hook (at line 185) change on every render. To fix this, wrap the initialization of 'selectedClusters' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 157,
-    "column": 9,
-    "message": "The 'selectedClusters' conditional could make the dependencies of useMemo Hook (at line 223) change on every render. To fix this, wrap the initialization of 'selectedClusters' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 158,
-    "column": 9,
-    "message": "The 'clusterInfoMap' logical expression could make the dependencies of useMemo Hook (at line 223) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'clusterInfoMap' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 230,
-    "column": 9,
-    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 231) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 230,
-    "column": 9,
-    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 232) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 230,
-    "column": 9,
-    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 233) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 230,
-    "column": 9,
-    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 234) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 230,
-    "column": 9,
-    "message": "The 'chartTimePoints' logical expression could make the dependencies of useMemo Hook (at line 333) change on every render. To fix this, wrap the initialization of 'chartTimePoints' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/EventsTimeline.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 381,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/EventSummary.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 62,
-    "column": 9,
-    "message": "The 'allEvents' logical expression could make the dependencies of useMemo Hook (at line 90) change on every render. To fix this, wrap the initialization of 'allEvents' in its own useMemo() Hook."
-  },
-  {
     "file": "src/components/cards/flatcar_status/flatcar_status.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 10,
     "column": 20,
     "message": "'ns' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/GatewayStatus.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 16,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/GitHubActivity.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 438,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/GitHubActivity.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 582,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/GitOpsDrift.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 83,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 330,
-    "column": 3,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 330,
-    "column": 21,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 330,
-    "column": 44,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUInventoryHistory.parts.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 330,
-    "column": 60,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUInventoryHistory.tsx",
-    "rule": "null",
-    "line": 1,
-    "column": 1,
-    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
-  },
-  {
-    "file": "src/components/cards/GPUOverview.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 246,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/GPUStatus.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 219,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/GPUTaintFilter.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 53,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUTaintFilter.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 62,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUTaintFilter.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 78,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUTaintFilter.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 108,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/GPUTaintFilter.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 284,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/GPUUsageTrend.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 441,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/GPUUtilization.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 271,
-    "column": 15,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/GPUUtilization.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 332,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/HelmHistory.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 299,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/HelmHistory.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 312,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/HelmReleaseStatus.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 247,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/HelmValuesDiff.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 297,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/HelmValuesDiff.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 310,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/IframeEmbed.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 278,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/IframeEmbed.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 289,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/IframeEmbed.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 301,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/IframeEmbed.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 313,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/cards/insights/RightSizeAdvisor.tsx",
@@ -2429,137 +3199,11 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/cards/KagentiStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 76,
-    "column": 9,
-    "message": "The 'agentItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'agentItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentiStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 77,
-    "column": 9,
-    "message": "The 'buildItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'buildItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentiStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 77,
-    "column": 9,
-    "message": "The 'buildItems' logical expression could make the dependencies of useMemo Hook (at line 124) change on every render. To fix this, wrap the initialization of 'buildItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentiStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 78,
-    "column": 9,
-    "message": "The 'toolItems' logical expression could make the dependencies of useMemo Hook (at line 117) change on every render. To fix this, wrap the initialization of 'toolItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 67,
-    "column": 9,
-    "message": "The 'agentItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'agentItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 68,
-    "column": 9,
-    "message": "The 'toolItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'toolItems' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/KagentStatusCard.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 69,
-    "column": 9,
-    "message": "The 'modelItems' logical expression could make the dependencies of useMemo Hook (at line 113) change on every render. To fix this, wrap the initialization of 'modelItems' in its own useMemo() Hook."
-  },
-  {
     "file": "src/components/cards/karmada_status/__tests__/KarmadaStatus.test.tsx",
     "rule": "no-restricted-syntax",
     "line": 29,
     "column": 67,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/Kubectl.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 380,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/Kubectl.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 520,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/KubectlAIPanel.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 29,
-    "column": 7,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/KubectlHistoryPanel.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 34,
-    "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/KubectlYAMLEditorPanel.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 104,
-    "column": 7,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/cards/KubeDoom.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 300,
-    "column": 6,
-    "message": "React Hook useCallback has an unnecessary dependency: 'shoot'. Either exclude it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/KubeGalaga.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 95,
-    "column": 9,
-    "message": "The 'initStars' function makes the dependencies of useCallback Hook (at line 136) change on every render. Move it inside the useCallback callback. Alternatively, wrap the definition of 'initStars' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/cards/KubeGalaga.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 104,
-    "column": 9,
-    "message": "The 'initEnemies' function makes the dependencies of useCallback Hook (at line 136) change on every render. To fix this, wrap the definition of 'initEnemies' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/cards/KubeGalaga.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 364,
-    "column": 6,
-    "message": "React Hook useCallback has a missing dependency: 'level'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/KubeKong.tsx",
-    "rule": "null",
-    "line": 1,
-    "column": 1,
-    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
-  },
-  {
-    "file": "src/components/cards/KubePong.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 238,
-    "column": 6,
-    "message": "React Hook useCallback has a missing dependency: 'aiSettings'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/cards/kubescape/KubescapeDetailModal.tsx",
@@ -2576,39 +3220,193 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/cards/KubeSnake.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 75,
-    "column": 9,
-    "message": "The 'generateFood' function makes the dependencies of useCallback Hook (at line 98) change on every render. To fix this, wrap the definition of 'generateFood' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/cards/KubeSnake.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 75,
-    "column": 9,
-    "message": "The 'generateFood' function makes the dependencies of useCallback Hook (at line 161) change on every render. To fix this, wrap the definition of 'generateFood' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/cards/KustomizationStatus.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 273,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/KustomizationStatus.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 286,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
     "file": "src/components/cards/kyverno/KyvernoDetailModal.tsx",
     "rule": "no-restricted-syntax",
     "line": 159,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 94,
+    "column": 9,
+    "message": "The 'effectiveReports' conditional could make the dependencies of useMemo Hook (at line 145) change on every render. To fix this, wrap the initialization of 'effectiveReports' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 210,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 222,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/llmd/HardwareLeaderboard.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 135,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdAIInsights.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 516,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdConfigurator.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 137,
+    "column": 9,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdFlow.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 235,
+    "column": 9,
+    "message": "The 'generateLiveMetrics' function makes the dependencies of useEffect Hook (at line 328) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'generateLiveMetrics' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 5,
+    "column": 14,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 28,
+    "column": 14,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 45,
+    "column": 14,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 223,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 231,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 239,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/NightlyE2EDetailPanel.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 215,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/llmd/NightlyE2EDetailPanel.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 383,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/cards/llmd/PDDisaggregation.tsx",
+    "rule": "null",
+    "line": 280,
+    "column": 3,
+    "message": "Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')."
+  },
+  {
+    "file": "src/components/cards/llmd/ParetoFrontier.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 634,
+    "column": 7,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/PerformanceTimeline.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 142,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/PerformanceTimeline.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 150,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/ResourceUtilization.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 198,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/ResourceUtilization.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 206,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/StackSelector.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 250,
+    "column": 9,
+    "message": "The 'stacks' logical expression could make the dependencies of useMemo Hook (at line 308) change on every render. To fix this, wrap the initialization of 'stacks' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/cards/llmd/StackSelector.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 468,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 188,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 196,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 204,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/cards/llmd/__tests__/KVCacheMonitor.utils.test.ts",
@@ -2646,20 +3444,6 @@
     "message": "Unexpected any. Specify a different type."
   },
   {
-    "file": "src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 25,
-    "column": 39,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 26,
-    "column": 28,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
     "file": "src/components/cards/llmd/__tests__/LLMdFlowNodes.test.tsx",
     "rule": "@typescript-eslint/no-explicit-any",
     "line": 8,
@@ -2693,6 +3477,20 @@
     "line": 20,
     "column": 23,
     "message": "'value' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
+    "file": "src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 25,
+    "column": 39,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/cards/llmd/__tests__/LatencyBreakdown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 26,
+    "column": 28,
+    "message": "Unexpected any. Specify a different type."
   },
   {
     "file": "src/components/cards/llmd/__tests__/NightlyE2EDetailPanel.test.tsx",
@@ -2772,27 +3570,6 @@
     "message": "Unexpected any. Specify a different type."
   },
   {
-    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 94,
-    "column": 9,
-    "message": "The 'effectiveReports' conditional could make the dependencies of useMemo Hook (at line 145) change on every render. To fix this, wrap the initialization of 'effectiveReports' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 210,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/BenchmarkHero.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 222,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/cards/llmd/epp-routing/useEPPRoutingData.ts",
     "rule": "null",
     "line": 455,
@@ -2800,242 +3577,11 @@
     "message": "Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')."
   },
   {
-    "file": "src/components/cards/llmd/HardwareLeaderboard.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 135,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 223,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 231,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/LatencyBreakdown.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 239,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdAIInsights.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 516,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdConfigurator.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 137,
-    "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdFlow.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 235,
-    "column": 9,
-    "message": "The 'generateLiveMetrics' function makes the dependencies of useEffect Hook (at line 328) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'generateLiveMetrics' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 5,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 28,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/LLMdFlowNodes.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 45,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/NightlyE2EDetailPanel.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 215,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/NightlyE2EDetailPanel.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 383,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/ParetoFrontier.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 634,
-    "column": 7,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/PDDisaggregation.tsx",
-    "rule": "null",
-    "line": 280,
-    "column": 3,
-    "message": "Unused eslint-disable directive (no problems were reported from 'react-hooks/exhaustive-deps')."
-  },
-  {
-    "file": "src/components/cards/llmd/PerformanceTimeline.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 142,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/PerformanceTimeline.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 150,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/ResourceUtilization.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 198,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/ResourceUtilization.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 206,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
     "file": "src/components/cards/llmd/shared/PortalTooltip.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 102,
     "column": 14,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/llmd/StackSelector.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 250,
-    "column": 9,
-    "message": "The 'stacks' logical expression could make the dependencies of useMemo Hook (at line 308) change on every render. To fix this, wrap the initialization of 'stacks' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/llmd/StackSelector.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 468,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 188,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 196,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/llmd/ThroughputComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 204,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 12,
-    "column": 26,
-    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 69,
-    "column": 41,
-    "message": "React Hook useMemo has an unnecessary dependency: 'tick'. Either exclude it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 166,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 177,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 185,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 193,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 199,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/MaintenanceWindows.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 210,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/Missions.tsx",
-    "rule": "null",
-    "line": 1,
-    "column": 1,
-    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
-  },
-  {
-    "file": "src/components/cards/MobileBrowser.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 281,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/cards/multi-tenancy/k3s-status/K3sDetailModal.tsx",
@@ -3094,188 +3640,6 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/cards/NamespaceEvents.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 221,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceEvents.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 231,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceOverview.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 30,
-    "column": 9,
-    "message": "The 'safeAllClusters' logical expression could make the dependencies of useMemo Hook (at line 63) change on every render. To fix this, wrap the initialization of 'safeAllClusters' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/NamespaceOverview.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 87,
-    "column": 9,
-    "message": "The 'safeNamespaces' logical expression could make the dependencies of useEffect Hook (at line 96) change on every render. To fix this, wrap the initialization of 'safeNamespaces' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/NamespaceOverview.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 213,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceOverview.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 227,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotas.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 320,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotas.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 331,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 119,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 135,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 151,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 204,
-    "column": 19,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 216,
-    "column": 21,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NamespaceQuotasModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 223,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NamespaceRBAC.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 64,
-    "column": 9,
-    "message": "The 'safeNamespaces' logical expression could make the dependencies of useEffect Hook (at line 102) change on every render. To fix this, wrap the initialization of 'safeNamespaces' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/NamespaceRBAC.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 255,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NamespaceRBAC.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 268,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NetworkUtils.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 401,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NetworkUtils.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 442,
-    "column": 15,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NetworkUtils.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 551,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NetworkUtils.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 558,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/NodeConditions.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 13,
-    "column": 26,
-    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/NodeDebug.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 198,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NodeDebug.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 206,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NodeDebug.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 269,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/NodeDebug.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 303,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/cards/opa/ClusterOPAModal.tsx",
     "rule": "no-restricted-syntax",
     "line": 529,
@@ -3304,39 +3668,11 @@
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },
   {
-    "file": "src/components/cards/OPAPoliciesTable.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 15,
-    "message": "'Policy' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/cards/openfeature_status/OpenFeatureStatus.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 8,
     "column": 29,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/cards/OverlayComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 150,
-    "column": 7,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/OverlayComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 180,
-    "column": 15,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/OverlayComparison.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 193,
-    "column": 15,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/cards/pipelines/LogsModal.tsx",
@@ -3395,83 +3731,6 @@
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
-    "file": "src/components/cards/PodCrosser.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 485,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'time'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setScore' needs the current value of 'time'."
-  },
-  {
-    "file": "src/components/cards/PodHealthTrend.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 375,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/PodIssues.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 68,
-    "column": 11,
-    "message": "'Icon' is defined but never used. Allowed unused args must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/PodIssues.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 89,
-    "column": 5,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/PodPitfall.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 511,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'time'. Either include it or remove the dependency array. You can also replace multiple useState variables with useReducer if 'setScore' needs the current value of 'time'."
-  },
-  {
-    "file": "src/components/cards/PodSweeper.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 320,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 269,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 278,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 289,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 335,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/ProactiveGPUNodeHealthMonitor.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 622,
-    "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/cards/quantum/QuantumControlPanel.tsx",
     "rule": "no-restricted-syntax",
     "line": 547,
@@ -3512,41 +3771,6 @@
     "line": 405,
     "column": 11,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/RecentEvents.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 158,
-    "column": 89,
-    "message": "React Hook useCallback has a missing dependency: 'sorting'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/cards/ResourceMarshall.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 68,
-    "column": 9,
-    "message": "The 'availableNamespaces' logical expression could make the dependencies of useEffect Hook (at line 106) change on every render. To fix this, wrap the initialization of 'availableNamespaces' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/cards/ResourceMarshall.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 179,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/ResourceMarshall.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 204,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/ResourceTrend.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 290,
-    "column": 13,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/cards/rss/FeedFilterEditor.tsx",
@@ -3612,95 +3836,11 @@
     "message": "React Hook useCallback has a missing dependency: 't'. Either include it or remove the dependency array."
   },
   {
-    "file": "src/components/cards/StockMarketTicker.tsx",
-    "rule": "null",
-    "line": 1,
-    "column": 1,
-    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
-  },
-  {
-    "file": "src/components/cards/StockMarketTicker.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 765,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/SudokuGame.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 279,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'gameState'. Either include it or remove the dependency array."
-  },
-  {
     "file": "src/components/cards/trivy/TrivyDetailModal.tsx",
     "rule": "no-restricted-syntax",
     "line": 205,
     "column": 13,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/UserManagementList.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 220,
-    "column": 9,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/UserManagementList.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 312,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/UserManagementList.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 330,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "null",
-    "line": 98,
-    "column": 5,
-    "message": "Unused eslint-disable directive"
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 104,
-    "column": 10,
-    "message": "Unexpected any."
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "null",
-    "line": 122,
-    "column": 5,
-    "message": "Unused eslint-disable directive"
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 128,
-    "column": 10,
-    "message": "Unexpected any."
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "null",
-    "line": 138,
-    "column": 5,
-    "message": "Unused eslint-disable directive"
-  },
-  {
-    "file": "src/components/cards/VClusterStatus.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 144,
-    "column": 10,
-    "message": "Unexpected any."
   },
   {
     "file": "src/components/cards/weather/Weather.tsx",
@@ -3750,13 +3890,6 @@
     "line": 158,
     "column": 11,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 38,
-    "column": 26,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/cards/workload-monitor/GitHubCIMonitor.tsx",
@@ -3829,101 +3962,10 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/cards/WorkloadDeployment.tsx",
+    "file": "src/components/cards/workload-monitor/__tests__/GitHubCIMonitor.test.tsx",
     "rule": "no-restricted-syntax",
-    "line": 259,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/WorkloadDeployment.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 270,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
-  },
-  {
-    "file": "src/components/cards/WorkloadDeploymentItem.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 393,
-    "column": 21,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 37,
-    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 435,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 438,
-    "column": 7,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 483,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 492,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 501,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 510,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 520,
-    "column": 9,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 560,
-    "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 569,
-    "column": 9,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/cards/WorkloadImportDialog.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 609,
-    "column": 9,
+    "line": 38,
+    "column": 26,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
@@ -4039,6 +4081,13 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
+    "file": "src/components/clusters/ClusterGroupsSection.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 99,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
     "file": "src/components/clusters/__tests__/ClusterDetailModal.diagnosePrompt.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -4093,76 +4142,6 @@
     "line": 49,
     "column": 31,
     "message": "React Hook useMemo has a missing dependency: 'input'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/clusters/ClusterGroupsSection.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 99,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/CardConfigModal.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/ClusterGrid.common.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 44,
-    "column": 15,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/ClusterGroups.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/DragPreviewCard.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/GPUDetailModal.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/NamespaceResources.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/SortableClusterCard.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/StatsConfig.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/clusters/components/__tests__/StatsOverview.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/clusters/components/CardConfigModal.tsx",
@@ -4261,6 +4240,69 @@
     "line": 250,
     "column": 17,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/CardConfigModal.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/ClusterGrid.common.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 44,
+    "column": 15,
+    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/ClusterGroups.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/DragPreviewCard.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/GPUDetailModal.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/NamespaceResources.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/SortableClusterCard.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/StatsConfig.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/clusters/components/__tests__/StatsOverview.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/compliance/ComplianceFrameworks.tsx",
@@ -4515,48 +4557,6 @@
     "message": "React Hook useCallback has a missing dependency: 't'. Either include it or remove the dependency array."
   },
   {
-    "file": "src/components/dashboard/customizer/__tests__/comprehensive.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 82,
-    "column": 17,
-    "message": "'category' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
-  },
-  {
-    "file": "src/components/dashboard/customizer/AIAssistBar.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 49,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/dashboard/customizer/sections/AISuggestionsSection.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 88,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/dashboard/customizer/sections/CardCatalogSection.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 217,
-    "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/dashboard/customizer/sections/TemplateGallerySection.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 75,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/dashboard/customizer/sections/UnifiedCardsSection.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 225,
-    "column": 15,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/dashboard/Dashboard.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -4683,6 +4683,48 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
+    "file": "src/components/dashboard/customizer/AIAssistBar.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 49,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/dashboard/customizer/__tests__/comprehensive.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 82,
+    "column": 17,
+    "message": "'category' is assigned a value but never used. Allowed unused elements of array destructuring must match /^_/u."
+  },
+  {
+    "file": "src/components/dashboard/customizer/sections/AISuggestionsSection.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 88,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/dashboard/customizer/sections/CardCatalogSection.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 217,
+    "column": 13,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/dashboard/customizer/sections/TemplateGallerySection.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 75,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/dashboard/customizer/sections/UnifiedCardsSection.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 225,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
     "file": "src/components/data-compliance/DataCompliance.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -4716,118 +4758,6 @@
     "line": 662,
     "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/AlertDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/ArgoAppDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-require-imports",
-    "line": 148,
-    "column": 21,
-    "message": "A `require()` style import is forbidden."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.actions.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 24,
-    "column": 23,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 103,
-    "column": 55,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 144,
-    "column": 26,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 182,
-    "column": 33,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 182,
-    "column": 44,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "@typescript-eslint/no-explicit-any",
-    "line": 182,
-    "column": 58,
-    "message": "Unexpected any. Specify a different type."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 190,
-    "column": 10,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisData'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisData' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 194,
-    "column": 10,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisLoading'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisLoading' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 198,
-    "column": 10,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisError'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisError' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 271,
-    "column": 8,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockShowDeletePodConfirm'. Either exclude it or remove the dependency array. Outer scope values like 'mockShowDeletePodConfirm' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 275,
-    "column": 8,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockDeletingPod'. Either exclude it or remove the dependency array. Outer scope values like 'mockDeletingPod' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 279,
-    "column": 8,
-    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockDeleteError'. Either exclude it or remove the dependency array. Outer scope values like 'mockDeleteError' aren't valid dependencies because mutating them doesn't re-render the component."
   },
   {
     "file": "src/components/drilldown/views/AlertDrillDown.tsx",
@@ -4886,6 +4816,20 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
+    "file": "src/components/drilldown/views/CRDDrillDown.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 148,
+    "column": 9,
+    "message": "The 'fetchCRDDetails' function makes the dependencies of useEffect Hook (at line 275) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchCRDDetails' in its own useCallback() Hook."
+  },
+  {
+    "file": "src/components/drilldown/views/CRDDrillDown.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 202,
+    "column": 9,
+    "message": "The 'fetchInstances' function makes the dependencies of useEffect Hook (at line 275) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchInstances' in its own useCallback() Hook."
+  },
+  {
     "file": "src/components/drilldown/views/ClusterDrillDown.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -4919,20 +4863,6 @@
     "line": 102,
     "column": 9,
     "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 143) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/drilldown/views/CRDDrillDown.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 148,
-    "column": 9,
-    "message": "The 'fetchCRDDetails' function makes the dependencies of useEffect Hook (at line 275) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchCRDDetails' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/drilldown/views/CRDDrillDown.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 202,
-    "column": 9,
-    "message": "The 'fetchInstances' function makes the dependencies of useEffect Hook (at line 275) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchInstances' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/DeploymentDrillDown.tsx",
@@ -5089,53 +5019,11 @@
     "message": "The 'fetchSubscription' function makes the dependencies of useEffect Hook (at line 236) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchSubscription' in its own useCallback() Hook."
   },
   {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsContext.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 60,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 135,
-    "column": 27,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 170,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 178,
-    "column": 19,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 335,
-    "column": 27,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 351,
-    "column": 21,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 359,
-    "column": 19,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+    "file": "src/components/drilldown/views/PVCDrillDown.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 84,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'fetchData'. Either include it or remove the dependency array."
   },
   {
     "file": "src/components/drilldown/views/PodDrillDown.hooks.ts",
@@ -5171,27 +5059,6 @@
     "line": 188,
     "column": 9,
     "message": "The 'fetchSpec' function makes the dependencies of useEffect Hook (at line 224) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchSpec' in its own useCallback() Hook."
-  },
-  {
-    "file": "src/components/drilldown/views/PVCDrillDown.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 84,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'fetchData'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 86,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 111,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/drilldown/views/ReplicaSetDrillDown.tsx",
@@ -5285,6 +5152,181 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
+    "file": "src/components/drilldown/views/__tests__/AlertDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/ArgoAppDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/ConfigMapDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-require-imports",
+    "line": 148,
+    "column": 21,
+    "message": "A `require()` style import is forbidden."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.actions.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 24,
+    "column": 23,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 103,
+    "column": 55,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 144,
+    "column": 26,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 182,
+    "column": 33,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 182,
+    "column": 44,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "@typescript-eslint/no-explicit-any",
+    "line": 182,
+    "column": 58,
+    "message": "Unexpected any. Specify a different type."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 190,
+    "column": 10,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisData'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisData' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 194,
+    "column": 10,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisLoading'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisLoading' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 198,
+    "column": 10,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockAiAnalysisError'. Either exclude it or remove the dependency array. Outer scope values like 'mockAiAnalysisError' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 271,
+    "column": 8,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockShowDeletePodConfirm'. Either exclude it or remove the dependency array. Outer scope values like 'mockShowDeletePodConfirm' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 275,
+    "column": 8,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockDeletingPod'. Either exclude it or remove the dependency array. Outer scope values like 'mockDeletingPod' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/__tests__/PodDrillDown.test.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 279,
+    "column": 8,
+    "message": "React Hook React.useEffect has an unnecessary dependency: 'mockDeleteError'. Either exclude it or remove the dependency array. Outer scope values like 'mockDeleteError' aren't valid dependencies because mutating them doesn't re-render the component."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 60,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 135,
+    "column": 27,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 170,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 178,
+    "column": 19,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 335,
+    "column": 27,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 351,
+    "column": 21,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/drilldown/views/pod-drilldown/PodLabelsTab.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 359,
+    "column": 19,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 86,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/drilldown/views/quantum/QuantumCredentialsDrillDown.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 111,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
     "file": "src/components/enterprise/__tests__/enterpriseNav.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 6,
@@ -5318,34 +5360,6 @@
     "line": 582,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/feedback/__tests__/DraftsTab.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 26,
-    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 26,
-    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 37,
-    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 5,
-    "column": 10,
-    "message": "'createPortal' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/feedback/FeatureRequestList.test.tsx",
@@ -5397,13 +5411,6 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/feedback/NotificationBadge.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/feedback/NPSSurvey.tsx",
     "rule": "no-restricted-syntax",
     "line": 144,
@@ -5416,6 +5423,13 @@
     "line": 157,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/feedback/NotificationBadge.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/feedback/SubmitTab.tsx",
@@ -5451,6 +5465,34 @@
     "line": 444,
     "column": 11,
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/feedback/__tests__/DraftsTab.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 26,
+    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 26,
+    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 37,
+    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/feedback/__tests__/NPSSurvey.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 5,
+    "column": 10,
+    "message": "'createPortal' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/gitops/GitOps.tsx",
@@ -5600,6 +5642,27 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
+    "file": "src/components/layout/Layout.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 45,
+    "column": 10,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/layout/Layout.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 246,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'updateProgress'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/layout/SidebarShell.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 566,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
     "file": "src/components/layout/__tests__/Layout.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -5614,18 +5677,18 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/layout/Layout.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 45,
-    "column": 10,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+    "file": "src/components/layout/mission-sidebar/MissionListPanel.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 79,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/layout/Layout.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 246,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'updateProgress'. Either include it or remove the dependency array."
+    "file": "src/components/layout/mission-sidebar/MissionSidebarNewMission.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 32,
+    "column": 9,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },
   {
     "file": "src/components/layout/mission-sidebar/__tests__/MissionListPanel.test.tsx",
@@ -5740,20 +5803,6 @@
     "message": "The 'missionMessages' logical expression could make the dependencies of useCallback Hook (at line 305) change on every render. To fix this, wrap the initialization of 'missionMessages' in its own useMemo() Hook."
   },
   {
-    "file": "src/components/layout/mission-sidebar/MissionListPanel.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 79,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/layout/mission-sidebar/MissionSidebarNewMission.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 32,
-    "column": 9,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
     "file": "src/components/layout/navbar/LearnDropdown.tsx",
     "rule": "react-hooks/exhaustive-deps",
     "line": 117,
@@ -5772,13 +5821,6 @@
     "rule": "no-restricted-syntax",
     "line": 53,
     "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/layout/SidebarShell.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 566,
-    "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
@@ -5815,6 +5857,83 @@
     "line": 1,
     "column": 8,
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
+    "rule": "null",
+    "line": 1,
+    "column": 1,
+    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
+  },
+  {
+    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 32,
+    "column": 14,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 39,
+    "column": 14,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 465,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 496,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/components/mission-control/ClusterReadinessCard.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 211,
+    "column": 17,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/mission-control/FlightPlanBlueprint.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 259,
+    "column": 6,
+    "message": "React Hook useMemo has an unnecessary dependency: 'hoveredProjectKey'. Either exclude it or remove the dependency array."
+  },
+  {
+    "file": "src/components/mission-control/LaunchSequence.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 328,
+    "column": 6,
+    "message": "React Hook useEffect has missing dependencies: 'effectivePhases', 'onUpdateProgress', and 'state.launchProgress'. Either include them or remove the dependency array. If 'onUpdateProgress' changes too often, find the parent component that defines it and wrap that definition in useCallback."
+  },
+  {
+    "file": "src/components/mission-control/LaunchSequence.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 558,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/mission-control/LaunchSequence.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 566,
+    "column": 6,
+    "message": "React Hook useEffect has a missing dependency: 'startUnifiedMission'. Either include it or remove the dependency array."
+  },
+  {
+    "file": "src/components/mission-control/PayloadGrid.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 57,
+    "column": 11,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/mission-control/__tests__/blueprint-info-panels.test.tsx",
@@ -5866,48 +5985,6 @@
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
-    "rule": "null",
-    "line": 1,
-    "column": 1,
-    "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
-  },
-  {
-    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 32,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 39,
-    "column": 14,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 465,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/mission-control/BlueprintInfoPanels.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 496,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/mission-control/ClusterReadinessCard.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 211,
-    "column": 17,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/mission-control/fixer-definition-panel/FixerDefinitionForm.tsx",
     "rule": "no-restricted-syntax",
     "line": 97,
@@ -5927,6 +6004,20 @@
     "line": 186,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/mission-control/fixer-definition-panel/FixerDefinitionPanelContent.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 88,
+    "column": 9,
+    "message": "The 'projects' logical expression could make the dependencies of useEffect Hook (at line 149) change on every render. To fix this, wrap the initialization of 'projects' in its own useMemo() Hook."
+  },
+  {
+    "file": "src/components/mission-control/fixer-definition-panel/FixerDefinitionPanelContent.tsx",
+    "rule": "react-hooks/exhaustive-deps",
+    "line": 88,
+    "column": 9,
+    "message": "The 'projects' logical expression could make the dependencies of useMemo Hook (at line 153) change on every render. To fix this, wrap the initialization of 'projects' in its own useMemo() Hook."
   },
   {
     "file": "src/components/mission-control/fixer-definition-panel/fixerDefinitionPanel.constants.tsx",
@@ -5999,55 +6090,6 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/components/mission-control/fixer-definition-panel/FixerDefinitionPanelContent.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 88,
-    "column": 9,
-    "message": "The 'projects' logical expression could make the dependencies of useEffect Hook (at line 149) change on every render. To fix this, wrap the initialization of 'projects' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/mission-control/fixer-definition-panel/FixerDefinitionPanelContent.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 88,
-    "column": 9,
-    "message": "The 'projects' logical expression could make the dependencies of useMemo Hook (at line 153) change on every render. To fix this, wrap the initialization of 'projects' in its own useMemo() Hook."
-  },
-  {
-    "file": "src/components/mission-control/FlightPlanBlueprint.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 259,
-    "column": 6,
-    "message": "React Hook useMemo has an unnecessary dependency: 'hoveredProjectKey'. Either exclude it or remove the dependency array."
-  },
-  {
-    "file": "src/components/mission-control/LaunchSequence.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 328,
-    "column": 6,
-    "message": "React Hook useEffect has missing dependencies: 'effectivePhases', 'onUpdateProgress', and 'state.launchProgress'. Either include them or remove the dependency array. If 'onUpdateProgress' changes too often, find the parent component that defines it and wrap that definition in useCallback."
-  },
-  {
-    "file": "src/components/mission-control/LaunchSequence.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 558,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 't'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/mission-control/LaunchSequence.tsx",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 566,
-    "column": 6,
-    "message": "React Hook useEffect has a missing dependency: 'startUnifiedMission'. Either include it or remove the dependency array."
-  },
-  {
-    "file": "src/components/mission-control/PayloadGrid.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 57,
-    "column": 11,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
     "file": "src/components/mission-control/svg/DependencyPath.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 41,
@@ -6060,34 +6102,6 @@
     "line": 52,
     "column": 109,
     "message": "React Hook useMemo has an unnecessary dependency: 'planningMission.id'. Either exclude it or remove the dependency array."
-  },
-  {
-    "file": "src/components/missions/__tests__/ConfirmMissionPromptDialog.test.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 48,
-    "column": 92,
-    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
-  },
-  {
-    "file": "src/components/missions/__tests__/MissionBrowserTopBar.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 26,
-    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/missions/__tests__/OrbitStatusTracker.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 15,
-    "message": "'OrbitCadence' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/missions/__tests__/useMissionRecommendations.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 2,
-    "column": 27,
-    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/missions/ClusterSelectionDialog.tsx",
@@ -6426,6 +6440,34 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
+    "file": "src/components/missions/__tests__/ConfirmMissionPromptDialog.test.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 48,
+    "column": 92,
+    "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
+  },
+  {
+    "file": "src/components/missions/__tests__/MissionBrowserTopBar.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 26,
+    "message": "'fireEvent' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/missions/__tests__/OrbitStatusTracker.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 15,
+    "message": "'OrbitCadence' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/missions/__tests__/useMissionRecommendations.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 2,
+    "column": 27,
+    "message": "'waitFor' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/components/modals/sections/AIActionBar.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -6629,13 +6671,6 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/rewards/__tests__/RewardsPanel.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/components/rewards/GitHubInvite.tsx",
     "rule": "no-restricted-syntax",
     "line": 156,
@@ -6643,11 +6678,11 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
-    "file": "src/components/security/__tests__/Security.test.tsx",
+    "file": "src/components/rewards/__tests__/RewardsPanel.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
-    "line": 10,
-    "column": 20,
-    "message": "'ns' is defined but never used. Allowed unused args must match /^_/u."
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/security/Security.tsx",
@@ -6664,6 +6699,13 @@
     "message": "The 'complianceChecks' conditional could make the dependencies of useMemo Hook (at line 182) change on every render. Move it inside the useMemo callback. Alternatively, wrap the initialization of 'complianceChecks' in its own useMemo() Hook."
   },
   {
+    "file": "src/components/security/__tests__/Security.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 10,
+    "column": 20,
+    "message": "'ns' is defined but never used. Allowed unused args must match /^_/u."
+  },
+  {
     "file": "src/components/settings/__tests__/Settings.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -6672,34 +6714,6 @@
   },
   {
     "file": "src/components/settings/__tests__/UpdateSettings.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/settings/sections/__tests__/AnalyticsSection.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/settings/sections/__tests__/BrowserNotificationSettings.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/settings/sections/__tests__/MiscSections.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/settings/sections/__tests__/NotificationSettings.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
     "column": 8,
@@ -6993,6 +7007,34 @@
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
+    "file": "src/components/settings/sections/__tests__/AnalyticsSection.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/settings/sections/__tests__/BrowserNotificationSettings.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/settings/sections/__tests__/MiscSections.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/settings/sections/__tests__/NotificationSettings.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/components/setup/SetupInstructionsDialog.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -7047,20 +7089,6 @@
     "line": 193,
     "column": 17,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/stellar/__tests__/EventsPanel.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 3,
-    "column": 10,
-    "message": "'render' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/components/stellar/__tests__/EventsPanel.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 72,
-    "column": 7,
-    "message": "'mockNotifications' is assigned a value but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/stellar/EventModal.tsx",
@@ -7126,6 +7154,20 @@
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
+    "file": "src/components/stellar/__tests__/EventsPanel.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 3,
+    "column": 10,
+    "message": "'render' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/components/stellar/__tests__/EventsPanel.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 72,
+    "column": 7,
+    "message": "'mockNotifications' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/components/storage/Storage.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -7138,13 +7180,6 @@
     "line": 65,
     "column": 9,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/teams/__tests__/TeamMemberManager.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 6,
-    "column": 31,
-    "message": "'TeamRole' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/teams/TeamAccessGrants.tsx",
@@ -7215,6 +7250,13 @@
     "line": 130,
     "column": 17,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
+    "file": "src/components/teams/__tests__/TeamMemberManager.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 6,
+    "column": 31,
+    "message": "'TeamRole' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/components/terminal/__tests__/PodExecTerminal.test.tsx",
@@ -8008,6 +8050,27 @@
     "message": "Unexpected any. Specify a different type."
   },
   {
+    "file": "src/contexts/AlertsContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 61,
+    "column": 25,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/contexts/DashboardContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 63,
+    "column": 28,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/contexts/DashboardContext.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 63,
+    "column": 49,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
     "file": "src/contexts/__tests__/AlertsContext.additional.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 23,
@@ -8071,6 +8134,13 @@
     "message": "'flushTimers' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
+    "file": "src/contexts/__tests__/DashboardContext.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
     "file": "src/contexts/__tests__/createStateContext.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 1,
@@ -8090,34 +8160,6 @@
     "line": 8,
     "column": 10,
     "message": "'createContext' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/contexts/__tests__/DashboardContext.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/contexts/AlertsContext.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 61,
-    "column": 25,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/contexts/DashboardContext.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 63,
-    "column": 28,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/contexts/DashboardContext.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 63,
-    "column": 49,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
     "file": "src/hooks/__tests__/agentConnectivity.test.tsx",
@@ -8141,13 +8183,6 @@
     "message": "'callsAtStart' is assigned a value but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/hooks/__tests__/useActiveUsers-coverage.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 228,
-    "column": 13,
-    "message": "'WINDOW_SIZE' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/hooks/__tests__/useAIPredictions-hook.test.ts",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 73,
@@ -8160,6 +8195,13 @@
     "line": 73,
     "column": 64,
     "message": "'syncSettingsToBackend' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/hooks/__tests__/useActiveUsers-coverage.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 228,
+    "column": 13,
+    "message": "'WINDOW_SIZE' is assigned a value but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/hooks/__tests__/useArgoCD-additional.test.ts",
@@ -18914,48 +18956,6 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 221,
-    "column": 11,
-    "message": "'btnRef' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 222,
-    "column": 13,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 262,
-    "column": 13,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 678,
-    "column": 11,
-    "message": "'onDismiss' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/useStablePageHeight-coverage.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 13,
-    "column": 22,
-    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/useStablePageHeight-coverage.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 19,
-    "column": 7,
-    "message": "'SMALLER_SCROLL_HEIGHT_PX' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/lib/cards/CardClusterFilter.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 197,
@@ -18975,13 +18975,6 @@
     "line": 16,
     "column": 14,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/lib/cards/cardInstallMap.ts",
-    "rule": "null",
-    "line": 137,
-    "column": 5,
-    "message": "Unused eslint-disable directive (no problems were reported from 'no-console')."
   },
   {
     "file": "src/lib/cards/CardRuntime.tsx",
@@ -19045,6 +19038,55 @@
     "line": 19,
     "column": 14,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 221,
+    "column": 11,
+    "message": "'btnRef' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 222,
+    "column": 13,
+    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 262,
+    "column": 13,
+    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 678,
+    "column": 11,
+    "message": "'onDismiss' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/__tests__/useStablePageHeight-coverage.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 13,
+    "column": 22,
+    "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/__tests__/useStablePageHeight-coverage.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 19,
+    "column": 7,
+    "message": "'SMALLER_SCROLL_HEIGHT_PX' is assigned a value but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/cards/cardInstallMap.ts",
+    "rule": "null",
+    "line": 137,
+    "column": 5,
+    "message": "Unused eslint-disable directive (no problems were reported from 'no-console')."
   },
   {
     "file": "src/lib/compat/echarts-for-react/lib/types.test.ts",
@@ -19159,6 +19201,34 @@
     "message": "Unused eslint-disable directive (no problems were reported from 'max-lines')."
   },
   {
+    "file": "src/lib/modals/ModalRuntime.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 78,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/lib/modals/ModalRuntime.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 82,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/lib/modals/ModalRuntime.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 86,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
+    "file": "src/lib/modals/ModalRuntime.tsx",
+    "rule": "react-refresh/only-export-components",
+    "line": 96,
+    "column": 17,
+    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
+  },
+  {
     "file": "src/lib/modals/__tests__/BaseModal.safety.test.tsx",
     "rule": "no-restricted-syntax",
     "line": 17,
@@ -19192,34 +19262,6 @@
     "line": 1,
     "column": 8,
     "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/modals/ModalRuntime.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 78,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/lib/modals/ModalRuntime.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 82,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/lib/modals/ModalRuntime.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 86,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/lib/modals/ModalRuntime.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 96,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
     "file": "src/lib/quantum/__tests__/patternChangeEmitter.test.ts",
@@ -19320,27 +19362,6 @@
     "message": "'mockGetCardConfigForGrid' is assigned a value but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/lib/unified/card/__tests__/UnifiedCardAdapter.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 1,
-    "column": 8,
-    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/unified/card/renderers/__tests__/registry-coverage.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 16,
-    "column": 36,
-    "message": "'beforeAll' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/unified/card/renderers/__tests__/registry-coverage.test.ts",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 19,
-    "column": 3,
-    "message": "'getRenderer' is defined but never used. Allowed unused vars must match /^_/u."
-  },
-  {
     "file": "src/lib/unified/card/UnifiedCardAdapter.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 31,
@@ -19383,6 +19404,34 @@
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
   {
+    "file": "src/lib/unified/card/__tests__/UnifiedCardAdapter.test.tsx",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 1,
+    "column": 8,
+    "message": "'React' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/unified/card/renderers/__tests__/registry-coverage.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 16,
+    "column": 36,
+    "message": "'beforeAll' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/unified/card/renderers/__tests__/registry-coverage.test.ts",
+    "rule": "@typescript-eslint/no-unused-vars",
+    "line": 19,
+    "column": 3,
+    "message": "'getRenderer' is defined but never used. Allowed unused vars must match /^_/u."
+  },
+  {
+    "file": "src/lib/unified/card/visualizations/ListVisualization.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 146,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
     "file": "src/lib/unified/card/visualizations/__tests__/TableVisualization.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 2,
@@ -19409,13 +19458,6 @@
     "line": 361,
     "column": 13,
     "message": "'user' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/unified/card/visualizations/ListVisualization.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 146,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/lib/unified/demo/UnifiedDemo.tsx",
@@ -19488,6 +19530,13 @@
     "message": "Fast refresh only works when a file has exports. Move your component(s) to a separate file."
   },
   {
+    "file": "src/pages/UnifiedDashboardTest.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 66,
+    "column": 11,
+    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
+  },
+  {
     "file": "src/pages/__tests__/FromHeadlamp.test.tsx",
     "rule": "@typescript-eslint/no-unused-vars",
     "line": 21,
@@ -19500,13 +19549,6 @@
     "line": 21,
     "column": 3,
     "message": "'emitFromLensCommandCopy' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/pages/UnifiedDashboardTest.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 66,
-    "column": 11,
-    "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/test/api-contract.test.ts",


### PR DESCRIPTION
Fixes #21130

Regenerated web/.eslint-baseline.json to absorb pre-existing main-side violations that were blocking all PRs. Verified via lint-baseline-check.mjs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>