### PR TITLE
[scanner] 🐛 fix: repair unit-test failures from nightly regression

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -32,7 +32,11 @@ env:
   TOTAL_SHARDS: 12
 
 jobs:
-  # Run tests in 12 shards to stay within 7GB runner memory
+  # Run tests in 12 shards to stay within 7GB runner memory.
+  # NODE_OPTIONS is capped at 5120 MB (5 GB) to leave ~2 GB headroom for
+  # OS, V8 off-heap memory, and npm/Node overhead on the ubuntu-latest
+  # 7 GB runner. Setting it to ≥7 GB causes OOM kills from the kernel
+  # rather than a graceful V8 heap exhaustion (#21169, #21083).
   test-shard:
     if: github.repository == 'kubestellar/console'
     runs-on: ubuntu-latest
@@ -62,7 +66,7 @@ jobs:
         id: test
         working-directory: web
         env:
-          NODE_OPTIONS: '--max-old-space-size=7168'
+          NODE_OPTIONS: '--max-old-space-size=5120'
         run: |
           npx vitest run --coverage --coverage.reportOnFailure \
             --reporter=verbose --reporter=json \

--- a/scripts/unit-test.sh
+++ b/scripts/unit-test.sh
@@ -37,6 +37,10 @@ echo "Running Vitest unit tests..."
 # headroom: 3.5 GB worker + 1.5 GB system/V8 overhead + 2 GB safety margin.
 # Previous 1792 MB limit caused "Worker exited unexpectedly" OOM crashes (#20007).
 # Increased to 3584 MB (3.5 GB) to prevent nightly regressions.
+# The test suite has since grown past 560 files; the nightly runner OOMs with
+# 4 shards when a single shard accumulates too many heavy test files in one
+# batch. Increasing to 8 shards halves per-shard test count and peak memory
+# while keeping the sequential run within the 180m nightly timeout (#21083).
 if [ -n "${CI:-}" ]; then
   export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=3584"
 fi
@@ -50,20 +54,20 @@ fi
 # vite.config correctly limited to 1 for CI memory constraints (#20007).
 #
 # In CI, run tests in shards to reduce parent process memory footprint. With
-# 2100+ test files, the Vitest parent process accumulates results in memory
+# 560+ test files, the Vitest parent process accumulates results in memory
 # for final reporting, causing OOM on 7GB runners even with 1 worker (#20007).
-# Running 4 shards sequentially reduces peak memory by ~75%.
+# Running 8 shards sequentially reduces peak memory by ~87.5% vs single run.
 OUTPUT_FILE="vitest-output.log"
 EXIT_CODE=0
 
 if [ -n "${CI:-}" ]; then
-  # CI: run in 4 shards sequentially, combining output
-  echo "Running tests in 4 shards to prevent OOM..."
+  # CI: run in 8 shards sequentially, combining output
+  echo "Running tests in 8 shards to prevent OOM..."
   > "$OUTPUT_FILE"  # Clear file
-  for shard in 1 2 3 4; do
+  for shard in 1 2 3 4 5 6 7 8; do
     echo ""
-    echo "=== Shard $shard/4 ==="
-    npx vitest run $EXTRA_ARGS --pool=forks --testTimeout=30000 --reporter=verbose --shard=$shard/4 2>&1 | tee -a "$OUTPUT_FILE" || EXIT_CODE=$?
+    echo "=== Shard $shard/8 ==="
+    npx vitest run $EXTRA_ARGS --pool=forks --testTimeout=30000 --reporter=verbose --shard=$shard/8 2>&1 | tee -a "$OUTPUT_FILE" || EXIT_CODE=$?
   done
 else
   # Local: run all tests at once


### PR DESCRIPTION
Fixes #21169
Fixes #21083

## Root Cause

Both issues are **OOM crashes in CI runners**, not test logic failures. Every failing shard in Coverage Suite run #4294 logged `"Shard N exited with code 1 (possible OOM)"` — the test that happened to be running when the kernel OOM-killed the Node process was reported as "failed".

## Changes

### `.github/workflows/coverage-hourly.yml`
Reduce `NODE_OPTIONS --max-old-space-size` from **7168 MB to 5120 MB**.

Setting 7168 MB (≈7 GB) on an `ubuntu-latest` 7 GB runner leaves ~0 MB for the OS (~500 MB), V8 off-heap JIT/C++ objects (~1–2 GB), and npm overhead. The kernel's OOM killer terminates the Node process and reports whichever test was in-flight as failed (45 spurious failures, #21169).

5120 MB leaves ~2 GB headroom, which matches V8's typical off-heap overhead.

### `scripts/unit-test.sh`
Increase CI shard count from **4 to 8**.

The test suite has grown past 560 files. A single 4-shard batch now accumulates enough module cache to exceed the 3584 MB heap limit, causing "Worker exited unexpectedly" OOM crashes in the nightly runner (#21083). Halving per-shard test count keeps peak memory well within budget while adding only ~15 min to the sequential nightly run (well under the 60 min per-suite cap and the 180 min nightly timeout).
