### PR TITLE
[scanner] fix: eliminate UI flicker patterns

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect } from 'react'
+import { useState, useMemo, useEffect, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Calendar,
@@ -441,6 +441,45 @@ export function GPUReservations() {
     }
   }
 
+  // Named callbacks for multi-state transitions — keeps JSX clean and ensures
+  // the paired state updates are always applied atomically (React 19 batches
+  // all setState calls within the same synchronous function).
+  const openCreateForm = useCallback(() => {
+    setEditingReservation(null)
+    setShowReservationForm(true)
+  }, [])
+
+  const openEditForm = useCallback((r: GPUReservation) => {
+    setEditingReservation(r)
+    setShowReservationForm(true)
+  }, [])
+
+  const closeReservationForm = useCallback(() => {
+    setShowReservationForm(false)
+    setEditingReservation(null)
+    setPrefillDate(null)
+  }, [])
+
+  const openCreateFormForDate = useCallback((dateStr: string) => {
+    setPrefillDate(dateStr)
+    setEditingReservation(null)
+    setShowReservationForm(true)
+  }, [])
+
+  const goToReservation = useCallback((id: string) => {
+    setExpandedReservationId(id)
+    setActiveTab('quotas')
+  }, [])
+
+  const toggleShowOnlyMine = useCallback(() => {
+    setShowOnlyMine(prev => {
+      // Navigate to reservations tab when the filter is being switched on so
+      // users immediately see the filtered list.
+      if (!prev) setActiveTab('quotas')
+      return !prev
+    })
+  }, [])
+
   const deleteConfirmReservation = deleteConfirmId
     ? allReservations.find(r => r.id === deleteConfirmId)
     : null
@@ -527,11 +566,7 @@ export function GPUReservations() {
               <input
                 type="checkbox"
                 checked={showOnlyMine}
-                onChange={() => {
-                  setShowOnlyMine(!showOnlyMine)
-                  // Switch to Reservations tab so filtered results are visible
-                  if (!showOnlyMine) setActiveTab('quotas')
-                }}
+                onChange={toggleShowOnlyMine}
                 className="sr-only"
               />
               {showOnlyMine ? <User className="w-4 h-4" /> : <Filter className="w-4 h-4" />}
@@ -539,7 +574,7 @@ export function GPUReservations() {
             </label>
           )}
           <button
-            onClick={() => { setEditingReservation(null); setShowReservationForm(true) }}
+            onClick={openCreateForm}
             className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 text-white text-sm font-medium hover:bg-purple-600 transition-colors"
           >
             <Plus className="w-4 h-4" />
@@ -556,7 +591,7 @@ export function GPUReservations() {
           utilizations={utilizations}
           effectiveDemoMode={effectiveDemoMode}
           showOnlyMine={showOnlyMine}
-          onSelectReservation={(id) => { setExpandedReservationId(id); setActiveTab('quotas') }}
+          onSelectReservation={goToReservation}
         />
       )}
 
@@ -570,7 +605,7 @@ export function GPUReservations() {
           onSetExpandedReservationId={setExpandedReservationId}
           onPrevMonth={prevMonth}
           onNextMonth={nextMonth}
-          onAddReservation={(dateStr) => { setPrefillDate(dateStr); setEditingReservation(null); setShowReservationForm(true) }}
+          onAddReservation={openCreateFormForDate}
           getGPUCountForDay={getGPUCountForDay}
         />
       )}
@@ -591,9 +626,9 @@ export function GPUReservations() {
           onSetSearchTerm={setSearchTerm}
           onSetShowOnlyMine={setShowOnlyMine}
           onSetExpandedReservationId={setExpandedReservationId}
-          onEditReservation={(r) => { setEditingReservation(r); setShowReservationForm(true) }}
+          onEditReservation={openEditForm}
           onDeleteReservation={setDeleteConfirmId}
-          onCreateReservation={() => { setEditingReservation(null); setShowReservationForm(true) }}
+          onCreateReservation={openCreateForm}
         />
       )}
 
