### PR TITLE
[scanner] fix: add test coverage for GPU components

### DIFF
--- a/web/src/components/gpu/__tests__/GPUCalendarTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUCalendarTab.test.tsx
@@ -1,0 +1,81 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GPUCalendarTab } from '../GPUCalendarTab'
+import type { CalendarWeek } from '../GPUCalendarTab'
+
+const noop = vi.fn()
+
+const JANUARY_2024 = new Date(2024, 0, 1) // January 2024
+
+const EMPTY_WEEKS: CalendarWeek[] = []
+
+const SINGLE_WEEK: CalendarWeek[] = [
+  {
+    days: [1, 2, 3, 4, 5, 6, 7],
+    bars: [],
+  },
+]
+
+function renderCalendar(overrides: Partial<React.ComponentProps<typeof GPUCalendarTab>> = {}) {
+  const defaults: React.ComponentProps<typeof GPUCalendarTab> = {
+    currentMonth: JANUARY_2024,
+    calendarWeeks: EMPTY_WEEKS,
+    effectiveDemoMode: false,
+    expandedReservationId: null,
+    onSetExpandedReservationId: noop,
+    onPrevMonth: noop,
+    onNextMonth: noop,
+    onAddReservation: noop,
+    getGPUCountForDay: () => 0,
+  }
+  return render(<GPUCalendarTab {...defaults} {...overrides} />)
+}
+
+describe('GPUCalendarTab', () => {
+  it('renders the current month name and year', () => {
+    renderCalendar()
+    expect(screen.getByText('January 2024')).toBeTruthy()
+  })
+
+  it('renders a different month when currentMonth changes', () => {
+    renderCalendar({ currentMonth: new Date(2024, 5, 1) }) // June 2024
+    expect(screen.getByText('June 2024')).toBeTruthy()
+  })
+
+  it('calls onPrevMonth when the previous month button is clicked', () => {
+    const onPrevMonth = vi.fn()
+    renderCalendar({ onPrevMonth })
+    fireEvent.click(screen.getByLabelText('Previous month'))
+    expect(onPrevMonth).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onNextMonth when the next month button is clicked', () => {
+    const onNextMonth = vi.fn()
+    renderCalendar({ onNextMonth })
+    fireEvent.click(screen.getByLabelText('Next month'))
+    expect(onNextMonth).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders day numbers from the calendar weeks', () => {
+    renderCalendar({ calendarWeeks: SINGLE_WEEK })
+    // Days 1-7 should all be visible
+    for (let d = 1; d <= 7; d++) {
+      expect(screen.getAllByText(String(d)).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('calls onAddReservation with the correct date string when the add button is clicked', () => {
+    const onAddReservation = vi.fn()
+    renderCalendar({ calendarWeeks: SINGLE_WEEK, onAddReservation })
+    const addButtons = screen.getAllByLabelText(/Add reservation on/)
+    fireEvent.click(addButtons[0])
+    expect(onAddReservation).toHaveBeenCalledWith(expect.stringMatching(/^2024-01-\d{2}$/))
+  })
+
+  it('applies demo mode border when effectiveDemoMode is true', () => {
+    const { container } = renderCalendar({ effectiveDemoMode: true })
+    const demoEl = container.querySelector('.border-yellow-500\\/50')
+    expect(demoEl).not.toBeNull()
+  })
+})

--- a/web/src/components/gpu/__tests__/GPUDashboardTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUDashboardTab.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { GPUDashboardTab } from '../GPUDashboardTab'
+import type { GPUDashboardTabProps } from '../GPUDashboardTab'
+import type { GpuDashCard } from '../SortableGpuCard'
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+vi.mock('../../../hooks/useMCP', () => ({
+  useClusters: vi.fn(() => ({
+    deduplicatedClusters: [],
+  })),
+}))
+
+vi.mock('./SortableGpuCard', () => ({
+  SortableGpuCard: ({ card }: { card: GpuDashCard }) => (
+    <div data-testid="sortable-card" data-type={card.type} />
+  ),
+}))
+
+vi.mock('../../charts/StatusIndicator', () => ({
+  StatusIndicator: ({ status }: { status: string }) => (
+    <span data-testid={`status-${status}`} />
+  ),
+}))
+
+vi.mock('@dnd-kit/core', () => ({
+  DndContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  closestCenter: vi.fn(),
+  useSensor: vi.fn(),
+  useSensors: vi.fn(() => []),
+  MouseSensor: vi.fn(),
+  TouchSensor: vi.fn(),
+  KeyboardSensor: vi.fn(),
+}))
+
+vi.mock('@dnd-kit/sortable', () => ({
+  SortableContext: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  rectSortingStrategy: vi.fn(),
+  useSortable: () => ({
+    attributes: {},
+    listeners: {},
+    setNodeRef: vi.fn(),
+    transform: null,
+    transition: undefined,
+    isDragging: false,
+  }),
+}))
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeCard(type: string): GpuDashCard {
+  return { type, width: 6 }
+}
+
+function renderTab(overrides: Partial<GPUDashboardTabProps> = {}) {
+  const defaults: GPUDashboardTabProps = {
+    dashboardCards: [],
+    dashCardIds: [],
+    gpuDashSensors: [],
+    gpuLiveMode: false,
+    isRefreshingDashboard: false,
+    onDashDragEnd: vi.fn(),
+    onRemoveDashboardCard: vi.fn(),
+    onDashCardWidthChange: vi.fn(),
+    onTriggerRefresh: vi.fn(),
+    onShowAddCardModal: vi.fn(),
+  }
+  return render(<GPUDashboardTab {...defaults} {...overrides} />)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GPUDashboardTab', () => {
+  it('renders the "Add card" button', () => {
+    renderTab()
+    // t() returns the key
+    expect(screen.getByText('gpuReservations.dashboard.addCard')).toBeTruthy()
+  })
+
+  it('shows empty state message when no cards are present', () => {
+    renderTab({ dashboardCards: [] })
+    expect(screen.getByText('gpuReservations.dashboard.noCardsYet')).toBeTruthy()
+  })
+
+  it('renders a sortable card for each dashboard card', () => {
+    const cards = [makeCard('gpu_overview'), makeCard('gpu_status')]
+    renderTab({ dashboardCards: cards, dashCardIds: ['id-0', 'id-1'] })
+    const renderedCards = screen.getAllByTestId('sortable-card')
+    expect(renderedCards).toHaveLength(2)
+    expect(renderedCards[0].getAttribute('data-type')).toBe('gpu_overview')
+    expect(renderedCards[1].getAttribute('data-type')).toBe('gpu_status')
+  })
+
+  it('calls onShowAddCardModal when the "Add card" button is clicked', () => {
+    const onShowAddCardModal = vi.fn()
+    renderTab({ onShowAddCardModal })
+    fireEvent.click(screen.getByText('gpuReservations.dashboard.addCard'))
+    expect(onShowAddCardModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('calls onShowAddCardModal when the empty-state "Add first card" button is clicked', () => {
+    const onShowAddCardModal = vi.fn()
+    renderTab({ dashboardCards: [], onShowAddCardModal })
+    fireEvent.click(screen.getByText('gpuReservations.dashboard.addFirstCard'))
+    expect(onShowAddCardModal).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not show the empty state when cards are present', () => {
+    const cards = [makeCard('gpu_overview')]
+    renderTab({ dashboardCards: cards, dashCardIds: ['id-0'] })
+    expect(screen.queryByText('gpuReservations.dashboard.noCardsYet')).toBeNull()
+  })
+})

--- a/web/src/components/gpu/__tests__/GPUOverviewTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUOverviewTab.test.tsx
@@ -1,0 +1,162 @@
+import React from 'react'
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { GPUOverviewTab } from '../GPUOverviewTab'
+import type { GPUOverviewTabProps } from '../GPUOverviewTab'
+import type { GPUOverviewStats } from '../gpuOverviewStats'
+
+// ── Lightweight component mocks ──────────────────────────────────────────────
+
+vi.mock('../../charts/PieChart', () => ({
+  DonutChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="donut-chart" data-count={data.length} />
+  ),
+}))
+
+vi.mock('../../charts/BarChart', () => ({
+  BarChart: ({ data }: { data: unknown[] }) => (
+    <div data-testid="bar-chart" data-count={data.length} />
+  ),
+}))
+
+vi.mock('../../ui/ClusterBadge', () => ({
+  ClusterBadge: ({ cluster }: { cluster: string }) => <span data-testid="cluster-badge">{cluster}</span>,
+}))
+
+vi.mock('../../shared/TechnicalAcronym', () => ({
+  TechnicalAcronym: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}))
+
+vi.mock('../../../lib/theme/chartColors', () => ({
+  getChartColorByName: () => '#8b5cf6',
+  PURPLE_600: '#8b5cf6',
+}))
+
+vi.mock('../../charts/Sparkline', () => ({
+  Sparkline: () => <div data-testid="sparkline" />,
+}))
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeStats = (overrides: Partial<GPUOverviewStats> = {}): GPUOverviewStats => ({
+  totalGPUs: 10,
+  allocatedGPUs: 4,
+  availableGPUs: 6,
+  utilizationPercent: 40,
+  activeReservations: 2,
+  reservedGPUs: 4,
+  typeChartData: [],
+  usageByNamespace: [],
+  clusterUsage: [],
+  ...overrides,
+})
+
+const makeReservation = (overrides = {}) => ({
+  id: 'res-1',
+  user_id: 'u1',
+  user_name: 'alice',
+  title: 'My GPU Job',
+  description: '',
+  cluster: 'cluster-a',
+  namespace: 'ml',
+  gpu_count: 2,
+  gpu_type: 'NVIDIA A100',
+  gpu_types: ['NVIDIA A100'],
+  start_date: '2024-01-15',
+  duration_hours: 24,
+  notes: '',
+  status: 'active' as const,
+  quota_name: '',
+  quota_enforced: false,
+  created_at: '2024-01-15T00:00:00Z',
+  ...overrides,
+})
+
+function renderTab(overrides: Partial<GPUOverviewTabProps> = {}) {
+  const defaults: GPUOverviewTabProps = {
+    stats: makeStats(),
+    filteredReservations: [],
+    utilizations: null,
+    effectiveDemoMode: false,
+    showOnlyMine: false,
+  }
+  return render(<GPUOverviewTab {...defaults} {...overrides} />)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('GPUOverviewTab', () => {
+  it('displays the key headline stat numbers', () => {
+    renderTab({ stats: makeStats({ totalGPUs: 8, availableGPUs: 3, activeReservations: 5, reservedGPUs: 5 }) })
+    expect(screen.getByText('8')).toBeTruthy()
+    expect(screen.getByText('3')).toBeTruthy()
+    expect(screen.getByText('5')).toBeTruthy()
+  })
+
+  it('shows the utilization percentage in the donut gauge', () => {
+    renderTab({ stats: makeStats({ utilizationPercent: 75 }) })
+    expect(screen.getByText('75%')).toBeTruthy()
+  })
+
+  it('renders empty reservation message when no reservations exist', () => {
+    renderTab({ filteredReservations: [], showOnlyMine: false })
+    // t() returns the key
+    expect(screen.getByText('gpuReservations.overview.noReservationsYet')).toBeTruthy()
+  })
+
+  it('renders "no my reservations" message when showOnlyMine and list is empty', () => {
+    renderTab({ filteredReservations: [], showOnlyMine: true })
+    expect(screen.getByText('gpuReservations.overview.noReservationsUser')).toBeTruthy()
+  })
+
+  it('renders reservation titles when reservations are provided', () => {
+    const reservations = [makeReservation({ title: 'Training Run' })]
+    renderTab({ filteredReservations: reservations })
+    expect(screen.getByText('Training Run')).toBeTruthy()
+  })
+
+  it('renders cluster badge for each visible reservation', () => {
+    const reservations = [makeReservation({ cluster: 'prod-cluster' })]
+    renderTab({ filteredReservations: reservations })
+    expect(screen.getByTestId('cluster-badge')).toBeTruthy()
+    expect(screen.getByText('prod-cluster')).toBeTruthy()
+  })
+
+  it('shows a sparkline when utilization snapshots are provided', () => {
+    const snapshots = [
+      {
+        id: 'snap-1',
+        reservation_id: 'res-1',
+        timestamp: '2024-01-15T10:00:00Z',
+        gpu_utilization_pct: 60,
+        memory_utilization_pct: 40,
+        active_gpu_count: 1,
+        total_gpu_count: 4,
+      },
+    ]
+    const reservations = [makeReservation({ id: 'res-1' })]
+    renderTab({ filteredReservations: reservations, utilizations: { 'res-1': snapshots } })
+    expect(screen.getByTestId('sparkline')).toBeTruthy()
+  })
+
+  it('shows "no usage data yet" when utilizations is null for a reservation', () => {
+    const reservations = [makeReservation()]
+    renderTab({ filteredReservations: reservations, utilizations: null })
+    expect(screen.getByText('gpuReservations.utilization.noData')).toBeTruthy()
+  })
+
+  it('calls onSelectReservation when an interactive reservation is clicked', () => {
+    const onSelectReservation = vi.fn()
+    const reservations = [makeReservation({ id: 'res-42' })]
+    renderTab({ filteredReservations: reservations, onSelectReservation })
+    const item = screen.getByRole('button', { name: /My GPU Job/ })
+    item.click()
+    expect(onSelectReservation).toHaveBeenCalledWith('res-42')
+  })
+
+  it('renders bar chart when clusterUsage data is present', () => {
+    const stats = makeStats({ clusterUsage: [{ name: 'cluster-a', value: 4 }] })
+    renderTab({ stats })
+    expect(screen.getByTestId('bar-chart')).toBeTruthy()
+  })
+})

--- a/web/src/components/gpu/__tests__/gpu-constants.test.ts
+++ b/web/src/components/gpu/__tests__/gpu-constants.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getUtilizationColor,
+  countActiveDays,
+  computeAvgUtilization,
+  SPARKLINE_HIGH_UTIL_PCT,
+  SPARKLINE_LOW_UTIL_PCT,
+} from '../gpu-constants'
+import type { GPUUtilizationSnapshot } from '../../../hooks/useGPUUtilizations'
+
+const makeSnapshot = (overrides: Partial<GPUUtilizationSnapshot> = {}): GPUUtilizationSnapshot => ({
+  id: 'snap-1',
+  reservation_id: 'res-1',
+  timestamp: '2024-01-15T10:00:00Z',
+  gpu_utilization_pct: 50,
+  memory_utilization_pct: 30,
+  active_gpu_count: 1,
+  total_gpu_count: 4,
+  ...overrides,
+})
+
+describe('getUtilizationColor', () => {
+  it('returns green when utilization is at or above the high threshold', () => {
+    expect(getUtilizationColor(SPARKLINE_HIGH_UTIL_PCT)).toBe('#22c55e')
+    expect(getUtilizationColor(100)).toBe('#22c55e')
+  })
+
+  it('returns yellow when utilization is between low and high thresholds', () => {
+    expect(getUtilizationColor(SPARKLINE_LOW_UTIL_PCT)).toBe('#eab308')
+    expect(getUtilizationColor(50)).toBe('#eab308')
+  })
+
+  it('returns red when utilization is below the low threshold', () => {
+    expect(getUtilizationColor(0)).toBe('#ef4444')
+    expect(getUtilizationColor(SPARKLINE_LOW_UTIL_PCT - 1)).toBe('#ef4444')
+  })
+})
+
+describe('countActiveDays', () => {
+  it('returns 0 for an empty snapshot array', () => {
+    expect(countActiveDays([])).toBe(0)
+  })
+
+  it('returns 0 when no snapshots have active GPUs', () => {
+    const snapshots = [
+      makeSnapshot({ active_gpu_count: 0, timestamp: '2024-01-15T10:00:00Z' }),
+      makeSnapshot({ active_gpu_count: 0, timestamp: '2024-01-16T10:00:00Z' }),
+    ]
+    expect(countActiveDays(snapshots)).toBe(0)
+  })
+
+  it('counts unique calendar days with active GPUs', () => {
+    const snapshots = [
+      makeSnapshot({ active_gpu_count: 2, timestamp: '2024-01-15T08:00:00Z' }),
+      makeSnapshot({ active_gpu_count: 1, timestamp: '2024-01-15T14:00:00Z' }), // same day
+      makeSnapshot({ active_gpu_count: 3, timestamp: '2024-01-16T10:00:00Z' }),
+      makeSnapshot({ active_gpu_count: 0, timestamp: '2024-01-17T10:00:00Z' }), // inactive
+    ]
+    expect(countActiveDays(snapshots)).toBe(2)
+  })
+})
+
+describe('computeAvgUtilization', () => {
+  it('returns 0 for an empty snapshot array', () => {
+    expect(computeAvgUtilization([])).toBe(0)
+  })
+
+  it('returns the rounded average of gpu_utilization_pct', () => {
+    const snapshots = [
+      makeSnapshot({ gpu_utilization_pct: 10 }),
+      makeSnapshot({ gpu_utilization_pct: 20 }),
+      makeSnapshot({ gpu_utilization_pct: 30 }),
+    ]
+    expect(computeAvgUtilization(snapshots)).toBe(20)
+  })
+
+  it('rounds fractional averages', () => {
+    const snapshots = [
+      makeSnapshot({ gpu_utilization_pct: 10 }),
+      makeSnapshot({ gpu_utilization_pct: 11 }),
+    ]
+    // (10 + 11) / 2 = 10.5 → rounds to 11
+    expect(computeAvgUtilization(snapshots)).toBe(11)
+  })
+})


### PR DESCRIPTION
Fixes #21151

Adds unit tests for previously untested GPU component utilities and tab components:
- `gpu-constants.ts`: `getUtilizationColor`, `countActiveDays`, `computeAvgUtilization`
- `GPUCalendarTab`: month navigation, day rendering, add-reservation callbacks
- `GPUOverviewTab`: stats display, reservation list, sparklines, interactive selection
- `GPUDashboardTab`: card rendering, empty state, add card modal callbacks

> **Scope note:** The remaining untested GPU components (`GPUInventoryTab`, `GPUReservationsTab`, `ReservationFormModal`, `SortableGpuCard`) are deferred to a follow-up PR — this PR focuses on the four highest-priority components.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>