### PR TITLE
[scanner] 🐛 fix: repair 12 test failures blocking coverage suite

### DIFF
--- a/web/src/components/feedback/DraftsTab.test.tsx
+++ b/web/src/components/feedback/DraftsTab.test.tsx
@@ -37,7 +37,8 @@ describe('DraftsTab', () => {
       />
     )
 
-    expect(screen.getByText(/drafts\.savedDrafts/i)).toBeInTheDocument()
+    // t('drafts.savedDrafts', 'Saved Drafts') returns the default value when provided
+    expect(screen.getByText(/Saved Drafts/i)).toBeInTheDocument()
     expect(screen.getByText(/Improve touch targets/)).toBeInTheDocument()
   })
 })

--- a/web/src/components/gpu/__tests__/GPUDashboardTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUDashboardTab.test.tsx
@@ -13,7 +13,7 @@ vi.mock('../../../hooks/useMCP', () => ({
   })),
 }))
 
-vi.mock('./SortableGpuCard', () => ({
+vi.mock('../SortableGpuCard', () => ({
   SortableGpuCard: ({ card }: { card: GpuDashCard }) => (
     <div data-testid="sortable-card" data-type={card.type} />
   ),

--- a/web/src/components/gpu/__tests__/GPUOverviewTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUOverviewTab.test.tsx
@@ -87,10 +87,12 @@ function renderTab(overrides: Partial<GPUOverviewTabProps> = {}) {
 
 describe('GPUOverviewTab', () => {
   it('displays the key headline stat numbers', () => {
-    renderTab({ stats: makeStats({ totalGPUs: 8, availableGPUs: 3, activeReservations: 5, reservedGPUs: 5 }) })
+    // Use distinct values for all stats to avoid multiple-match errors with getByText
+    renderTab({ stats: makeStats({ totalGPUs: 8, availableGPUs: 3, activeReservations: 5, reservedGPUs: 6 }) })
     expect(screen.getByText('8')).toBeTruthy()
     expect(screen.getByText('3')).toBeTruthy()
     expect(screen.getByText('5')).toBeTruthy()
+    expect(screen.getByText('6')).toBeTruthy()
   })
 
   it('shows the utilization percentage in the donut gauge', () => {
@@ -142,7 +144,8 @@ describe('GPUOverviewTab', () => {
   it('shows "no usage data yet" when utilizations is null for a reservation', () => {
     const reservations = [makeReservation()]
     renderTab({ filteredReservations: reservations, utilizations: null })
-    expect(screen.getByText('gpuReservations.utilization.noData')).toBeTruthy()
+    // t('gpuReservations.utilization.noData', 'No usage data yet') returns the default value
+    expect(screen.getByText('No usage data yet')).toBeTruthy()
   })
 
   it('calls onSelectReservation when an interactive reservation is clicked', () => {

--- a/web/src/components/stellar/ScheduleActionForm.tsx
+++ b/web/src/components/stellar/ScheduleActionForm.tsx
@@ -25,7 +25,7 @@ export function ScheduleActionForm() {
         {Object.entries(ACTION_CONFIGS).map(([key, cfg]) => <option key={key} value={key}>{cfg.label}</option>)}
       </select>
       {(ACTION_CONFIGS[actionType]?.params || []).map(param => (
-        <input key={param.name} type={param.type} value={values[param.name] || ''} onChange={(e) => setValues(prev => ({ ...prev, [param.name]: e.target.value }))} placeholder={param.label} />
+        <input key={param.name} type={param.type} value={values[param.name] || ''} onChange={(e) => setValues(prev => ({ ...prev, [param.name]: e.target.value }))} placeholder={param.placeholder ?? param.label} />
       ))}
       <button
         onClick={() => {

--- a/web/src/components/stellar/WatchCard.test.tsx
+++ b/web/src/components/stellar/WatchCard.test.tsx
@@ -35,7 +35,8 @@ describe('WatchCard', () => {
         onSnooze={vi.fn()}
       />
     )
-    expect(screen.getByText('api-server')).toBeInTheDocument()
+    // namespace and name are rendered together as "namespace/name"
+    expect(screen.getByText('default/api-server')).toBeInTheDocument()
   })
 
   it('renders the namespace', () => {
@@ -47,7 +48,8 @@ describe('WatchCard', () => {
         onSnooze={vi.fn()}
       />
     )
-    expect(screen.getByText('default')).toBeInTheDocument()
+    // namespace is rendered as part of "namespace/name"
+    expect(screen.getByText('default/api-server')).toBeInTheDocument()
   })
 
   it('renders the resource kind', () => {
@@ -59,7 +61,8 @@ describe('WatchCard', () => {
         onSnooze={vi.fn()}
       />
     )
-    expect(screen.getByText('Deployment')).toBeInTheDocument()
+    // kind is rendered as part of "kind · cluster"
+    expect(screen.getByText('Deployment · prod')).toBeInTheDocument()
   })
 
   it('renders the watch reason', () => {


### PR DESCRIPTION
Fixes #21179

Repairs the 8 remaining test failures from Coverage Suite run #4295 (the 4 snapshot tests already pass on current `main`).

## Root causes & fixes

| Test | Root cause | Fix |
|------|-----------|-----|
| WatchCard × 3 | Namespace and name rendered as `ns/name` combined; kind rendered as `kind · cluster`. Tests used exact-match on individual tokens. | Update assertions to match actual DOM text (`'default/api-server'`, `'Deployment · prod'`). |
| DraftsTab | `t('drafts.savedDrafts', 'Saved Drafts')` — mock returns the *default* string when one is provided, not the key. Test expected the key. | Assert on `'Saved Drafts'` instead. |
| GPUDashboardTab | `vi.mock('./SortableGpuCard')` was relative to `__tests__/` subdir, so it mocked a non-existent module instead of the one the component imports. | Change to `vi.mock('../SortableGpuCard')`. |
| GPUOverviewTab 'stats' | `activeReservations` and `reservedGPUs` both set to 5 → `getByText('5')` found multiple elements and threw. | Use distinct values (reservedGPUs: 6). |
| GPUOverviewTab 'no data' | `t('key', 'No usage data yet')` returns the default string; test expected the raw key. | Assert on `'No usage data yet'`. |
| ScheduleActionForm | Input used `param.label` as placeholder even when an explicit `param.placeholder` was configured. Test expected `'payments'` (the placeholder), component rendered `'Namespace'` (the label). | Use `param.placeholder ?? param.label` in the component. |