### PR TITLE
[scanner] 🐛 fix: complete vi.mock returns for Coverage Suite tests

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -926,7 +926,7 @@
   {
     "file": "src/components/cards/ChartVersions.test.tsx",
     "rule": "no-restricted-syntax",
-    "line": 71,
+    "line": 73,
     "column": 5,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },

--- a/web/src/components/cards/ClusterHealth.test.tsx
+++ b/web/src/components/cards/ClusterHealth.test.tsx
@@ -19,6 +19,7 @@ vi.mock('../../hooks/useCachedData', () => ({
 
 vi.mock('react-router-dom', () => ({
   useLocation: vi.fn(() => ({ pathname: '/', search: '', hash: '', state: null })),
+  useNavigate: vi.fn(() => vi.fn()),
 }))
 
 vi.mock('../ui/RefreshIndicator', () => ({

--- a/web/src/components/cards/FlappyPod.test.tsx
+++ b/web/src/components/cards/FlappyPod.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
 }))
 
 vi.mock('../../lib/safeLocalStorage', () => ({

--- a/web/src/components/cards/Game2048.test.tsx
+++ b/web/src/components/cards/Game2048.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
 }))
 
 vi.mock('@/lib/utils/localStorage', () => ({

--- a/web/src/components/cards/GitHubActivity.test.tsx
+++ b/web/src/components/cards/GitHubActivity.test.tsx
@@ -137,6 +137,7 @@ vi.mock('./GitHubActivityItems', () => ({
 
 vi.mock('../../lib/constants/time', () => ({
   MS_PER_DAY: 86400000,
+  MS_PER_HOUR: 3600000,
 }))
 
 vi.mock('../../lib/constants/network', () => ({

--- a/web/src/components/cards/KubeBert.test.tsx
+++ b/web/src/components/cards/KubeBert.test.tsx
@@ -31,6 +31,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: vi.fn(),
+  useGameKeyTracking: vi.fn(),
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/KubeChess.test.tsx
+++ b/web/src/components/cards/KubeChess.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../../lib/analytics', () => ({
   emitGameEnded: vi.fn(),
 }))
 
+vi.mock('../../hooks/useGameKeys', () => ({
+  useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
+}))
+
 vi.mock('../../lib/safeLocalStorage', () => ({
   safeGetItem: vi.fn(() => null),
   safeSetItem: vi.fn(),

--- a/web/src/components/cards/KubeSnake.test.tsx
+++ b/web/src/components/cards/KubeSnake.test.tsx
@@ -22,6 +22,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
 }))
 
 vi.mock('@/lib/utils/localStorage', () => ({

--- a/web/src/components/cards/PlatformerGames.test.tsx
+++ b/web/src/components/cards/PlatformerGames.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
 }))
 
 vi.mock('../../lib/safeLocalStorage', () => ({

--- a/web/src/components/cards/ShooterGames.test.tsx
+++ b/web/src/components/cards/ShooterGames.test.tsx
@@ -22,6 +22,7 @@ vi.mock('./CardWrapper', () => ({
 vi.mock('./CardDataContext', () => ({
   useCardLoadingState: vi.fn(),
   useReportCardDataState: vi.fn(),
+  useCardDemoState: vi.fn(() => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false })),
 }))
 
 vi.mock('../../lib/analytics', () => ({
@@ -31,6 +32,7 @@ vi.mock('../../lib/analytics', () => ({
 
 vi.mock('../../hooks/useGameKeys', () => ({
   useGameKeys: () => ({ key: null }),
+  useGameKeyTracking: vi.fn(),
 }))
 
 vi.mock('../../lib/safeLocalStorage', () => ({


### PR DESCRIPTION
Fixes #21136

Completes incomplete Vitest mocks for Coverage Suite card tests by adding missing hook/router/time exports used by the components under test.