### PR TITLE
[scanner] 🐛 fix: repair functional test failures in card test suite

### DIFF
--- a/web/src/components/cards/ArcadeGames.test.tsx
+++ b/web/src/components/cards/ArcadeGames.test.tsx
@@ -39,7 +39,7 @@ vi.mock('../../lib/safeLocalStorage', () => ({
   safeGetItem: vi.fn(() => null),
   safeSet: vi.fn(),
   safeSetItem: vi.fn(),
-  safeGetJSON: vi.fn(() => null),
+  safeGetJSON: vi.fn((_key, fallback) => fallback),
   safeSetJSON: vi.fn(),
   safeRemove: vi.fn(),
 }))
@@ -47,7 +47,7 @@ vi.mock('../../lib/safeLocalStorage', () => ({
 vi.mock('@/lib/utils/localStorage', () => ({
   safeGetItem: vi.fn(() => null),
   safeSetItem: vi.fn(),
-  safeGetJSON: vi.fn(() => null),
+  safeGetJSON: vi.fn((_key, fallback) => fallback),
   safeSetJSON: vi.fn(),
 }))
 
@@ -71,9 +71,10 @@ describe('Checkers', () => {
   })
 
   it('displays checkers board', () => {
-    render(<Checkers />)
-    const board = document.querySelector('[role="grid"]')
-    expect(board || screen.getByText(/checkers|board/i)).toBeInTheDocument()
+    const { container } = render(<Checkers />)
+    // Board renders as 8 rows of divs inside an inline-block container
+    const boardContainer = container.querySelector('.inline-block')
+    expect(boardContainer).toBeInTheDocument()
   })
 
   it('shows score or game state', () => {

--- a/web/src/components/cards/ClusterGroups.test.tsx
+++ b/web/src/components/cards/ClusterGroups.test.tsx
@@ -104,9 +104,10 @@ describe('ClusterGroups', () => {
     expect(container.firstChild).toBeTruthy()
   })
 
-  it('renders empty state when no groups exist', () => {
+  it('renders built-in group when no user groups exist', () => {
     render(<ClusterGroups />)
-    expect(screen.getByText('noGroupsYet')).toBeInTheDocument()
+    // builtInGroup (all-healthy-clusters) is always included; noGroupsYet is never shown
+    expect(screen.getByText('all-healthy-clusters')).toBeInTheDocument()
   })
 
   it('renders demo data when shouldUseDemoData is true', () => {

--- a/web/src/components/cards/MaintenanceWindows.test.tsx
+++ b/web/src/components/cards/MaintenanceWindows.test.tsx
@@ -139,8 +139,12 @@ describe('MaintenanceWindows', () => {
       const clusterSelect = screen.getAllByRole('combobox')[0]
       await userEvent.selectOptions(clusterSelect, 'prod')
 
-      const startInput = screen.getAllByDisplayValue('')[0]
-      const endInput = screen.getAllByDisplayValue('')[1]
+      // Get datetime-local inputs specifically (description text input is at index [0])
+      const datetimeInputs = screen.getAllByDisplayValue('').filter(
+        el => (el as HTMLInputElement).type === 'datetime-local'
+      )
+      const startInput = datetimeInputs[0]
+      const endInput = datetimeInputs[1]
 
       // Use fireEvent.change for datetime-local inputs (userEvent.type has issues with these)
       fireEvent.change(startInput, { target: { value: getTwoHoursFromNow() } })

--- a/web/src/components/cards/ShooterGames.test.tsx
+++ b/web/src/components/cards/ShooterGames.test.tsx
@@ -91,7 +91,8 @@ describe('KubeGalaga', () => {
 
   it('shows score indicator', () => {
     render(<KubeGalaga />)
-    expect(screen.getByText(/score|level/i)).toBeInTheDocument()
+    // Stats bar shows level as "Lv.N"; no "score"/"level" labels, just the prefix
+    expect(screen.getByText(/Lv\./)).toBeInTheDocument()
   })
 })
 
@@ -114,7 +115,8 @@ describe('KubeKart', () => {
 
   it('shows game status', () => {
     render(<KubeKart />)
-    expect(screen.getByText(/race|time|lap/i)).toBeInTheDocument()
+    // Stats bar renders "Lap N/M"; use getAllByText since "Pod Racer" also matches /race/i
+    expect(screen.getAllByText(/race|time|lap/i)[0]).toBeInTheDocument()
   })
 })
 
@@ -137,7 +139,8 @@ describe('KubeKong', () => {
 
   it('shows score and level', () => {
     render(<KubeKong />)
-    expect(screen.getByText(/score|level/i)).toBeInTheDocument()
+    // Stats bar renders t('kubeKong.score') → "score" and t('kubeKong.level') → "level"
+    expect(screen.getAllByText(/score|level/i)[0]).toBeInTheDocument()
   })
 })
 
@@ -160,7 +163,8 @@ describe('KubeMan', () => {
 
   it('shows game metrics', () => {
     render(<KubeMan />)
-    expect(screen.getByText(/score|lives/i)).toBeInTheDocument()
+    // Stats bar renders "Score" and "Lives" labels; use getAllByText for multiple matches
+    expect(screen.getAllByText(/score|lives/i)[0]).toBeInTheDocument()
   })
 })
 
@@ -183,7 +187,8 @@ describe('KubePong', () => {
 
   it('shows score display', () => {
     render(<KubePong />)
-    expect(screen.getByText(/score|player/i)).toBeInTheDocument()
+    // Stats bar renders "{wins} wins" (e.g. "0 wins"); no "score"/"player" labels
+    expect(screen.getAllByText(/\d+ wins/i)[0]).toBeInTheDocument()
   })
 })
 
@@ -230,7 +235,8 @@ describe('MissileCommand', () => {
 
   it('shows game status', () => {
     render(<MissileCommand />)
-    expect(screen.getByText(/score|wave|city/i)).toBeInTheDocument()
+    // Stats bar renders "Score" and "Wave" labels; use getAllByText for multiple matches
+    expect(screen.getAllByText(/score|wave|city/i)[0]).toBeInTheDocument()
   })
 })
 
@@ -253,6 +259,7 @@ describe('NodeInvaders', () => {
 
   it('shows score and level', () => {
     render(<NodeInvaders />)
-    expect(screen.getByText(/score|level|wave/i)).toBeInTheDocument()
+    // Stats bar renders t('nodeInvaders.score') → "score", t('nodeInvaders.wave') → "wave"
+    expect(screen.getAllByText(/score|level|wave/i)[0]).toBeInTheDocument()
   })
 })

--- a/web/src/components/cards/__snapshots__/ACMMLevel.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/ACMMLevel.test.tsx.snap
@@ -1,0 +1,377 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ACMMLevel > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col p-4 gap-4 overflow-y-auto"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2"
+    >
+      <div
+        class="text-xs text-muted-foreground font-mono truncate"
+      >
+        kubestellar/console
+      </div>
+      <a
+        class="flex items-center gap-1 text-xs text-muted-foreground hover:text-primary transition-colors shrink-0 ml-2"
+        href="https://arxiv.org/abs/2604.09388"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-3 h-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+        Source
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-2 gap-4"
+    >
+      <div
+        class="relative shrink-0"
+      >
+        <svg
+          class="-rotate-90"
+          height="120"
+          width="120"
+        >
+          <circle
+            class="text-muted/30"
+            cx="60"
+            cy="60"
+            fill="none"
+            r="55"
+            stroke="currentColor"
+            stroke-width="10"
+          />
+          <circle
+            class="text-primary transition-all duration-500"
+            cx="60"
+            cy="60"
+            fill="none"
+            r="55"
+            stroke="currentColor"
+            stroke-dasharray="345.57519189487726"
+            stroke-dashoffset="230.38346126325152"
+            stroke-linecap="round"
+            stroke-width="10"
+          />
+        </svg>
+        <div
+          class="absolute inset-0 flex flex-col items-center justify-center"
+        >
+          <div
+            class="text-2xl font-bold leading-none"
+          >
+            L2
+          </div>
+          <div
+            class="text-xs text-muted-foreground uppercase tracking-wide mt-0.5 max-w-[90px] text-center leading-tight"
+          >
+            Adaptive
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="flex items-center gap-1 gap-1.5 mb-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-chart-column w-3.5 h-3.5 text-primary"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 3v16a2 2 0 0 0 2 2h16"
+            />
+            <path
+              d="M18 17V9"
+            />
+            <path
+              d="M13 17V5"
+            />
+            <path
+              d="M8 17v-3"
+            />
+          </svg>
+          <div
+            class="text-xs text-muted-foreground"
+          >
+            Role: 
+            <span
+              class="text-foreground font-medium"
+            >
+              Rule-writer
+            </span>
+          </div>
+        </div>
+        <p
+          class="text-xs leading-snug text-muted-foreground line-clamp-3"
+        >
+          Writes rules and adapts.
+        </p>
+      </div>
+    </div>
+    <div
+      class="flex items-center gap-2 px-2 py-1.5 rounded bg-muted/30 text-xs"
+    >
+      <span
+        class="text-muted-foreground"
+      >
+        Foundations:
+      </span>
+      <span
+        class="font-mono font-medium text-yellow-400"
+      >
+        2/3
+      </span>
+      <span
+        class="text-xs text-muted-foreground ml-auto"
+      >
+        prerequisites
+      </span>
+    </div>
+    <div
+      class="p-3 rounded-md bg-primary/5 border border-primary/10"
+    >
+      <div
+        class="text-xs text-primary uppercase tracking-wide mb-1"
+      >
+        Why move to L3?
+      </div>
+      <p
+        class="text-xs text-muted-foreground leading-relaxed italic mb-1.5"
+      >
+        When feedback loops are automated.
+      </p>
+      <p
+        class="text-xs text-foreground leading-relaxed"
+      >
+        At 
+        <span
+          class="font-mono"
+        >
+          L3 Proactive
+        </span>
+         you become an 
+        <span
+          class="font-medium"
+        >
+          Analyst
+        </span>
+         — analyses data.
+      </p>
+    </div>
+    <div
+      class="text-xs text-muted-foreground leading-relaxed space-y-1.5"
+    >
+      <div
+        class="text-xs uppercase tracking-wide text-foreground/70"
+      >
+        How to level up
+      </div>
+      <p>
+        Check the 
+        <span
+          class="text-foreground font-medium"
+        >
+          Feedback Loop Inventory
+        </span>
+         below for missing criteria at L3. Click 
+        <span
+          class="text-primary"
+        >
+          Ask agent for help
+        </span>
+         on any item to have an AI agent add it, or use the 
+        <span
+          class="text-primary"
+        >
+          Help me reach L3
+        </span>
+         button at the bottom to tackle them all at once.
+      </p>
+      <p
+        class="text-muted-foreground/70"
+      >
+        No agent? Add the files manually — each criterion shows the exact detection pattern to match.
+      </p>
+    </div>
+    <div
+      class="flex flex-col gap-1"
+    >
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors text-muted-foreground/70"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L1
+        </span>
+        <span
+          class="truncate"
+        >
+          Managed
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Executor
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors bg-primary/15 text-foreground font-semibold"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L2
+        </span>
+        <span
+          class="truncate"
+        >
+          Adaptive
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Rule-writer
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors text-muted-foreground/40"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L3
+        </span>
+        <span
+          class="truncate"
+        >
+          Proactive
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Analyst
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors text-muted-foreground/40"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L4
+        </span>
+        <span
+          class="truncate"
+        >
+          Governing
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Governor
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors text-muted-foreground/40"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L5
+        </span>
+        <span
+          class="truncate"
+        >
+          Operating
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Operator
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2 px-2 py-1 rounded text-xs transition-colors text-muted-foreground/40"
+      >
+        <span
+          class="font-mono w-5 text-right shrink-0"
+        >
+          L6
+        </span>
+        <span
+          class="truncate"
+        >
+          Strategic
+        </span>
+        <span
+          class="ml-auto text-xs truncate"
+        >
+          Strategist
+        </span>
+      </div>
+    </div>
+    <div
+      class="mt-auto pt-2 border-t border-border/50"
+    >
+      <div
+        class="flex flex-wrap items-center justify-between gap-y-2 text-xs mb-1"
+      >
+        <span
+          class="text-muted-foreground"
+        >
+          Progress to L3
+        </span>
+        <span
+          class="font-mono"
+        >
+          3/5
+        </span>
+      </div>
+      <div
+        class="h-1.5 bg-muted/30 rounded-full overflow-hidden"
+      >
+        <div
+          class="h-full bg-primary transition-all duration-500"
+          style="width: 60%;"
+        />
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/ControlPlaneHealth.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/ControlPlaneHealth.test.tsx.snap
@@ -1,0 +1,135 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ControlPlaneHealth > matches snapshot 1`] = `
+<div>
+  <div
+    class="space-y-2 p-1"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="w-2 h-2 rounded-full bg-green-500"
+        />
+        <span
+          class="text-sm font-medium"
+        >
+          API Server
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-3 text-xs text-muted-foreground"
+      >
+        <span>
+          1
+          /
+          1
+        </span>
+      </div>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="w-2 h-2 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="text-sm font-medium"
+        >
+          Scheduler
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-3 text-xs text-muted-foreground"
+      >
+        <span>
+          0
+          /
+          0
+        </span>
+      </div>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="w-2 h-2 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="text-sm font-medium"
+        >
+          Controller Mgr
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-3 text-xs text-muted-foreground"
+      >
+        <span>
+          0
+          /
+          0
+        </span>
+      </div>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="w-2 h-2 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="text-sm font-medium"
+        >
+          etcd
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-3 text-xs text-muted-foreground"
+      >
+        <span>
+          0
+          /
+          0
+        </span>
+      </div>
+    </div>
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-2 py-1.5 rounded-lg bg-muted/30 hover:bg-muted/50 transition-colors"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          class="w-2 h-2 rounded-full bg-muted-foreground/30"
+        />
+        <span
+          class="text-sm font-medium"
+        >
+          CoreDNS
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-3 text-xs text-muted-foreground"
+      >
+        <span>
+          0
+          /
+          0
+        </span>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/CrossClusterPolicyComparison.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/CrossClusterPolicyComparison.test.tsx.snap
@@ -1,0 +1,189 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`CrossClusterPolicyComparison > snapshot > matches snapshot for loaded policy table 1`] = `
+<div
+  class="space-y-2 p-1"
+>
+  <div
+    class="flex items-start gap-1.5 text-xs text-muted-foreground bg-secondary/20 rounded-md px-2 py-1.5"
+  >
+    <svg
+      aria-hidden="true"
+      class="lucide lucide-info w-3 h-3 shrink-0 mt-0.5 text-muted-foreground/60"
+      fill="none"
+      height="24"
+      stroke="currentColor"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      stroke-width="2"
+      viewBox="0 0 24 24"
+      width="24"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <circle
+        cx="12"
+        cy="12"
+        r="10"
+      />
+      <path
+        d="M12 16v-4"
+      />
+      <path
+        d="M12 8h.01"
+      />
+    </svg>
+    <span>
+      contextDescription
+    </span>
+  </div>
+  <div
+    class="flex flex-wrap items-center justify-between gap-y-2"
+  >
+    <div
+      class="ml-auto"
+    >
+      <div
+        data-testid="refresh-indicator"
+      />
+    </div>
+  </div>
+  <div
+    class="flex flex-wrap gap-1"
+  >
+    <button
+      class="px-2 py-0.5 rounded text-xs font-mono border transition-colors bg-blue-500/20 border-blue-500/40 text-blue-400"
+    >
+      prod
+    </button>
+  </div>
+  <div
+    class="overflow-x-auto"
+  >
+    <table
+      class="w-full text-xs"
+    >
+      <thead>
+        <tr
+          class="border-b border-border/50"
+        >
+          <th
+            class="text-left py-1 px-1 font-medium text-muted-foreground"
+          >
+            Policy
+          </th>
+          <th
+            class="text-center py-1 px-1 font-mono font-medium text-muted-foreground truncate max-w-[80px]"
+            title="prod"
+          >
+            prod
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          aria-label="View policy details: ClusterPolicy/no-privileged"
+          class="border-b border-border/20 cursor-pointer hover:bg-secondary/30 transition-colors "
+          role="button"
+          tabindex="0"
+        >
+          <td
+            class="py-1 px-1"
+          >
+            <span
+              class="font-mono truncate block max-w-[120px]"
+              title="ClusterPolicy/no-privileged"
+            >
+              no-privileged
+            </span>
+          </td>
+          <td
+            class="text-center py-1 px-1"
+          >
+            <span
+              class="inline-flex justify-center"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-circle-check w-3.5 h-3.5 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <path
+                  d="m9 12 2 2 4-4"
+                />
+              </svg>
+            </span>
+          </td>
+        </tr>
+        <tr
+          aria-label="View policy details: ClusterPolicy/require-labels"
+          class="border-b border-border/20 cursor-pointer hover:bg-secondary/30 transition-colors "
+          role="button"
+          tabindex="0"
+        >
+          <td
+            class="py-1 px-1"
+          >
+            <span
+              class="font-mono truncate block max-w-[120px]"
+              title="ClusterPolicy/require-labels"
+            >
+              require-labels
+            </span>
+          </td>
+          <td
+            class="text-center py-1 px-1"
+          >
+            <span
+              class="inline-flex justify-center"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-circle-check w-3.5 h-3.5 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <path
+                  d="m9 12 2 2 4-4"
+                />
+              </svg>
+            </span>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+  <div
+    class="text-xs text-muted-foreground border-t border-border/50 pt-1"
+  >
+    2
+     policies across 
+    1
+     clusters
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/DrasiPipelineHealth.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DrasiPipelineHealth.test.tsx.snap
@@ -1,0 +1,148 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DrasiPipelineHealth > matches snapshot for healthy state 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Drasi Pipeline Health"
+    class="h-full flex flex-col min-h-card"
+    role="region"
+  >
+    <div
+      class="p-3 rounded-lg bg-green-500/10 border border-green-500/20 mb-3 flex items-center gap-3"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-check-big w-8 h-8 text-green-400"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21.801 10A10 10 0 1 1 17 3.335"
+        />
+        <path
+          d="m9 11 3 3L22 4"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-lg font-bold text-green-400"
+        >
+          Healthy
+        </p>
+        <p
+          class="text-xs text-muted-foreground"
+        >
+          1 pipeline · 2/2 sources · 3/3 queries · 1/1 reactions
+        </p>
+      </div>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto space-y-2"
+    >
+      <div
+        class="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+      >
+        <div
+          class="flex items-center justify-between mb-1.5"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-circle-check-big w-4 h-4 text-green-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21.801 10A10 10 0 1 1 17 3.335"
+              />
+              <path
+                d="m9 11 3 3L22 4"
+              />
+            </svg>
+            <span
+              class="text-sm font-medium text-foreground truncate"
+            >
+              pipeline-alpha
+            </span>
+            <span
+              class="px-1.5 py-0.5 rounded text-2xs bg-green-500/10 text-green-400"
+            >
+              Healthy
+            </span>
+          </div>
+          <span
+            class="text-xs text-muted-foreground"
+          >
+            99.9% uptime
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-4"
+        >
+          <div
+            class="text-center"
+          >
+            <p
+              class="text-2xs text-muted-foreground"
+            >
+              Sources
+            </p>
+            <p
+              aria-label="2 of 2 Sources healthy"
+              class="text-sm font-medium text-green-400"
+            >
+              2/2
+            </p>
+          </div>
+          <div
+            class="text-center"
+          >
+            <p
+              class="text-2xs text-muted-foreground"
+            >
+              Queries
+            </p>
+            <p
+              aria-label="3 of 3 Queries healthy"
+              class="text-sm font-medium text-green-400"
+            >
+              3/3
+            </p>
+          </div>
+          <div
+            class="text-center"
+          >
+            <p
+              class="text-2xs text-muted-foreground"
+            >
+              Reactions
+            </p>
+            <p
+              aria-label="1 of 1 Reactions healthy"
+              class="text-sm font-medium text-green-400"
+            >
+              1/1
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/DrasiPipelines.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DrasiPipelines.test.tsx.snap
@@ -1,0 +1,131 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DrasiPipelines > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col min-h-card"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-2 shrink-0"
+    >
+      <span
+        class="text-sm font-medium text-muted-foreground"
+      >
+        1 pipeline
+      </span>
+      <div
+        data-testid="card-controls"
+      />
+    </div>
+    <input
+      data-testid="card-search"
+      placeholder="Search pipelines..."
+      value=""
+    />
+    <div
+      class="grid grid-cols-3 gap-2 mb-3"
+    >
+      <div
+        class="p-2 rounded-lg bg-green-500/10 border border-green-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-green-400"
+        >
+          Running
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          1
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-yellow-400"
+        >
+          Stopped
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          0
+        </p>
+      </div>
+      <div
+        class="p-2 rounded-lg bg-red-500/10 border border-red-500/20 text-center"
+      >
+        <p
+          class="text-2xs text-red-400"
+        >
+          Error
+        </p>
+        <p
+          class="text-lg font-bold text-foreground"
+        >
+          0
+        </p>
+      </div>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto space-y-2"
+    >
+      <div
+        class="p-2.5 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors"
+      >
+        <div
+          class="flex flex-wrap items-center justify-between gap-y-1 mb-1"
+        >
+          <div
+            class="flex items-center gap-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-activity w-4 h-4 text-green-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M22 12h-2.48a2 2 0 0 0-1.93 1.46l-2.35 8.36a.25.25 0 0 1-.48 0L9.24 2.18a.25.25 0 0 0-.48 0l-2.35 8.36A2 2 0 0 1 4.49 12H2"
+              />
+            </svg>
+            <span
+              class="text-sm font-medium text-foreground truncate"
+            >
+              pipeline-alpha
+            </span>
+            <span
+              class="px-1.5 py-0.5 rounded text-2xs bg-green-500/10 text-green-400"
+            >
+              Running
+            </span>
+          </div>
+          <span
+            class="text-2xs text-muted-foreground/60"
+          >
+            1m ago
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-4 text-xs text-muted-foreground"
+        >
+          <span>
+            3 queries
+          </span>
+          <span>
+            2 reactions
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/DrasiTopology.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/DrasiTopology.test.tsx.snap
@@ -1,0 +1,308 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DrasiTopology > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    aria-label="Drasi Topology"
+    class="h-full flex flex-col min-h-card"
+    role="region"
+  >
+    <div
+      class="flex items-center gap-4 mb-3 text-xs text-muted-foreground"
+    >
+      <span>
+        2 connections
+      </span>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto"
+    >
+      <div
+        class="grid grid-cols-[1fr_auto_1fr_auto_1fr] gap-2 items-start"
+      >
+        <div
+          class="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20"
+        >
+          <div
+            class="flex items-center gap-2 mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-database w-4 h-4 text-blue-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <ellipse
+                cx="12"
+                cy="5"
+                rx="9"
+                ry="3"
+              />
+              <path
+                d="M3 5V19A9 3 0 0 0 21 19V5"
+              />
+              <path
+                d="M3 12A9 3 0 0 0 21 12"
+              />
+            </svg>
+            <span
+              class="text-sm font-medium text-blue-400"
+            >
+              Sources
+            </span>
+            <span
+              class="text-xs text-muted-foreground ml-auto"
+            >
+              1
+            </span>
+          </div>
+          <div
+            class="space-y-1"
+          >
+            <div
+              class="flex items-center gap-2 text-xs"
+            >
+              <svg
+                aria-label="Ready"
+                class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21.801 10A10 10 0 1 1 17 3.335"
+                />
+                <path
+                  d="m9 11 3 3L22 4"
+                />
+              </svg>
+              <span
+                class="text-foreground truncate flex-1"
+              >
+                db-source
+              </span>
+              <span
+                class="text-muted-foreground/60 text-2xs"
+              >
+                PostgreSQL
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex items-center justify-center h-full pt-8"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-right w-5 h-5 text-muted-foreground/40"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 12h14"
+            />
+            <path
+              d="m12 5 7 7-7 7"
+            />
+          </svg>
+        </div>
+        <div
+          class="p-3 rounded-lg bg-purple-500/10 border border-purple-500/20"
+        >
+          <div
+            class="flex items-center gap-2 mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-search w-4 h-4 text-purple-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="m21 21-4.34-4.34"
+              />
+              <circle
+                cx="11"
+                cy="11"
+                r="8"
+              />
+            </svg>
+            <span
+              class="text-sm font-medium text-purple-400"
+            >
+              Queries
+            </span>
+            <span
+              class="text-xs text-muted-foreground ml-auto"
+            >
+              1
+            </span>
+          </div>
+          <div
+            class="space-y-1"
+          >
+            <div
+              class="flex items-center gap-2 text-xs"
+            >
+              <svg
+                aria-label="Ready"
+                class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21.801 10A10 10 0 1 1 17 3.335"
+                />
+                <path
+                  d="m9 11 3 3L22 4"
+                />
+              </svg>
+              <span
+                class="text-foreground truncate flex-1"
+              >
+                customer-query
+              </span>
+              <span
+                class="text-muted-foreground/60 text-2xs"
+              >
+                ContinuousQuery
+              </span>
+            </div>
+          </div>
+        </div>
+        <div
+          class="flex items-center justify-center h-full pt-8"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-right w-5 h-5 text-muted-foreground/40"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 12h14"
+            />
+            <path
+              d="m12 5 7 7-7 7"
+            />
+          </svg>
+        </div>
+        <div
+          class="p-3 rounded-lg bg-amber-500/10 border border-amber-500/20"
+        >
+          <div
+            class="flex items-center gap-2 mb-2"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-zap w-4 h-4 text-amber-400"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z"
+              />
+            </svg>
+            <span
+              class="text-sm font-medium text-amber-400"
+            >
+              Reactions
+            </span>
+            <span
+              class="text-xs text-muted-foreground ml-auto"
+            >
+              1
+            </span>
+          </div>
+          <div
+            class="space-y-1"
+          >
+            <div
+              class="flex items-center gap-2 text-xs"
+            >
+              <svg
+                aria-label="Ready"
+                class="lucide lucide-circle-check-big w-3 h-3 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21.801 10A10 10 0 1 1 17 3.335"
+                />
+                <path
+                  d="m9 11 3 3L22 4"
+                />
+              </svg>
+              <span
+                class="text-foreground truncate flex-1"
+              >
+                event-sink
+              </span>
+              <span
+                class="text-muted-foreground/60 text-2xs"
+              >
+                EventGrid
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/GitHubActivityItems.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/GitHubActivityItems.test.tsx.snap
@@ -1,0 +1,386 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ContributorItem > matches snapshot 1`] = `
+<DocumentFragment>
+  <a
+    class="block p-3 rounded-lg bg-secondary/20 hover:bg-secondary/40 border border-border/50 transition-colors"
+    href="https://github.com/top-dev"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="flex items-center gap-3"
+    >
+      <img
+        alt="top-dev"
+        class="w-10 h-10 rounded-full"
+        height="40"
+        loading="lazy"
+        width="40"
+      />
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="text-sm font-medium"
+        >
+          top-dev
+        </div>
+        <div
+          class="text-xs text-muted-foreground"
+        >
+          123 contributions
+        </div>
+      </div>
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-trending-up w-4 h-4 text-green-400"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16 7h6v6"
+        />
+        <path
+          d="m22 7-8.5 8.5-5-5L2 17"
+        />
+      </svg>
+    </div>
+  </a>
+</DocumentFragment>
+`;
+
+exports[`IssueItem > matches snapshot 1`] = `
+<DocumentFragment>
+  <a
+    class="block p-3 rounded-lg hover:bg-secondary/40 border transition-colors bg-orange-500/5 border-orange-500/20 hover:border-orange-500/30"
+    href="https://github.com/org/repo/issues/100"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="flex items-start gap-3"
+    >
+      <div
+        class="mt-0.5"
+        title="openIssue"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-alert w-4 h-4 text-orange-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="8"
+            y2="12"
+          />
+          <line
+            x1="12"
+            x2="12.01"
+            y1="16"
+            y2="16"
+          />
+        </svg>
+      </div>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="flex items-center gap-2 mb-1"
+        >
+          <span
+            class="text-sm font-medium truncate"
+          >
+            #100 bug: Something is broken
+          </span>
+          <span
+            class="text-xs px-2 py-0.5 rounded shrink-0 bg-orange-500/20 text-orange-400"
+          >
+            open
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-3 text-xs text-muted-foreground"
+        >
+          <span
+            class="flex items-center gap-1"
+          >
+            <img
+              alt="reporter"
+              class="w-4 h-4 rounded-full"
+              height="16"
+              loading="lazy"
+              width="16"
+            />
+            reporter
+          </span>
+          <span
+            class="flex items-center gap-1"
+            title="Updated 2h ago"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-clock w-3 h-3"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+              />
+              <path
+                d="M12 6v6l4 2"
+              />
+            </svg>
+            2h ago
+          </span>
+          <span
+            title="5 comments"
+          >
+            5 comments
+          </span>
+        </div>
+      </div>
+    </div>
+  </a>
+</DocumentFragment>
+`;
+
+exports[`PRItem > matches snapshot for open PR 1`] = `
+<DocumentFragment>
+  <a
+    class="block p-3 rounded-lg hover:bg-secondary/40 border transition-colors bg-green-500/5 border-green-500/20 hover:border-green-500/30"
+    href="https://github.com/org/repo/pull/42"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="flex items-start gap-3"
+    >
+      <div
+        class="mt-0.5"
+        title="openPR"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-git-pull-request w-4 h-4 text-green-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="18"
+            cy="18"
+            r="3"
+          />
+          <circle
+            cx="6"
+            cy="6"
+            r="3"
+          />
+          <path
+            d="M13 6h3a2 2 0 0 1 2 2v7"
+          />
+          <line
+            x1="6"
+            x2="6"
+            y1="9"
+            y2="21"
+          />
+        </svg>
+      </div>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="flex items-center gap-2 mb-1"
+        >
+          <span
+            class="text-sm font-medium truncate"
+          >
+            #42 feat: Add great feature
+          </span>
+          <span
+            class="text-xs px-2 py-0.5 rounded shrink-0 bg-green-500/20 text-green-400"
+          >
+            open
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-3 text-xs text-muted-foreground"
+        >
+          <span
+            class="flex items-center gap-1"
+          >
+            <img
+              alt="dev"
+              class="w-4 h-4 rounded-full"
+              height="16"
+              loading="lazy"
+              width="16"
+            />
+            dev
+          </span>
+          <span
+            class="flex items-center gap-1"
+            title="Updated 2h ago"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-clock w-3 h-3"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+              />
+              <path
+                d="M12 6v6l4 2"
+              />
+            </svg>
+            2h ago
+          </span>
+        </div>
+      </div>
+    </div>
+  </a>
+</DocumentFragment>
+`;
+
+exports[`ReleaseItem > matches snapshot 1`] = `
+<DocumentFragment>
+  <a
+    class="block p-3 rounded-lg bg-secondary/20 hover:bg-secondary/40 border border-border/50 transition-colors"
+    href="https://github.com/org/repo/releases/tag/v1.2.3"
+    rel="noopener noreferrer"
+    target="_blank"
+  >
+    <div
+      class="flex items-start gap-3"
+    >
+      <div
+        class="mt-0.5"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-package w-4 h-4 text-blue-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M11 21.73a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73z"
+          />
+          <path
+            d="M12 22V12"
+          />
+          <polyline
+            points="3.29 7 12 12 20.71 7"
+          />
+          <path
+            d="m7.5 4.27 9 5.15"
+          />
+        </svg>
+      </div>
+      <div
+        class="flex-1 min-w-0"
+      >
+        <div
+          class="flex items-center gap-2 mb-1"
+        >
+          <span
+            class="text-sm font-medium"
+          >
+            v1.2.3 Release
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-3 text-xs text-muted-foreground"
+        >
+          <span>
+            release-bot
+          </span>
+          <span
+            class="flex items-center gap-1"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-clock w-3 h-3"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <circle
+                cx="12"
+                cy="12"
+                r="10"
+              />
+              <path
+                d="M12 6v6l4 2"
+              />
+            </svg>
+            2h ago
+          </span>
+        </div>
+      </div>
+    </div>
+  </a>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/HelmHistory.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/HelmHistory.test.tsx.snap
@@ -1,0 +1,51 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`HelmHistory > snapshot > matches snapshot for selector-only state 1`] = `
+<div
+  class="h-full flex flex-col min-h-card content-loaded overflow-hidden"
+>
+  <div
+    class="flex flex-wrap items-center justify-between gap-y-2 mb-4"
+  >
+    <div
+      class="flex items-center gap-2"
+    />
+    <div
+      data-testid="card-controls"
+    />
+  </div>
+  <div
+    class="flex gap-2 mb-4"
+  >
+    <select
+      class="flex-1 px-3 py-1.5 rounded-lg bg-secondary border border-border text-sm text-foreground"
+    >
+      <option
+        value=""
+      >
+        selectCluster
+      </option>
+      <option
+        value="prod"
+      >
+        prod
+      </option>
+    </select>
+    <select
+      class="flex-1 px-3 py-1.5 rounded-lg bg-secondary border border-border text-sm text-foreground disabled:opacity-50"
+      disabled=""
+    >
+      <option
+        value=""
+      >
+        selectRelease
+      </option>
+    </select>
+  </div>
+  <div
+    class="flex-1 flex items-center justify-center text-muted-foreground text-sm"
+  >
+    selectClusterRelease
+  </div>
+</div>
+`;

--- a/web/src/components/cards/__snapshots__/IframeEmbed.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/IframeEmbed.test.tsx.snap
@@ -1,0 +1,235 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IframeEmbed > matches snapshot with no config 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col"
+  >
+    <div
+      class="h-full flex flex-col"
+    >
+      <div
+        class="flex flex-wrap items-center justify-between gap-y-2 mb-2"
+      >
+        <div
+          class="flex items-center gap-2 min-w-0"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-globe w-4 h-4 text-muted-foreground shrink-0"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="M12 2a14.5 14.5 0 0 0 0 20 14.5 14.5 0 0 0 0-20"
+            />
+            <path
+              d="M2 12h20"
+            />
+          </svg>
+          <span
+            class="text-xs text-muted-foreground"
+          >
+            configureUrl
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1"
+        >
+          <button
+            aria-expanded="true"
+            aria-label="settings"
+            class="p-1 rounded transition-colors bg-primary/20 text-primary"
+            title="settings"
+          >
+            <svg
+              aria-hidden="true"
+              class="lucide lucide-settings w-4 h-4"
+              fill="none"
+              height="24"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.671 4.136a2.34 2.34 0 0 1 4.659 0 2.34 2.34 0 0 0 3.319 1.915 2.34 2.34 0 0 1 2.33 4.033 2.34 2.34 0 0 0 0 3.831 2.34 2.34 0 0 1-2.33 4.033 2.34 2.34 0 0 0-3.319 1.915 2.34 2.34 0 0 1-4.659 0 2.34 2.34 0 0 0-3.32-1.915 2.34 2.34 0 0 1-2.33-4.033 2.34 2.34 0 0 0 0-3.831A2.34 2.34 0 0 1 6.35 6.051a2.34 2.34 0 0 0 3.319-1.915"
+              />
+              <circle
+                cx="12"
+                cy="12"
+                r="3"
+              />
+            </svg>
+          </button>
+        </div>
+      </div>
+      <div
+        class="mb-3 p-3 rounded-lg bg-secondary/30 border border-border/50"
+      >
+        <div
+          class="flex flex-wrap items-center justify-between gap-y-2 mb-3"
+        >
+          <span
+            class="text-sm font-medium"
+          >
+            embedConfiguration
+          </span>
+        </div>
+        <div
+          class="space-y-3"
+        >
+          <div>
+            <label
+              class="text-xs text-muted-foreground block mb-1"
+            >
+              urlLabel
+            </label>
+            <input
+              class="w-full px-3 py-1.5 text-sm bg-background border border-border rounded focus:outline-hidden focus:ring-1 focus:ring-primary"
+              placeholder="https://grafana.example.com/d/dashboard"
+              type="url"
+              value=""
+            />
+          </div>
+          <div>
+            <label
+              class="text-xs text-muted-foreground block mb-1"
+            >
+              titleLabel
+            </label>
+            <input
+              class="w-full px-3 py-1.5 text-sm bg-background border border-border rounded focus:outline-hidden focus:ring-1 focus:ring-primary"
+              placeholder="titlePlaceholder"
+              type="text"
+              value=""
+            />
+          </div>
+          <div
+            class="grid grid-cols-2 gap-3"
+          >
+            <div>
+              <label
+                class="text-xs text-muted-foreground block mb-1"
+              >
+                autoRefreshLabel
+              </label>
+              <input
+                class="w-full px-3 py-1.5 text-sm bg-background border border-border rounded focus:outline-hidden focus:ring-1 focus:ring-primary"
+                max="3600"
+                min="0"
+                placeholder="0 = disabled"
+                type="number"
+                value="0"
+              />
+            </div>
+            <div>
+              <label
+                class="text-xs text-muted-foreground block mb-1"
+              >
+                heightLabel
+              </label>
+              <input
+                class="w-full px-3 py-1.5 text-sm bg-background border border-border rounded focus:outline-hidden focus:ring-1 focus:ring-primary"
+                max="1000"
+                min="200"
+                type="number"
+                value="400"
+              />
+            </div>
+          </div>
+          <div>
+            <label
+              class="text-xs text-muted-foreground block mb-1"
+            >
+              quickPresets
+            </label>
+            <div
+              class="flex flex-wrap gap-1"
+            >
+              <button
+                class="px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary transition-colors"
+              >
+                📊 Grafana
+              </button>
+              <button
+                class="px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary transition-colors"
+              >
+                🔥 Prometheus
+              </button>
+              <button
+                class="px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary transition-colors"
+              >
+                📈 Kibana
+              </button>
+              <button
+                class="px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary transition-colors"
+              >
+                🔄 ArgoCD
+              </button>
+              <button
+                class="px-2 py-1 text-xs rounded bg-secondary/50 hover:bg-secondary transition-colors"
+              >
+                🔍 Jaeger
+              </button>
+            </div>
+          </div>
+          <div
+            class="flex gap-2 pt-2"
+          >
+            <button
+              class="flex-1 flex items-center justify-center gap-1 px-3 py-1.5 text-sm bg-primary text-primary-foreground rounded hover:bg-primary/90 disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled=""
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-save w-4 h-4"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M15.2 3a2 2 0 0 1 1.4.6l3.8 3.8a2 2 0 0 1 .6 1.4V19a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2z"
+                />
+                <path
+                  d="M17 21v-7a1 1 0 0 0-1-1H8a1 1 0 0 0-1 1v7"
+                />
+                <path
+                  d="M7 3v4a1 1 0 0 0 1 1h7"
+                />
+              </svg>
+              saveAndLoad
+            </button>
+          </div>
+        </div>
+        <p
+          class="text-xs text-muted-foreground mt-3"
+        >
+          iframeNote
+        </p>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/IssueActivityChart.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/IssueActivityChart.test.tsx.snap
@@ -1,0 +1,184 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`IssueActivityChart > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="p-4 space-y-3"
+  >
+    <div
+      class="flex flex-wrap @lg:flex-nowrap items-center justify-between gap-2"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-calendar h-4 w-4 text-muted-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M8 2v4"
+          />
+          <path
+            d="M16 2v4"
+          />
+          <rect
+            height="18"
+            rx="2"
+            width="18"
+            x="3"
+            y="4"
+          />
+          <path
+            d="M3 10h18"
+          />
+        </svg>
+        <span
+          data-testid="repo-subtitle"
+        >
+          kubestellar/console
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-1"
+      >
+        <button>
+          30d
+        </button>
+        <button>
+          60d
+        </button>
+        <button>
+          90d
+        </button>
+        <button>
+          180d
+        </button>
+        <button>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-refresh-cw h-3 w-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 12a9 9 0 0 1 9-9 9.75 9.75 0 0 1 6.74 2.74L21 8"
+            />
+            <path
+              d="M21 3v5h-5"
+            />
+            <path
+              d="M21 12a9 9 0 0 1-9 9 9.75 9.75 0 0 1-6.74-2.74L3 16"
+            />
+            <path
+              d="M8 16H3v5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      class="grid grid-cols-2 @md:grid-cols-3 gap-3"
+    >
+      <div
+        class="rounded-md bg-blue-500/10 border border-blue-500/20 px-3 py-2 text-center"
+      >
+        <div
+          class="text-lg font-semibold text-blue-400"
+        >
+          0
+        </div>
+        <div
+          class="text-xs text-muted-foreground uppercase tracking-wide"
+        >
+          opened
+        </div>
+      </div>
+      <div
+        class="rounded-md bg-green-500/10 border border-green-500/20 px-3 py-2 text-center"
+      >
+        <div
+          class="text-lg font-semibold text-green-400"
+        >
+          0
+        </div>
+        <div
+          class="text-xs text-muted-foreground uppercase tracking-wide"
+        >
+          closed
+        </div>
+      </div>
+      <div
+        class="rounded-md bg-orange-500/10 border border-orange-500/20 px-3 py-2 text-center"
+      >
+        <div
+          class="text-lg font-semibold text-orange-400"
+        >
+          0
+        </div>
+        <div
+          class="text-xs text-muted-foreground uppercase tracking-wide flex items-center justify-center gap-1"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-git-pull-request h-3 w-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="18"
+              cy="18"
+              r="3"
+            />
+            <circle
+              cx="6"
+              cy="6"
+              r="3"
+            />
+            <path
+              d="M13 6h3a2 2 0 0 1 2 2v7"
+            />
+            <line
+              x1="6"
+              x2="6"
+              y1="9"
+              y2="21"
+            />
+          </svg>
+          merged
+        </div>
+      </div>
+    </div>
+    <div
+      class="w-full overflow-hidden"
+      style="min-width: 0px;"
+    >
+      <div
+        data-testid="echarts"
+      />
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KagentAgentListCard.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KagentAgentListCard.test.tsx.snap
@@ -1,0 +1,295 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KagentAgentListCard > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="space-y-3 p-1"
+  >
+    <div
+      class="grid grid-cols-3 gap-2"
+    >
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-blue-500/20 text-blue-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-bot w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 8V4H8"
+            />
+            <rect
+              height="12"
+              rx="2"
+              width="16"
+              x="4"
+              y="8"
+            />
+            <path
+              d="M2 14h2"
+            />
+            <path
+              d="M20 14h2"
+            />
+            <path
+              d="M15 13v2"
+            />
+            <path
+              d="M9 13v2"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            2
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            totalAgents
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-green-500/20 text-green-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="m9 12 2 2 4-4"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            2
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            ready
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-yellow-500/20 text-yellow-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-triangle-alert w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+            />
+            <path
+              d="M12 9v4"
+            />
+            <path
+              d="M12 17h.01"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            0
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            issues
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-1 flex items-center justify-between"
+    >
+      <div
+        class="text-xs uppercase tracking-wider text-muted-foreground"
+      >
+        overallHealth
+      </div>
+      <span
+        class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border bg-green-500/15 text-green-400 border-green-500/20"
+      >
+        100% healthy
+      </span>
+    </div>
+    <div
+      class="px-1"
+    >
+      <div
+        class="text-xs uppercase tracking-wider text-muted-foreground mb-1.5"
+      >
+        agentsByCluster
+      </div>
+      <div
+        class="space-y-1"
+      >
+        <div
+          class="px-2 py-1.5 rounded-lg bg-muted/20 border border-border/40"
+        >
+          <div
+            class="flex items-center justify-between mb-1"
+          >
+            <div
+              class="text-sm font-medium text-foreground"
+            >
+              prod
+            </div>
+            <span
+              class="inline-flex items-center px-2 py-0.5 text-xs font-medium rounded border bg-green-500/15 text-green-400 border-green-500/20"
+            >
+              100% healthy
+            </span>
+          </div>
+          <div
+            class="flex items-center gap-3 text-xs text-muted-foreground"
+          >
+            <span
+              class="flex items-center gap-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-circle-check w-3 h-3 text-green-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <circle
+                  cx="12"
+                  cy="12"
+                  r="10"
+                />
+                <path
+                  d="m9 12 2 2 4-4"
+                />
+              </svg>
+              2 ready
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-1"
+    >
+      <div
+        class="text-xs uppercase tracking-wider text-muted-foreground mb-1.5"
+      >
+        recentAgents
+      </div>
+      <div
+        class="space-y-1"
+      >
+        <div
+          class="flex items-center gap-2 px-2 py-1.5 rounded-lg hover:bg-secondary/50 transition-colors"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-circle-check w-3.5 h-3.5 text-green-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+            />
+            <path
+              d="m9 12 2 2 4-4"
+            />
+          </svg>
+          <div
+            class="min-w-0 flex-1"
+          >
+            <div
+              class="text-sm font-medium truncate"
+            >
+              agent-1
+            </div>
+            <div
+              class="text-xs text-muted-foreground"
+            >
+              prod / default
+            </div>
+          </div>
+          <div
+            class="text-xs text-muted-foreground"
+          >
+            2/2
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KagentStatusCard.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KagentStatusCard.test.tsx.snap
@@ -1,0 +1,326 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KagentStatusCard > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="space-y-3 p-1"
+  >
+    <div
+      class="grid grid-cols-2 @md:grid-cols-3 gap-2"
+    >
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-blue-500/20 text-blue-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-bot w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 8V4H8"
+            />
+            <rect
+              height="12"
+              rx="2"
+              width="16"
+              x="4"
+              y="8"
+            />
+            <path
+              d="M2 14h2"
+            />
+            <path
+              d="M20 14h2"
+            />
+            <path
+              d="M15 13v2"
+            />
+            <path
+              d="M9 13v2"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            1
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            agents
+          </div>
+          <div
+            class="text-xs text-muted-foreground"
+          >
+            1
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-cyan-500/20 text-cyan-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-wrench w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.106-3.105c.32-.322.863-.22.983.218a6 6 0 0 1-8.259 7.057l-7.91 7.91a1 1 0 0 1-2.999-3l7.91-7.91a6 6 0 0 1 7.057-8.259c.438.12.54.662.219.984z"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            1
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            toolServers
+          </div>
+          <div
+            class="text-xs text-muted-foreground"
+          >
+            2
+          </div>
+        </div>
+      </div>
+      <div
+        class="flex items-center gap-2 px-3 py-2 rounded-lg bg-muted/30 border border-border/50"
+      >
+        <div
+          class="p-1.5 rounded-md bg-emerald-500/20 text-emerald-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-cpu w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 20v2"
+            />
+            <path
+              d="M12 2v2"
+            />
+            <path
+              d="M17 20v2"
+            />
+            <path
+              d="M17 2v2"
+            />
+            <path
+              d="M2 12h2"
+            />
+            <path
+              d="M2 17h2"
+            />
+            <path
+              d="M2 7h2"
+            />
+            <path
+              d="M20 12h2"
+            />
+            <path
+              d="M20 17h2"
+            />
+            <path
+              d="M20 7h2"
+            />
+            <path
+              d="M7 20v2"
+            />
+            <path
+              d="M7 2v2"
+            />
+            <rect
+              height="16"
+              rx="2"
+              width="16"
+              x="4"
+              y="4"
+            />
+            <rect
+              height="8"
+              rx="1"
+              width="8"
+              x="8"
+              y="8"
+            />
+          </svg>
+        </div>
+        <div
+          class="min-w-0"
+        >
+          <div
+            class="text-lg font-semibold leading-tight"
+          >
+            1
+          </div>
+          <div
+            class="text-xs text-muted-foreground truncate"
+          >
+            modelConfigs
+          </div>
+          <div
+            class="text-xs text-muted-foreground"
+          >
+            1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-1"
+    >
+      <div
+        class="text-xs uppercase tracking-wider text-muted-foreground mb-1.5"
+      >
+        runtimes
+      </div>
+      <div
+        class="space-y-1"
+      >
+        <div
+          class="flex items-center gap-2"
+        >
+          <div
+            class="text-sm text-muted-foreground w-20 truncate"
+          >
+            openai
+          </div>
+          <div
+            class="flex-1 h-1.5 rounded-full bg-muted/30 overflow-hidden"
+          >
+            <div
+              class="h-full rounded-full bg-blue-500/60"
+              style="width: 100%;"
+            />
+          </div>
+          <div
+            class="text-sm text-muted-foreground w-6 text-right"
+          >
+            1
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="px-1"
+    >
+      <div
+        class="text-xs uppercase tracking-wider text-muted-foreground mb-1.5"
+      >
+        clusters
+      </div>
+      <div
+        class="space-y-1"
+      >
+        <div
+          class="flex items-center gap-2 text-sm"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-server w-3.5 h-3.5 text-muted-foreground/40"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="8"
+              rx="2"
+              ry="2"
+              width="20"
+              x="2"
+              y="2"
+            />
+            <rect
+              height="8"
+              rx="2"
+              ry="2"
+              width="20"
+              x="2"
+              y="14"
+            />
+            <line
+              x1="6"
+              x2="6.01"
+              y1="6"
+              y2="6"
+            />
+            <line
+              x1="6"
+              x2="6.01"
+              y1="18"
+              y2="18"
+            />
+          </svg>
+          <span
+            class="text-muted-foreground truncate flex-1"
+          >
+            prod
+          </span>
+          <span
+            class="text-blue-400"
+          >
+            1
+          </span>
+          <span
+            class="text-cyan-400"
+          >
+            1
+          </span>
+          <span
+            class="text-emerald-400"
+          >
+            1
+          </span>
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KubeBert.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubeBert.test.tsx.snap
@@ -1,0 +1,285 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KubeBert > matches snapshot of start screen 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 px-3 py-1.5 bg-black/30 rounded-t-lg text-xs"
+    >
+      <div
+        class="flex items-center gap-3"
+      >
+        <span
+          class="flex items-center gap-1 text-yellow-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-trophy w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"
+            />
+            <path
+              d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"
+            />
+            <path
+              d="M18 9h1.5a1 1 0 0 0 0-5H18"
+            />
+            <path
+              d="M4 22h16"
+            />
+            <path
+              d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"
+            />
+            <path
+              d="M6 9H4.5a1 1 0 0 1 0-5H6"
+            />
+          </svg>
+          0
+        </span>
+        <span
+          class="text-blue-400"
+        >
+          Lvl 1
+        </span>
+        <span
+          class="flex items-center gap-1 text-red-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart w-3 h-3 fill-red-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart w-3 h-3 fill-red-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5"
+            />
+          </svg>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-heart w-3 h-3 fill-red-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5"
+            />
+          </svg>
+        </span>
+      </div>
+      <span
+        class="text-muted-foreground"
+      >
+        Best: 0
+      </span>
+    </div>
+    <div
+      class="flex-1 relative"
+    >
+      <canvas
+        height="150"
+        style="width: 100%; height: 320px; display: block;"
+        width="0"
+      />
+      <div
+        class="absolute inset-0 flex flex-col items-center justify-center bg-black/60 rounded-b-lg"
+      >
+        <div
+          class="text-2xl font-bold text-yellow-400 mb-1"
+        >
+          Kube Bert
+        </div>
+        <p
+          class="text-xs text-muted-foreground mb-3 text-center px-4"
+        >
+          Hop on every tile to change its color!
+          <br />
+          Avoid enemies and don't fall off!
+        </p>
+        <button
+          class="flex items-center gap-2 px-4 py-2 bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 rounded-lg text-sm font-medium transition-colors"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-play w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M5 5a2 2 0 0 1 3.008-1.728l11.997 6.998a2 2 0 0 1 .003 3.458l-12 7A2 2 0 0 1 5 19z"
+            />
+          </svg>
+           Start Game
+        </button>
+      </div>
+    </div>
+    <div
+      class="flex items-center justify-center gap-1 py-1.5 bg-black/20"
+    >
+      <div
+        class="grid grid-cols-2 gap-1"
+      >
+        <button
+          class="p-1.5 rounded bg-black/10 hover:bg-black/20 active:bg-black/30 dark:bg-white/10 dark:hover:bg-white/20 dark:active:bg-white/30 transition-colors"
+          title="Up-Left (↑)"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-up w-4 h-4 text-blue-400 -rotate-45"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m5 12 7-7 7 7"
+            />
+            <path
+              d="M12 19V5"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded bg-black/10 hover:bg-black/20 active:bg-black/30 dark:bg-white/10 dark:hover:bg-white/20 dark:active:bg-white/30 transition-colors"
+          title="Up-Right (→)"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-up w-4 h-4 text-blue-400 rotate-45"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="m5 12 7-7 7 7"
+            />
+            <path
+              d="M12 19V5"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded bg-black/10 hover:bg-black/20 active:bg-black/30 dark:bg-white/10 dark:hover:bg-white/20 dark:active:bg-white/30 transition-colors"
+          title="Down-Left (←)"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-down w-4 h-4 text-orange-400 -rotate-45"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 5v14"
+            />
+            <path
+              d="m19 12-7 7-7-7"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded bg-black/10 hover:bg-black/20 active:bg-black/30 dark:bg-white/10 dark:hover:bg-white/20 dark:active:bg-white/30 transition-colors"
+          title="Down-Right (↓)"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-arrow-down w-4 h-4 text-orange-400 rotate-45"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 5v14"
+            />
+            <path
+              d="m19 12-7 7-7-7"
+            />
+          </svg>
+        </button>
+      </div>
+      <div
+        class="ml-3 text-xs text-muted-foreground leading-tight"
+      >
+        <div>
+          ↑ up-left   → up-right
+        </div>
+        <div>
+          ← down-left   ↓ down-right
+        </div>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KubecostOverview.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubecostOverview.test.tsx.snap
@@ -1,0 +1,538 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KubecostOverview > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded"
+  >
+    <div
+      class="flex items-center justify-end gap-1 mb-3"
+    >
+      <a
+        class="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-purple-400"
+        href="https://www.kubecost.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Kubecost Website"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-4 h-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+    <div
+      class="flex items-start gap-2 p-2 mb-3 rounded-lg bg-green-500/10 border border-green-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-green-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-green-400 font-medium"
+        >
+          Kubecost Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install Kubecost for detailed cost allocation and optimization recommendations. 
+          <a
+            class="text-purple-400 hover:underline inline-block py-2"
+            href="https://docs.kubecost.com/install-and-configure/install/first-time-user-guide"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <div
+      class="grid grid-cols-2 gap-2 mb-3"
+    >
+      <div
+        class="p-3 rounded-lg bg-linear-to-r from-green-500/20 to-green-500/20 border border-green-500/30"
+      >
+        <p
+          class="text-xs text-green-400 mb-1"
+        >
+          monthlyCost
+        </p>
+        <p
+          class="text-xl font-bold text-foreground"
+        >
+          $12,450
+        </p>
+      </div>
+      <div
+        class="p-3 rounded-lg bg-linear-to-r from-purple-500/20 to-purple-500/20 border border-purple-500/30"
+      >
+        <div
+          class="flex items-center gap-1 mb-1"
+        >
+          <p
+            class="text-xs text-purple-400"
+          >
+            Efficiency
+          </p>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-chart-pie w-3 h-3 text-purple-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 12c.552 0 1.005-.449.95-.998a10 10 0 0 0-8.953-8.951c-.55-.055-.998.398-.998.95v8a1 1 0 0 0 1 1z"
+            />
+            <path
+              d="M21.21 15.89A10 10 0 1 1 8 2.83"
+            />
+          </svg>
+        </div>
+        <p
+          class="text-xl font-bold text-foreground"
+        >
+          72%
+        </p>
+      </div>
+    </div>
+    <div
+      class="mb-3"
+    >
+      <p
+        class="text-xs text-muted-foreground font-medium mb-2"
+      >
+        Cost Breakdown
+      </p>
+      <div
+        class="h-3 rounded-full overflow-hidden flex"
+      >
+        <div
+          class="bg-blue-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 42%;"
+          title="CPU: $5200"
+        />
+        <div
+          class="bg-green-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 25%;"
+          title="Memory: $3100"
+        />
+        <div
+          class="bg-purple-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 15%;"
+          title="Storage: $1850"
+        />
+        <div
+          class="bg-yellow-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 11%;"
+          title="GPU: $1410"
+        />
+        <div
+          class="bg-cyan-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 7%;"
+          title="Network: $890"
+        />
+      </div>
+      <div
+        class="flex flex-wrap gap-x-3 gap-y-1 mt-2"
+      >
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-blue-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            CPU: $5200
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-green-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Memory: $3100
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-purple-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Storage: $1850
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-yellow-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            GPU: $1410
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-cyan-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Network: $890
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto"
+    >
+      <div
+        class="flex flex-wrap items-center justify-between gap-y-2 mb-2"
+      >
+        <p
+          class="text-xs text-muted-foreground font-medium"
+        >
+          savingsRecommendations
+        </p>
+        <span
+          class="flex items-center gap-1 text-xs text-green-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-trending-down w-3 h-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16 17h6v-6"
+            />
+            <path
+              d="m22 17-8.5-8.5-5 5L2 7"
+            />
+          </svg>
+          $2340/mo potential
+        </span>
+      </div>
+      <div
+        class="space-y-2"
+      >
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Rightsize 12 over-provisioned workloads
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$890
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Remove 3 idle workloads
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$450
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Use spot instances for batch jobs
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$1000
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-3 pt-2 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground"
+    >
+      <span>
+        poweredBy
+      </span>
+      <a
+        class="flex items-center gap-1 text-purple-400 hover:text-purple-300 transition-colors"
+        href="https://docs.kubecost.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <span>
+          docs
+        </span>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-3 h-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/Kubectl.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/Kubectl.test.tsx.snap
@@ -1,0 +1,345 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Kubectl > matches snapshot with clusters 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col min-h-card overflow-hidden"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-4 gap-2 min-w-0"
+    >
+      <div
+        class="flex items-center gap-2 min-w-0 flex-1"
+      >
+        <select
+          class="text-xs bg-secondary border border-border/50 rounded px-2 py-1 text-foreground max-w-[150px] truncate"
+          title="selectCluster"
+        >
+          <option
+            value=""
+          >
+            selectCluster
+          </option>
+          <option
+            value="prod"
+          >
+            prod
+          </option>
+        </select>
+      </div>
+      <div
+        class="flex items-center gap-1"
+      >
+        <button
+          class="p-1.5 rounded-lg transition-colors text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+          title="aiAssist"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-sparkles w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+            />
+            <path
+              d="M20 2v4"
+            />
+            <path
+              d="M22 4h-4"
+            />
+            <circle
+              cx="4"
+              cy="20"
+              r="2"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded-lg transition-colors text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+          title="yamlEditor"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-file-code w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+            />
+            <path
+              d="M14 2v5a1 1 0 0 0 1 1h5"
+            />
+            <path
+              d="M10 12.5 8 15l2 2.5"
+            />
+            <path
+              d="m14 12.5 2 2.5-2 2.5"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded-lg transition-colors text-muted-foreground hover:bg-secondary/50 hover:text-foreground"
+          title="history"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-history w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"
+            />
+            <path
+              d="M3 3v5h5"
+            />
+            <path
+              d="M12 7v5l4 2"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1.5 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
+          title="clearOutput"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-trash2 lucide-trash-2 w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M10 11v6"
+            />
+            <path
+              d="M14 11v6"
+            />
+            <path
+              d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6"
+            />
+            <path
+              d="M3 6h18"
+            />
+            <path
+              d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <div
+      class="flex-1 font-mono text-xs bg-black/30 rounded-lg p-3 overflow-y-auto mb-3 min-h-0"
+    >
+      <div
+        class="text-muted-foreground/50 whitespace-pre"
+      >
+        <p>
+          terminalReady
+        </p>
+        <p
+          class="mt-2"
+        >
+          examples
+        </p>
+        <p
+          class="ml-4"
+        >
+            exampleGetPods
+        </p>
+        <p
+          class="ml-4"
+        >
+            exampleGetDeployments
+        </p>
+        <p
+          class="ml-4"
+        >
+            exampleDescribePod
+        </p>
+        <p
+          class="ml-4"
+        >
+            exampleLogs
+        </p>
+      </div>
+    </div>
+    <div
+      class="flex gap-2"
+    >
+      <div
+        class="flex-1 flex items-center gap-2 bg-secondary/50 rounded-lg px-3 py-2 border border-border/30 focus-within:border-green-500/50"
+      >
+        <span
+          class="text-green-400 text-sm font-semibold"
+        >
+          $
+        </span>
+        <input
+          class="flex-1 bg-transparent text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden disabled:opacity-50"
+          placeholder="Enter kubectl command (without 'kubectl' prefix)"
+          type="text"
+          value=""
+        />
+        <div
+          class="flex items-center gap-1"
+        >
+          <div
+            class="relative"
+          >
+            <button
+              class="p-1 rounded text-muted-foreground hover:text-foreground"
+              title="Output format: table"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-down w-3.5 h-3.5"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m6 9 6 6 6-6"
+                />
+              </svg>
+            </button>
+          </div>
+          <button
+            class="px-2 py-1 text-2xs rounded text-muted-foreground hover:bg-secondary"
+            title="Toggle dry-run mode"
+          >
+            run
+          </button>
+        </div>
+      </div>
+      <button
+        class="px-4 py-2 rounded-lg bg-green-500/20 hover:bg-green-500/30 text-green-400 disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center gap-2"
+        disabled=""
+        title="Execute command (or press Enter)"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-send w-4 h-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z"
+          />
+          <path
+            d="m21.854 2.147-10.94 10.939"
+          />
+        </svg>
+        <span
+          class="text-sm"
+        >
+          run
+        </span>
+      </button>
+    </div>
+    <div
+      class="mt-3 pt-3 border-t border-border/50 flex flex-wrap gap-2"
+    >
+      <span
+        class="text-xs text-muted-foreground"
+      >
+        quickCommands:
+      </span>
+      <button
+        class="px-2 py-1 text-2xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground"
+      >
+        listPods
+      </button>
+      <button
+        class="px-2 py-1 text-2xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground"
+      >
+        deployments
+      </button>
+      <button
+        class="px-2 py-1 text-2xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground"
+      >
+        services
+      </button>
+      <button
+        class="px-2 py-1 text-2xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground"
+      >
+        nodes
+      </button>
+      <button
+        class="px-2 py-1 text-2xs rounded bg-secondary/50 hover:bg-secondary text-muted-foreground hover:text-foreground disabled:opacity-50"
+        disabled=""
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-copy w-3 h-3 inline mr-1"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            height="14"
+            rx="2"
+            ry="2"
+            width="14"
+            x="8"
+            y="8"
+          />
+          <path
+            d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+          />
+        </svg>
+        copyOutput
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KubectlAIPanel.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubectlAIPanel.test.tsx.snap
@@ -1,0 +1,67 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AIAssistantPanel > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="mb-4 p-3 bg-purple-500/10 border border-purple-500/20 rounded-lg"
+  >
+    <div
+      class="flex items-center gap-2 mb-2"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-sparkles w-4 h-4 text-purple-400"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M11.017 2.814a1 1 0 0 1 1.966 0l1.051 5.558a2 2 0 0 0 1.594 1.594l5.558 1.051a1 1 0 0 1 0 1.966l-5.558 1.051a2 2 0 0 0-1.594 1.594l-1.051 5.558a1 1 0 0 1-1.966 0l-1.051-5.558a2 2 0 0 0-1.594-1.594l-5.558-1.051a1 1 0 0 1 0-1.966l5.558-1.051a2 2 0 0 0 1.594-1.594z"
+        />
+        <path
+          d="M20 2v4"
+        />
+        <path
+          d="M22 4h-4"
+        />
+        <circle
+          cx="4"
+          cy="20"
+          r="2"
+        />
+      </svg>
+      <span
+        class="text-sm font-medium text-purple-300"
+      >
+        aiAssist
+      </span>
+    </div>
+    <input
+      class="w-full px-3 py-2 text-sm bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-purple-500/50"
+      placeholder="e.g., Create a deployment for nginx with 3 replicas"
+      type="text"
+      value=""
+    />
+    <div
+      class="flex gap-2 mt-2"
+    >
+      <button
+        disabled=""
+      >
+        generateCommand
+      </button>
+      <button
+        disabled=""
+      >
+        generateYAML
+      </button>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/KubectlYAMLEditorPanel.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubectlYAMLEditorPanel.test.tsx.snap
@@ -1,0 +1,223 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`YAMLEditorPanel > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="mb-4 p-3 bg-blue-500/10 border border-blue-500/20 rounded-lg"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-2"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-file-code w-4 h-4 text-blue-400"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+          />
+          <path
+            d="M14 2v5a1 1 0 0 0 1 1h5"
+          />
+          <path
+            d="M10 12.5 8 15l2 2.5"
+          />
+          <path
+            d="m14 12.5 2 2.5-2 2.5"
+          />
+        </svg>
+        <span
+          class="text-sm font-medium text-blue-300"
+        >
+          yamlEditor
+        </span>
+      </div>
+      <div
+        class="flex items-center gap-2"
+      >
+        <button
+          class="px-2 py-1 text-xs rounded bg-secondary text-muted-foreground"
+          title="dryRunDisabled"
+        >
+          dryRun
+        </button>
+        <button
+          class="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground disabled:opacity-50"
+          title="copyYaml"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-copy w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              height="14"
+              rx="2"
+              ry="2"
+              width="14"
+              x="8"
+              y="8"
+            />
+            <path
+              d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"
+            />
+          </svg>
+        </button>
+        <button
+          class="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground disabled:opacity-50"
+          title="downloadYaml"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-download w-3.5 h-3.5"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M12 15V3"
+            />
+            <path
+              d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"
+            />
+            <path
+              d="m7 10 5 5 5-5"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+    <textarea
+      class="w-full h-40 px-3 py-2 text-xs font-mono bg-black/30 rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-blue-500/50 resize-none"
+      placeholder="yamlPlaceholder"
+    >
+      apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: test
+    </textarea>
+    <div
+      class="flex items-center gap-2 mt-2 text-xs text-green-400"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-check-big w-3.5 h-3.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M21.801 10A10 10 0 1 1 17 3.335"
+        />
+        <path
+          d="m9 11 3 3L22 4"
+        />
+      </svg>
+      validYaml
+    </div>
+    <div
+      class="flex gap-2 mt-2"
+    >
+      <button>
+        apply
+      </button>
+      <button>
+        clear
+      </button>
+    </div>
+    <div
+      class="mt-3 pt-3 border-t border-border/30"
+    >
+      <div
+        class="flex items-center gap-2 mb-2"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-file-text w-3.5 h-3.5 text-muted-foreground"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 22a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h8a2.4 2.4 0 0 1 1.704.706l3.588 3.588A2.4 2.4 0 0 1 20 8v12a2 2 0 0 1-2 2z"
+          />
+          <path
+            d="M14 2v5a1 1 0 0 0 1 1h5"
+          />
+          <path
+            d="M10 9H8"
+          />
+          <path
+            d="M16 13H8"
+          />
+          <path
+            d="M16 17H8"
+          />
+        </svg>
+        <span
+          class="text-xs text-muted-foreground"
+        >
+          savedManifests
+        </span>
+      </div>
+      <div
+        class="space-y-1"
+      >
+        <button
+          class="w-full px-2 py-1.5 text-xs rounded text-left hover:bg-secondary/50 text-muted-foreground"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <span>
+              my-deployment
+            </span>
+            <span
+              class="text-2xs"
+            >
+              5:00:00 AM
+            </span>
+          </div>
+        </button>
+      </div>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/ProviderHealth.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/ProviderHealth.test.tsx.snap
@@ -1,0 +1,110 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ProviderHealth > snapshot > matches snapshot for mixed AI and cloud providers 1`] = `
+<div
+  class="h-full min-h-0 overflow-y-auto pr-1"
+>
+  <div
+    class="space-y-4"
+  >
+    <div>
+      <h3
+        class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2"
+      >
+        aiProviders
+      </h3>
+      <div
+        class="space-y-0.5"
+      >
+        <div
+          class="@container flex flex-wrap items-start gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-secondary/30 @lg:flex-nowrap @lg:items-center"
+          style="container-type: inline-size;"
+        >
+          <div
+            class="shrink-0 pt-0.5 @lg:pt-0"
+          >
+            <span
+              data-provider="openai"
+              data-testid="agent-icon"
+            />
+          </div>
+          <div
+            class="min-w-0 flex-1 basis-[10rem]"
+          >
+            <div
+              class="text-sm font-medium text-foreground truncate"
+            >
+              OpenAI
+            </div>
+          </div>
+          <div
+            class="ml-auto flex flex-wrap items-center justify-end gap-1.5"
+          >
+            <div
+              class="flex flex-wrap items-center justify-end gap-1.5 shrink-0"
+            >
+              <div
+                class="w-2 h-2 rounded-full bg-green-500"
+              />
+              <span
+                class="text-xs text-muted-foreground"
+              >
+                operational
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div>
+      <h3
+        class="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-2"
+      >
+        cloudProviders
+      </h3>
+      <div
+        class="space-y-0.5"
+      >
+        <div
+          class="@container flex flex-wrap items-start gap-2 rounded-lg px-1 py-2 transition-colors hover:bg-secondary/30 @lg:flex-nowrap @lg:items-center"
+          style="container-type: inline-size;"
+        >
+          <div
+            class="shrink-0 pt-0.5 @lg:pt-0"
+          >
+            <span
+              data-provider="aws"
+              data-testid="cloud-provider-icon"
+            />
+          </div>
+          <div
+            class="min-w-0 flex-1 basis-[10rem]"
+          >
+            <div
+              class="text-sm font-medium text-foreground truncate"
+            >
+              AWS
+            </div>
+          </div>
+          <div
+            class="ml-auto flex flex-wrap items-center justify-end gap-1.5"
+          >
+            <div
+              class="flex flex-wrap items-center justify-end gap-1.5 shrink-0"
+            >
+              <div
+                class="w-2 h-2 rounded-full bg-yellow-500"
+              />
+              <span
+                class="text-xs text-muted-foreground"
+              >
+                degraded
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;


### PR DESCRIPTION
Fixes #21169

Repairs the functional (non-snapshot) test failures that contributed to the 45 failures in Coverage Suite run #4294, and commits the missing snapshot files.

### Root causes & fixes

**ArcadeGames / Checkers (4 failures)**
- `safeGetJSON` mock returned `null` instead of the fallback, causing `TypeError: Cannot read properties of null (reading 'wins')` on `highScore.wins`. Mock updated to `vi.fn((_key, fallback) => fallback)`.
- `displays checkers board` fell back to `getByText(/checkers|board/i)` which matched every i18n key starting with `checkers.`. Replaced with a `.inline-block` container query.

**ClusterGroups (1 failure)**
- Component always includes a built-in `all-healthy-clusters` group so `groups.length === 0` is never true and `noGroupsYet` is never rendered. Test updated to assert the built-in group is shown instead.

**MaintenanceWindows (1 failure)**
- `getAllByDisplayValue('')[0/1]` targeted the description text input and startTime input respectively (after cluster select was filled). Replaced with a `.filter(el => el.type === 'datetime-local')` so startInput/endInput are correct, allowing the end-before-start validation to trigger.

**ShooterGames (7 failures)**
- `KubeGalaga`: stats bar shows `Lv.N` prefix, not "level" text → assert `/Lv\./`.
- `KubeKart`: "Pod Racer" kart name matches `/race/i` → `getAllByText[0]`.
- `KubeKong / KubeMan / MissileCommand / NodeInvaders`: labels appear in both the stats bar and game-over overlay → `getAllByText[0]`.
- `KubePong`: "First to 7 wins!" also matches `/\d+ wins/i` → `getAllByText[0]`.

### Snapshot files committed
18 snapshot files that existed locally but were not yet tracked by git are added, ensuring the Coverage Suite does not fail on first-run snapshot creation races.