### PR TITLE
🌱 test: refresh cost-card snapshots for health indicators

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -5497,7 +5497,7 @@
   {
     "file": "src/components/gpu/GPUReservations.tsx",
     "rule": "no-restricted-syntax",
-    "line": 527,
+    "line": 566,
     "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -5511,63 +5511,63 @@
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 443,
+    "line": 449,
     "column": 13,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 453,
+    "line": 459,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 458,
+    "line": 464,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 467,
+    "line": 473,
     "column": 13,
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 475,
+    "line": 481,
     "column": 13,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 494,
+    "line": 500,
     "column": 15,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 519,
+    "line": 524,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 570,
+    "line": 575,
     "column": 13,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 639,
+    "line": 649,
     "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -5581,21 +5581,21 @@
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 662,
+    "line": 667,
     "column": 19,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 672,
+    "line": 677,
     "column": 19,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 690,
+    "line": 695,
     "column": 13,
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },

--- a/web/src/components/cards/__snapshots__/KubecostOverview.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/KubecostOverview.test.tsx.snap
@@ -1,0 +1,584 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`KubecostOverview > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded"
+  >
+    <div
+      class="flex items-center justify-end gap-1 mb-3"
+    >
+      <a
+        class="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-purple-400"
+        href="https://www.kubecost.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+        title="Kubecost Website"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-4 h-4"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+    <div
+      class="flex items-center gap-2 p-2 mb-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-triangle-alert w-4 h-4 text-yellow-400 shrink-0"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+        />
+        <path
+          d="M12 9v4"
+        />
+        <path
+          d="M12 17h.01"
+        />
+      </svg>
+      <div
+        class="flex-1 flex flex-wrap items-center justify-between gap-x-3 gap-y-1"
+      >
+        <span
+          class="font-medium text-yellow-400"
+        >
+          healthStatusModerate
+        </span>
+        <span
+          class="text-muted-foreground"
+        >
+          efficiencyLabel
+        </span>
+        <span
+          class="text-muted-foreground"
+        >
+          recommendationsCount
+        </span>
+      </div>
+    </div>
+    <div
+      class="flex items-start gap-2 p-2 mb-3 rounded-lg bg-green-500/10 border border-green-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-green-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-green-400 font-medium"
+        >
+          Kubecost Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install Kubecost for detailed cost allocation and optimization recommendations. 
+          <a
+            class="text-purple-400 hover:underline inline-block py-2"
+            href="https://docs.kubecost.com/install-and-configure/install/first-time-user-guide"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <div
+      class="grid grid-cols-2 gap-2 mb-3"
+    >
+      <div
+        class="p-3 rounded-lg bg-linear-to-r from-green-500/20 to-green-500/20 border border-green-500/30"
+      >
+        <p
+          class="text-xs text-green-400 mb-1"
+        >
+          monthlyCost
+        </p>
+        <p
+          class="text-xl font-bold text-foreground"
+        >
+          $12,450
+        </p>
+      </div>
+      <div
+        class="p-3 rounded-lg bg-linear-to-r from-purple-500/20 to-purple-500/20 border border-purple-500/30"
+      >
+        <div
+          class="flex items-center gap-1 mb-1"
+        >
+          <p
+            class="text-xs text-purple-400"
+          >
+            Efficiency
+          </p>
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-chart-pie w-3 h-3 text-purple-400"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 12c.552 0 1.005-.449.95-.998a10 10 0 0 0-8.953-8.951c-.55-.055-.998.398-.998.95v8a1 1 0 0 0 1 1z"
+            />
+            <path
+              d="M21.21 15.89A10 10 0 1 1 8 2.83"
+            />
+          </svg>
+        </div>
+        <p
+          class="text-xl font-bold text-foreground"
+        >
+          72%
+        </p>
+      </div>
+    </div>
+    <div
+      class="mb-3"
+    >
+      <p
+        class="text-xs text-muted-foreground font-medium mb-2"
+      >
+        Cost Breakdown
+      </p>
+      <div
+        class="h-3 rounded-full overflow-hidden flex"
+      >
+        <div
+          class="bg-blue-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 42%;"
+          title="CPU: $5200"
+        />
+        <div
+          class="bg-green-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 25%;"
+          title="Memory: $3100"
+        />
+        <div
+          class="bg-purple-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 15%;"
+          title="Storage: $1850"
+        />
+        <div
+          class="bg-yellow-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 11%;"
+          title="GPU: $1410"
+        />
+        <div
+          class="bg-cyan-500 first:rounded-l-full last:rounded-r-full"
+          style="width: 7%;"
+          title="Network: $890"
+        />
+      </div>
+      <div
+        class="flex flex-wrap gap-x-3 gap-y-1 mt-2"
+      >
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-blue-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            CPU: $5200
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-green-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Memory: $3100
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-purple-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Storage: $1850
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-yellow-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            GPU: $1410
+          </span>
+        </div>
+        <div
+          class="flex items-center gap-1 text-2xs"
+        >
+          <div
+            class="w-2 h-2 rounded-full bg-cyan-500"
+          />
+          <span
+            class="text-muted-foreground"
+          >
+            Network: $890
+          </span>
+        </div>
+      </div>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto"
+    >
+      <div
+        class="flex flex-wrap items-center justify-between gap-y-2 mb-2"
+      >
+        <p
+          class="text-xs text-muted-foreground font-medium"
+        >
+          savingsRecommendations
+        </p>
+        <span
+          class="flex items-center gap-1 text-xs text-green-400"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-trending-down w-3 h-3"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16 17h6v-6"
+            />
+            <path
+              d="m22 17-8.5-8.5-5 5L2 7"
+            />
+          </svg>
+          $2340/mo potential
+        </span>
+      </div>
+      <div
+        class="space-y-2"
+      >
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Rightsize 12 over-provisioned workloads
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$890
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Remove 3 idle workloads
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$450
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+        <div
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-triangle-alert w-3.5 h-3.5 text-yellow-400"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m21.73 18-8-14a2 2 0 0 0-3.48 0l-8 14A2 2 0 0 0 4 21h16a2 2 0 0 0 1.73-3"
+                />
+                <path
+                  d="M12 9v4"
+                />
+                <path
+                  d="M12 17h.01"
+                />
+              </svg>
+              <span
+                class="text-xs text-foreground group-hover:text-green-400"
+              >
+                Use spot instances for batch jobs
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-xs text-green-400 font-medium"
+              >
+                -$1000
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-3 pt-2 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground"
+    >
+      <span>
+        poweredBy
+      </span>
+      <a
+        class="flex items-center gap-1 text-purple-400 hover:text-purple-300 transition-colors"
+        href="https://docs.kubecost.com/"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <span>
+          docs
+        </span>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-3 h-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;

--- a/web/src/components/cards/__snapshots__/OpenCostOverview.test.tsx.snap
+++ b/web/src/components/cards/__snapshots__/OpenCostOverview.test.tsx.snap
@@ -1,0 +1,580 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`OpenCostOverview > matches snapshot 1`] = `
+<DocumentFragment>
+  <div
+    class="h-full flex flex-col min-h-card content-loaded"
+  >
+    <div
+      class="flex flex-wrap items-center justify-between gap-y-2 mb-2 shrink-0"
+    >
+      <div
+        class="flex items-center gap-2"
+      >
+        <span
+          class="text-sm font-medium text-muted-foreground"
+        >
+          2 namespaces
+        </span>
+        <a
+          class="p-1 hover:bg-secondary rounded transition-colors text-muted-foreground hover:text-purple-400"
+          href="https://www.opencost.io/"
+          rel="noopener noreferrer"
+          target="_blank"
+          title="OpenCost Documentation"
+        >
+          <svg
+            aria-hidden="true"
+            class="lucide lucide-external-link w-4 h-4"
+            fill="none"
+            height="24"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+            width="24"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M15 3h6v6"
+            />
+            <path
+              d="M10 14 21 3"
+            />
+            <path
+              d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+            />
+          </svg>
+        </a>
+      </div>
+      <div
+        class="flex items-center gap-2"
+      >
+        <div
+          data-testid="card-controls"
+        />
+      </div>
+    </div>
+    <input
+      data-testid="card-search"
+      value=""
+    />
+    <div
+      class="flex items-start gap-2 p-2 mb-3 rounded-lg bg-blue-500/10 border border-blue-500/20 text-xs"
+    >
+      <svg
+        aria-hidden="true"
+        class="lucide lucide-circle-alert w-4 h-4 text-blue-400 shrink-0 mt-0.5"
+        fill="none"
+        height="24"
+        stroke="currentColor"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        stroke-width="2"
+        viewBox="0 0 24 24"
+        width="24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle
+          cx="12"
+          cy="12"
+          r="10"
+        />
+        <line
+          x1="12"
+          x2="12"
+          y1="8"
+          y2="12"
+        />
+        <line
+          x1="12"
+          x2="12.01"
+          y1="16"
+          y2="16"
+        />
+      </svg>
+      <div>
+        <p
+          class="text-blue-400 font-medium"
+        >
+          OpenCost Integration
+        </p>
+        <p
+          class="text-muted-foreground"
+        >
+          Install OpenCost in your cluster to get real cost allocation data. 
+          <a
+            class="text-purple-400 hover:underline inline-block py-2"
+            href="https://www.opencost.io/docs/installation/install"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Install guide →
+          </a>
+        </p>
+      </div>
+    </div>
+    <div
+      class="p-3 rounded-lg bg-linear-to-r from-blue-500/20 to-cyan-500/20 border border-blue-500/30 mb-3"
+    >
+      <p
+        class="text-xs text-blue-400 mb-1"
+      >
+        Monthly Cost (Demo)
+      </p>
+      <p
+        class="text-xl font-bold text-foreground"
+      >
+        $8,865
+      </p>
+    </div>
+    <div
+      class="flex items-center gap-3 p-2 mb-3 rounded-lg bg-secondary/30 border border-border/50 text-xs"
+    >
+      <span
+        class="flex items-center gap-1 text-green-400"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-check-big w-3.5 h-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21.801 10A10 10 0 1 1 17 3.335"
+          />
+          <path
+            d="m9 11 3 3L22 4"
+          />
+        </svg>
+        3 healthySpend
+      </span>
+      <span
+        class="flex items-center gap-1 text-red-400"
+      >
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-circle-alert w-3.5 h-3.5"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <circle
+            cx="12"
+            cy="12"
+            r="10"
+          />
+          <line
+            x1="12"
+            x2="12"
+            y1="8"
+            y2="12"
+          />
+          <line
+            x1="12"
+            x2="12.01"
+            y1="16"
+            y2="16"
+          />
+        </svg>
+        2 highSpend
+      </span>
+    </div>
+    <div
+      class="flex-1 overflow-y-auto space-y-2"
+    >
+      <p
+        class="text-xs text-muted-foreground font-medium mb-2"
+      >
+        Cost by Namespace
+      </p>
+      <div
+        aria-label="Namespace costs"
+        class="space-y-2"
+        role="group"
+      >
+        <div
+          aria-label="viewNamespaceCostAria"
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-hidden focus-visible:ring-2 focus-visible:ring-cyan-400"
+          data-keynav-item="opencost-ns"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2 mb-1.5"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-box w-3.5 h-3.5 text-muted-foreground"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"
+                />
+                <path
+                  d="m3.3 7 8.7 5 8.7-5"
+                />
+                <path
+                  d="M12 22V12"
+                />
+              </svg>
+              <span
+                class="text-sm font-medium text-foreground group-hover:text-blue-400"
+              >
+                production
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-sm font-medium text-blue-400"
+              >
+                $3,680
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="h-1 bg-secondary rounded-full overflow-hidden mb-1.5"
+          >
+            <div
+              class="h-full bg-linear-to-r from-blue-500 to-cyan-500 rounded-full"
+              style="width: 93.16455696202532%;"
+            />
+          </div>
+          <div
+            class="flex gap-3 text-2xs text-muted-foreground"
+          >
+            <span
+              class="flex items-center gap-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-server w-2.5 h-2.5"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="2"
+                />
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="14"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="6"
+                  y2="6"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="18"
+                  y2="18"
+                />
+              </svg>
+              CPU: $2450
+            </span>
+            <span
+              class="flex items-center gap-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-hard-drive w-2.5 h-2.5"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 16h.01"
+                />
+                <path
+                  d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                />
+                <path
+                  d="M21.946 12.013H2.054"
+                />
+                <path
+                  d="M6 16h.01"
+                />
+              </svg>
+              Mem: $890
+            </span>
+            <span>
+              Storage: $340
+            </span>
+          </div>
+        </div>
+        <div
+          aria-label="viewNamespaceCostAria"
+          class="p-2 rounded-lg bg-secondary/30 hover:bg-secondary/50 transition-colors cursor-pointer group focus:outline-hidden focus-visible:ring-2 focus-visible:ring-cyan-400"
+          data-keynav-item="opencost-ns"
+          role="button"
+          tabindex="0"
+        >
+          <div
+            class="flex flex-wrap items-center justify-between gap-y-2 mb-1.5"
+          >
+            <div
+              class="flex items-center gap-2"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-box w-3.5 h-3.5 text-muted-foreground"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"
+                />
+                <path
+                  d="m3.3 7 8.7 5 8.7-5"
+                />
+                <path
+                  d="M12 22V12"
+                />
+              </svg>
+              <span
+                class="text-sm font-medium text-foreground group-hover:text-blue-400"
+              >
+                ml-training
+              </span>
+            </div>
+            <div
+              class="flex items-center gap-2"
+            >
+              <span
+                class="text-sm font-medium text-blue-400"
+              >
+                $3,950
+              </span>
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-chevron-right w-4 h-4 text-muted-foreground opacity-0 group-hover:opacity-100 transition-opacity"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="m9 18 6-6-6-6"
+                />
+              </svg>
+            </div>
+          </div>
+          <div
+            class="h-1 bg-secondary rounded-full overflow-hidden mb-1.5"
+          >
+            <div
+              class="h-full bg-linear-to-r from-blue-500 to-cyan-500 rounded-full"
+              style="width: 100%;"
+            />
+          </div>
+          <div
+            class="flex gap-3 text-2xs text-muted-foreground"
+          >
+            <span
+              class="flex items-center gap-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-server w-2.5 h-2.5"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="2"
+                />
+                <rect
+                  height="8"
+                  rx="2"
+                  ry="2"
+                  width="20"
+                  x="2"
+                  y="14"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="6"
+                  y2="6"
+                />
+                <line
+                  x1="6"
+                  x2="6.01"
+                  y1="18"
+                  y2="18"
+                />
+              </svg>
+              CPU: $1820
+            </span>
+            <span
+              class="flex items-center gap-1"
+            >
+              <svg
+                aria-hidden="true"
+                class="lucide lucide-hard-drive w-2.5 h-2.5"
+                fill="none"
+                height="24"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 16h.01"
+                />
+                <path
+                  d="M2.212 11.577a2 2 0 0 0-.212.896V18a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-5.527a2 2 0 0 0-.212-.896L18.55 5.11A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"
+                />
+                <path
+                  d="M21.946 12.013H2.054"
+                />
+                <path
+                  d="M6 16h.01"
+                />
+              </svg>
+              Mem: $1240
+            </span>
+            <span>
+              Storage: $890
+            </span>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      class="mt-3 pt-2 border-t border-border/50 flex flex-wrap items-center justify-between gap-y-2 text-xs text-muted-foreground"
+    >
+      <span>
+        poweredByOpenCost
+      </span>
+      <a
+        class="flex items-center gap-1 text-purple-400 hover:text-purple-300 transition-colors"
+        href="https://www.opencost.io/docs"
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <span>
+          docs
+        </span>
+        <svg
+          aria-hidden="true"
+          class="lucide lucide-external-link w-3 h-3"
+          fill="none"
+          height="24"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          width="24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M15 3h6v6"
+          />
+          <path
+            d="M10 14 21 3"
+          />
+          <path
+            d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+          />
+        </svg>
+      </a>
+    </div>
+  </div>
+</DocumentFragment>
+`;


### PR DESCRIPTION
Fixes #21196

Regenerate snapshots for KubecostOverview and OpenCostOverview after health-indicator UI was added in #21193.