### PR TITLE
[scanner] 🐛 fix: regenerate snapshots for 2 failing card tests

### DIFF
--- a/web/src/components/cards/__snapshots__/KubectlHistoryPanel.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubectlHistoryPanel.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`CommandHistoryPanel > matches snapshot with history 1`] = `
           <span
             class="text-2xs text-muted-foreground ml-2 shrink-0"
           >
-            5:00:00 AM
+            10:00:00 AM
           </span>
         </div>
         <div

--- a/web/src/components/cards/__snapshots__/KubectlYAMLEditorPanel.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubectlYAMLEditorPanel.test.tsx.snap
@@ -212,7 +212,7 @@ metadata:
             <span
               class="text-2xs"
             >
-              5:00:00 AM
+              10:00:00 AM
             </span>
           </div>
         </button>


### PR DESCRIPTION
Fixes #21186

Regenerates outdated snapshots for KubectlHistoryPanel and KubectlYAMLEditorPanel following recent component changes (follow-up to #21185).

Root cause: both snapshots contain a timezone-dependent `toLocaleTimeString()` value (`5:00:00 AM`) generated on a UTC-5 machine, but CI runs in UTC where `new Date('2026-01-01T10:00:00Z').toLocaleTimeString()` returns `10:00:00 AM`. Updated both snapshots to the UTC value.