### PR TITLE
[scanner] 🌱 test: add smoke tests for untested stellar components

### DIFF
--- a/web/src/components/stellar/MessageBubble.test.tsx
+++ b/web/src/components/stellar/MessageBubble.test.tsx
@@ -1,0 +1,73 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { MessageBubble } from './MessageBubble'
+
+vi.mock('react-markdown', () => ({
+  default: ({ children }: { children: string }) => <div>{children}</div>,
+}))
+
+vi.mock('remark-gfm', () => ({ default: () => {} }))
+vi.mock('rehype-sanitize', () => ({ default: () => {} }))
+
+describe('MessageBubble', () => {
+  it('renders user message content', () => {
+    render(
+      <MessageBubble
+        msg={{ id: 'msg-1', role: 'user', content: 'Hello Stellar' }}
+      />
+    )
+    expect(screen.getByText('Hello Stellar')).toBeInTheDocument()
+  })
+
+  it('renders user label for user messages', () => {
+    render(
+      <MessageBubble
+        msg={{ id: 'msg-2', role: 'user', content: 'Hi' }}
+      />
+    )
+    expect(screen.getByText('you')).toBeInTheDocument()
+  })
+
+  it('renders stellar label for stellar messages', () => {
+    render(
+      <MessageBubble
+        msg={{ id: 'msg-3', role: 'stellar', content: 'Hello!' }}
+      />
+    )
+    expect(screen.getByText('\u25cf stellar')).toBeInTheDocument()
+  })
+
+  it('renders loading dots when loading is true', () => {
+    const { container } = render(
+      <MessageBubble
+        msg={{ id: 'msg-4', role: 'stellar', content: '', loading: true }}
+      />
+    )
+    const dots = container.querySelectorAll('[style*="border-radius: 50%"]')
+    expect(dots.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('renders watch created indicator when watchCreated is true', () => {
+    render(
+      <MessageBubble
+        msg={{ id: 'msg-5', role: 'stellar', content: 'Watching now', watchCreated: true }}
+      />
+    )
+    expect(screen.getByText(/Stellar is watching this/)).toBeInTheDocument()
+  })
+
+  it('renders meta info when provided', () => {
+    render(
+      <MessageBubble
+        msg={{
+          id: 'msg-6',
+          role: 'stellar',
+          content: 'Response',
+          meta: { model: 'gpt-4o', tokens: 120, provider: 'openai', durationMs: 450 },
+        }}
+      />
+    )
+    expect(screen.getByText('openai \u00b7 gpt-4o \u00b7 120 tok \u00b7 450ms')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/stellar/ProactiveNudge.test.tsx
+++ b/web/src/components/stellar/ProactiveNudge.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { ProactiveNudge } from './ProactiveNudge'
+import type { StellarObservation } from '../../types/stellar'
+
+const baseNudge: StellarObservation = {
+  id: 'nudge-1',
+  summary: 'CPU usage is high on prod-cluster',
+}
+
+describe('ProactiveNudge', () => {
+  it('renders the nudge summary', () => {
+    render(
+      <ProactiveNudge
+        nudge={baseNudge}
+        onDismiss={() => {}}
+        onApplySuggestion={() => {}}
+      />
+    )
+    expect(screen.getByText('CPU usage is high on prod-cluster')).toBeInTheDocument()
+  })
+
+  it('renders suggestion button when suggest is provided', () => {
+    const nudge: StellarObservation = { ...baseNudge, suggest: 'Scale up the deployment' }
+    render(
+      <ProactiveNudge
+        nudge={nudge}
+        onDismiss={() => {}}
+        onApplySuggestion={() => {}}
+      />
+    )
+    expect(screen.getByText('\u2192 Scale up the deployment')).toBeInTheDocument()
+  })
+
+  it('does not render suggestion button when suggest is absent', () => {
+    render(
+      <ProactiveNudge
+        nudge={baseNudge}
+        onDismiss={() => {}}
+        onApplySuggestion={() => {}}
+      />
+    )
+    expect(screen.queryByRole('button', { name: /scale/i })).not.toBeInTheDocument()
+  })
+
+  it('calls onApplySuggestion with suggest text when clicked', () => {
+    const onApply = vi.fn()
+    const nudge: StellarObservation = { ...baseNudge, suggest: 'Scale up the deployment' }
+    render(
+      <ProactiveNudge
+        nudge={nudge}
+        onDismiss={() => {}}
+        onApplySuggestion={onApply}
+      />
+    )
+    fireEvent.click(screen.getByText('\u2192 Scale up the deployment'))
+    expect(onApply).toHaveBeenCalledWith('Scale up the deployment')
+  })
+
+  it('calls onDismiss when dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(
+      <ProactiveNudge
+        nudge={baseNudge}
+        onDismiss={onDismiss}
+        onApplySuggestion={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByLabelText('Dismiss nudge'))
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders reasoning in a details element when provided', () => {
+    const nudge: StellarObservation = { ...baseNudge, reasoning: 'High request rate observed' }
+    render(
+      <ProactiveNudge
+        nudge={nudge}
+        onDismiss={() => {}}
+        onApplySuggestion={() => {}}
+      />
+    )
+    expect(screen.getByText('High request rate observed')).toBeInTheDocument()
+  })
+})

--- a/web/src/components/stellar/StellarActivityPanel.test.tsx
+++ b/web/src/components/stellar/StellarActivityPanel.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { StellarActivityPanel } from './StellarActivityPanel'
+import type { StellarActivity } from '../../types/stellar'
+
+const makeActivity = (overrides: Partial<StellarActivity> = {}): StellarActivity => ({
+  id: 'act-1',
+  userId: 'user-1',
+  ts: new Date().toISOString(),
+  kind: 'auto_fixed',
+  title: 'Restarted pod my-app',
+  severity: 'info',
+  ...overrides,
+})
+
+describe('StellarActivityPanel', () => {
+  it('renders the Stellar log header', () => {
+    render(<StellarActivityPanel activity={[]} />)
+    expect(screen.getByText('Stellar log')).toBeInTheDocument()
+  })
+
+  it('shows activity count badge', () => {
+    render(<StellarActivityPanel activity={[makeActivity(), makeActivity({ id: 'act-2' })]} />)
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('shows empty message when no activity', () => {
+    render(<StellarActivityPanel activity={[]} />)
+    expect(screen.getByText(/Nothing to report yet/)).toBeInTheDocument()
+  })
+
+  it('renders activity entry title', () => {
+    render(<StellarActivityPanel activity={[makeActivity()]} />)
+    expect(screen.getByText('Restarted pod my-app')).toBeInTheDocument()
+  })
+
+  it('collapses the panel when header is clicked', () => {
+    render(<StellarActivityPanel activity={[makeActivity()]} />)
+    const header = screen.getByText('Stellar log').closest('div') as HTMLElement
+    fireEvent.click(header)
+    expect(screen.queryByText('Restarted pod my-app')).not.toBeInTheDocument()
+  })
+
+  it('filters to actions-only when Actions only chip is clicked', () => {
+    const activities = [
+      makeActivity({ id: 'act-eval', kind: 'evaluated', title: 'Noticed pod issue' }),
+      makeActivity({ id: 'act-fix', kind: 'auto_fixed', title: 'Restarted pod my-app' }),
+    ]
+    render(<StellarActivityPanel activity={activities} />)
+    fireEvent.click(screen.getByText('Actions only'))
+    expect(screen.queryByText('Noticed pod issue')).not.toBeInTheDocument()
+    expect(screen.getByText('Restarted pod my-app')).toBeInTheDocument()
+  })
+
+  it('calls onOpenEvent when a row with eventId is clicked', () => {
+    const onOpenEvent = vi.fn()
+    const activity = makeActivity({ id: 'act-evt', kind: 'auto_fixed', title: 'Fixed it', eventId: 'evt-99' })
+    render(<StellarActivityPanel activity={[activity]} onOpenEvent={onOpenEvent} />)
+    fireEvent.click(screen.getByText('Fixed it'))
+    expect(onOpenEvent).toHaveBeenCalledWith('evt-99', activity)
+  })
+})

--- a/web/src/components/stellar/TasksPanel.test.tsx
+++ b/web/src/components/stellar/TasksPanel.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TasksPanel } from './TasksPanel'
+import type { StellarTask } from '../../types/stellar'
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}))
+
+vi.mock('./TaskCard', () => ({
+  TaskCard: ({ task }: { task: StellarTask }) => (
+    <div data-testid={`task-${task.id}`}>{task.title}</div>
+  ),
+}))
+
+const baseTask: StellarTask = {
+  id: 'task-1',
+  sessionId: 'sess-1',
+  userId: 'user-1',
+  cluster: 'prod',
+  title: 'Fix crashing pod',
+  description: 'Pod keeps restarting',
+  status: 'open',
+  priority: 1,
+  source: 'stellar',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+}
+
+describe('TasksPanel', () => {
+  it('renders the panel toggle button with i18n title key', () => {
+    render(
+      <TasksPanel
+        tasks={[baseTask]}
+        expanded={false}
+        onToggle={() => {}}
+        onStatusChange={() => {}}
+      />
+    )
+    expect(screen.getByText('stellar.tasks.title')).toBeInTheDocument()
+  })
+
+  it('shows open task count badge', () => {
+    render(
+      <TasksPanel
+        tasks={[baseTask]}
+        expanded={false}
+        onToggle={() => {}}
+        onStatusChange={() => {}}
+      />
+    )
+    expect(screen.getByText('1 open')).toBeInTheDocument()
+  })
+
+  it('renders task cards when expanded', () => {
+    render(
+      <TasksPanel
+        tasks={[baseTask]}
+        expanded={true}
+        onToggle={() => {}}
+        onStatusChange={() => {}}
+      />
+    )
+    expect(screen.getByTestId('task-task-1')).toBeInTheDocument()
+    expect(screen.getByText('Fix crashing pod')).toBeInTheDocument()
+  })
+
+  it('hides task cards when collapsed', () => {
+    render(
+      <TasksPanel
+        tasks={[baseTask]}
+        expanded={false}
+        onToggle={() => {}}
+        onStatusChange={() => {}}
+      />
+    )
+    expect(screen.queryByTestId('task-task-1')).not.toBeInTheDocument()
+  })
+
+  it('shows empty message when expanded with no tasks', () => {
+    render(
+      <TasksPanel
+        tasks={[]}
+        expanded={true}
+        onToggle={() => {}}
+        onStatusChange={() => {}}
+      />
+    )
+    expect(screen.getByText('No open tasks.')).toBeInTheDocument()
+  })
+
+  it('calls onToggle when the button is clicked', () => {
+    const onToggle = vi.fn()
+    render(
+      <TasksPanel
+        tasks={[]}
+        expanded={false}
+        onToggle={onToggle}
+        onStatusChange={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByRole('button'))
+    expect(onToggle).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/stellar/WatchesPanel.test.tsx
+++ b/web/src/components/stellar/WatchesPanel.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { WatchesPanel } from './WatchesPanel'
+import type { StellarWatch } from '../../types/stellar'
+
+vi.mock('./WatchCard', () => ({
+  WatchCard: ({ watch }: { watch: StellarWatch }) => (
+    <div data-testid={`watch-card-${watch.id}`}>{watch.resourceName}</div>
+  ),
+}))
+
+vi.mock('./WatchDetailModal', () => ({
+  WatchDetailModal: ({ watch, onClose }: { watch: StellarWatch; onClose: () => void }) => (
+    <div data-testid="watch-detail-modal">
+      <span>{watch.resourceName}</span>
+      <button onClick={onClose}>Close</button>
+    </div>
+  ),
+}))
+
+const makeWatch = (overrides: Partial<StellarWatch> = {}): StellarWatch => ({
+  id: 'watch-1',
+  cluster: 'prod',
+  namespace: 'default',
+  resourceKind: 'Deployment',
+  resourceName: 'my-app',
+  reason: 'High restart count',
+  status: 'active',
+  lastUpdate: new Date().toISOString(),
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+  ...overrides,
+})
+
+describe('WatchesPanel', () => {
+  it('returns null when there are no active watches', () => {
+    const { container } = render(
+      <WatchesPanel
+        watches={[makeWatch({ status: 'resolved' })]}
+        onResolve={() => {}}
+        onDismiss={() => {}}
+        onSnooze={() => {}}
+      />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('renders the Watching header', () => {
+    render(
+      <WatchesPanel
+        watches={[makeWatch()]}
+        onResolve={() => {}}
+        onDismiss={() => {}}
+        onSnooze={() => {}}
+      />
+    )
+    expect(screen.getByText('Watching')).toBeInTheDocument()
+  })
+
+  it('shows active watch count badge', () => {
+    render(
+      <WatchesPanel
+        watches={[makeWatch(), makeWatch({ id: 'watch-2', resourceName: 'other-app' })]}
+        onResolve={() => {}}
+        onDismiss={() => {}}
+        onSnooze={() => {}}
+      />
+    )
+    expect(screen.getByText('2')).toBeInTheDocument()
+  })
+
+  it('renders WatchCard for each active watch', () => {
+    render(
+      <WatchesPanel
+        watches={[makeWatch()]}
+        onResolve={() => {}}
+        onDismiss={() => {}}
+        onSnooze={() => {}}
+      />
+    )
+    expect(screen.getByTestId('watch-card-watch-1')).toBeInTheDocument()
+    expect(screen.getByText('my-app')).toBeInTheDocument()
+  })
+
+  it('collapses watch list when header is clicked', () => {
+    render(
+      <WatchesPanel
+        watches={[makeWatch()]}
+        onResolve={() => {}}
+        onDismiss={() => {}}
+        onSnooze={() => {}}
+      />
+    )
+    fireEvent.click(screen.getByText('Watching').closest('div') as HTMLElement)
+    expect(screen.queryByTestId('watch-card-watch-1')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
Fixes #21147

Add Vitest smoke tests for 5 of the components listed in the Auto-QA report:

| Component | Tests added |
|-----------|-------------|
| `ProactiveNudge` | render, suggest button, dismiss callback, reasoning section |
| `MessageBubble` | user/stellar roles, loading dots, watchCreated indicator, meta info |
| `TasksPanel` | toggle button, task count badge, expanded/collapsed state, empty state, i18n |
| `StellarActivityPanel` | header, count badge, empty state, filter chips, click-to-open-event |
| `WatchesPanel` | null when no active watches, header, count badge, WatchCard render, collapse |

**Deferred components** (GPU tab components — `GPUDashboardTab`, `GPUOverviewTab`, `SortableGpuCard`, `GPUReservationsTab`, `GPUInventoryTab`, `GPUCalendarTab`, `ReservationFormModal`) require heavier mocking of data-fetching hooks and routing context. They are deferred to a follow-up PR to keep this batch focused and reviewable.

**Stellar components with complex dependencies** (`StellarPage`, `RecommendedTasksPanel`, `WatchDetailModal`, `EventModal`) are also deferred for the same reason.

Build and lint are validated by CI on this PR.