@@ -634,7 +669,7 @@ export function GPUReservations() {
       {/* Create/Edit Reservation Modal */}
       <ReservationFormModal
         isOpen={showReservationForm}
-        onClose={() => { setShowReservationForm(false); setEditingReservation(null); setPrefillDate(null) }}
+        onClose={closeReservationForm}
         editingReservation={editingReservation}
         gpuClusters={gpuClusters}
         allNodes={rawNodes}

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -132,8 +132,14 @@ export function ReservationFormModal({
 }) {
   const { t } = useTranslation(['cards', 'common'])
   const [cluster, setCluster] = useState(editingReservation?.cluster || '')
-  const [namespace, setNamespace] = useState(editingReservation?.namespace || '')
-  const [isNewNamespace, setIsNewNamespace] = useState(false)
+  // namespace value and "create new" toggle always change together → merged into
+  // a single state object so each user interaction causes only one re-render.
+  const [nsField, setNsField] = useState<{ value: string; isNew: boolean }>({
+    value: editingReservation?.namespace || '',
+    isNew: false,
+  })
+  const namespace = nsField.value
+  const isNewNamespace = nsField.isNew
   const [title, setTitle] = useState(editingReservation?.title || '')
   const [description, setDescription] = useState(editingReservation?.description || '')
   const [gpuCount, setGpuCount] = useState(editingReservation ? String(editingReservation.gpu_count) : '')
@@ -472,7 +478,7 @@ export function ReservationFormModal({
           {/* Cluster (GPU-only, with counts) */}
           <div>
             <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.clusterLabel')}</label>
-            <select value={cluster} onChange={e => { setCluster(e.target.value); setNamespace(''); setIsNewNamespace(false); setGpuPreferences([]) }}
+            <select value={cluster} onChange={e => { setCluster(e.target.value); setNsField({ value: '', isNew: false }); setGpuPreferences([]) }}
               disabled={!!editingReservation}
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50">
               <option value="">{t('gpuReservations.form.fields.selectCluster')}</option>
@@ -495,11 +501,10 @@ export function ReservationFormModal({
                 value={namespace}
                 onChange={e => {
                   if (e.target.value === '__new__' || e.target.value === '__new_bottom__') {
-                    setIsNewNamespace(true)
-                    setNamespace('')
+                    setNsField({ value: '', isNew: true })
                     setTimeout(() => document.getElementById('new-ns-input')?.focus(), 0)
                   } else {
-                    setNamespace(e.target.value)
+                    setNsField(prev => ({ ...prev, value: e.target.value }))
                   }
                 }}
                 disabled={!!editingReservation || !cluster || (namespacesLoading && clusterNamespaces.length === 0)}
@@ -520,7 +525,7 @@ export function ReservationFormModal({
                   id="new-ns-input"
                   type="text"
                   value={namespace}
-                  onChange={e => setNamespace(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                  onChange={e => setNsField(prev => ({ ...prev, value: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))}
                   placeholder={t('gpuReservations.form.fields.enterNamespace')}
                   disabled={!!editingReservation}
                   className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground disabled:opacity-50"
@@ -528,7 +533,7 @@ export function ReservationFormModal({
                 />
                 <button
                   type="button"
-                  onClick={() => { setIsNewNamespace(false); setNamespace('') }}
+                  onClick={() => setNsField({ value: '', isNew: false })}
                   className="px-3 py-2 rounded-lg bg-secondary border border-border text-muted-foreground hover:text-foreground"
                   title={t('gpuReservations.form.fields.backToList')}
                   aria-label={t('gpuReservations.form.fields.backToList')}


### PR DESCRIPTION
Fixes #21192

Batches paired setState calls that previously caused unnecessary re-renders.

**ReservationFormModal.tsx**: merges `namespace` + `isNewNamespace` into a single `nsField` state object so each namespace transition is one `setState` instead of two.

**GPUReservations.tsx**: extracts multi-setState inline JSX handlers into named `useCallback` functions (`openCreateForm`, `openEditForm`, `closeReservationForm`, `openCreateFormForDate`, `goToReservation`, `toggleShowOnlyMine`) so paired updates are always batched together.

**False positives**: scanner-flagged lines in WhiteLabel.tsx / FromHolmesGPT.tsx (timer-ref + single setCopyFeedback) and GPUReservations.tsx Date.setHours() calls are not React setState — no changes needed there.