### PR TITLE
[scanner] fix: drain server workers before TempDir cleanup in pkg/api tests

### DIFF
--- a/pkg/api/gpu_utilization_worker.go
+++ b/pkg/api/gpu_utilization_worker.go
@@ -60,6 +60,7 @@ type GPUUtilizationWorker struct {
 	interval           time.Duration
 	stopCh             chan struct{}
 	stopOnce           sync.Once // protects stopCh from double-close panic
+	wg                 sync.WaitGroup // tracks the background polling goroutine
 	baseCtx            context.Context
 	baseCancel         context.CancelFunc
 	gpuMetricsEnabled  bool
@@ -130,7 +131,9 @@ func NewGPUUtilizationWorker(s store.Store, k8sClient *k8s.MultiClusterClient, n
 
 // Start begins the background polling loop
 func (w *GPUUtilizationWorker) Start() {
+	w.wg.Add(1)
 	safego.GoWith("gpu-utilization-worker", func() {
+		defer w.wg.Done()
 		// Cleanup old snapshots on startup
 		w.cleanupOldSnapshots()
 
@@ -152,13 +155,14 @@ func (w *GPUUtilizationWorker) Start() {
 	slog.Info("GPU utilization worker started", "interval", w.interval)
 }
 
-// Stop signals the worker to stop. It is safe to call multiple times;
-// only the first call actually closes the stop channel.
+// Stop signals the worker to stop and waits for the background goroutine to exit.
+// It is safe to call multiple times; only the first call actually closes the stop channel.
 func (w *GPUUtilizationWorker) Stop() {
 	w.stopOnce.Do(func() {
 		w.baseCancel() // cancel all in-flight Kubernetes API calls (#6966)
 		close(w.stopCh)
 	})
+	w.wg.Wait() // wait for the polling goroutine to drain
 }
 
 // collectUtilization queries active reservations and records utilization snapshots

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -282,7 +282,9 @@ func (s *Server) startKBGapsSweeper(gapStore kbGapSweeper) {
 	if gapStore == nil {
 		return
 	}
+	s.lifecycle.wg.Add(1)
 	safego.GoWith("api/kb-gap-sweeper", func() {
+		defer s.lifecycle.wg.Done()
 		runSweep := func() {
 			deleted, err := gapStore.SweepOldKBGaps(context.Background())
 			if err != nil {

--- a/pkg/api/server_runtime.go
+++ b/pkg/api/server_runtime.go
@@ -26,6 +26,7 @@ type serverLifecycle struct {
 	done         chan struct{}
 	shutdownOnce sync.Once
 	shuttingDown int32
+	wg           sync.WaitGroup // tracks background goroutines that write to the data directory
 }
 
 type authRuntime struct {

--- a/pkg/api/startup.go
+++ b/pkg/api/startup.go
@@ -270,6 +270,22 @@ func (s *Server) Shutdown() error {
 		if s.background != nil && s.background.gpuUtilWorker != nil {
 			s.background.gpuUtilWorker.Stop()
 		}
+		// Wait for background goroutines tracked by lifecycle.wg (e.g. KB gap sweeper)
+		// to finish any in-flight writes before we close the store and allow
+		// t.TempDir / os.RemoveAll to remove the data directory. Without this wait
+		// the sweeper's eager first runSweep() can race with RemoveAll and produce
+		// "unlinkat .../001: directory not empty" failures in tests (#21198).
+		bgDrained := make(chan struct{})
+		go func() {
+			s.lifecycle.wg.Wait()
+			close(bgDrained)
+		}()
+		const bgDrainTimeout = 3 * time.Second
+		select {
+		case <-bgDrained:
+		case <-time.After(bgDrainTimeout):
+			slog.Warn("[Server] timed out waiting for background goroutines to drain")
+		}
 		s.hub.Close()
 		// #10007 — stop the periodic cluster group cache refresh goroutine.
 		if s.background != nil && s.background.workloadHandlers != nil {

--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -5497,7 +5497,7 @@
   {
     "file": "src/components/gpu/GPUReservations.tsx",
     "rule": "no-restricted-syntax",
-    "line": 527,
+    "line": 566,
     "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -5511,64 +5511,57 @@
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 443,
+    "line": 449,
     "column": 13,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 453,
+    "line": 459,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 458,
+    "line": 464,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 467,
+    "line": 473,
     "column": 13,
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 475,
+    "line": 481,
     "column": 13,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 494,
+    "line": 500,
     "column": 15,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 519,
+    "line": 524,
     "column": 17,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 570,
+    "line": 575,
     "column": 13,
-    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
-  },
-  {
-    "file": "src/components/gpu/ReservationFormModal.tsx",
-    "rule": "no-restricted-syntax",
-    "line": 639,
-    "column": 15,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
@@ -5581,21 +5574,28 @@
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 662,
+    "line": 649,
+    "column": 15,
+    "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
+  },
+  {
+    "file": "src/components/gpu/ReservationFormModal.tsx",
+    "rule": "no-restricted-syntax",
+    "line": 667,
     "column": 19,
     "message": "Use <Select> from components/ui/Select.tsx instead of raw <select>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 672,
+    "line": 677,
     "column": 19,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
   {
     "file": "src/components/gpu/ReservationFormModal.tsx",
     "rule": "no-restricted-syntax",
-    "line": 690,
+    "line": 695,
     "column": 13,
     "message": "Use <TextArea> from components/ui/TextArea.tsx instead of raw <textarea>."
   },
@@ -7458,13 +7458,6 @@
     "file": "src/components/ui/Toast.tsx",
     "rule": "react-refresh/only-export-components",
     "line": 26,
-    "column": 17,
-    "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/components/updates/WhatsNewModal.tsx",
-    "rule": "react-refresh/only-export-components",
-    "line": 32,
     "column": 17,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
   },
@@ -19024,34 +19017,6 @@
     "line": 19,
     "column": 14,
     "message": "Fast refresh only works when a file only exports components. Use a new file to share constants or functions between components."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 221,
-    "column": 11,
-    "message": "'btnRef' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 222,
-    "column": 13,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 262,
-    "column": 13,
-    "message": "'container' is assigned a value but never used. Allowed unused vars must match /^_/u."
-  },
-  {
-    "file": "src/lib/cards/__tests__/CardComponents-coverage.test.tsx",
-    "rule": "@typescript-eslint/no-unused-vars",
-    "line": 678,
-    "column": 11,
-    "message": "'onDismiss' is assigned a value but never used. Allowed unused vars must match /^_/u."
   },
   {
     "file": "src/lib/cards/__tests__/useStablePageHeight-coverage.test.ts",

--- a/web/public/mockServiceWorker.js
+++ b/web/public/mockServiceWorker.js
@@ -7,8 +7,8 @@
  * - Please do NOT modify this file.
  */
 
-const PACKAGE_VERSION = '2.14.6'
-const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const PACKAGE_VERSION = '2.15.0'
+const INTEGRITY_CHECKSUM = '03cb67ac84128e63d7cd722a6e5b7f1e'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()
 
@@ -137,8 +137,18 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
   if (client && activeClientIds.has(client.id)) {
     const serializedRequest = await serializeRequest(requestCloneForEvents)
 
+    // Omit the body of server-sent event stream responses.
+    // Cloning such responses would prevent client-side stream cancelations
+    // from reaching the original stream (a teed stream only cancels its
+    // source once both of its branches cancel) and would buffer the
+    // entire stream into the unconsumed clone indefinitely.
+    const isEventStreamResponse = response.headers
+      .get('content-type')
+      ?.toLowerCase()
+      .startsWith('text/event-stream')
+
     // Clone the response so both the client and the library could consume it.
-    const responseClone = response.clone()
+    const responseClone = isEventStreamResponse ? null : response.clone()
 
     sendToClient(
       client,
@@ -151,15 +161,17 @@ async function handleRequest(event, requestId, requestInterceptedAt) {
             ...serializedRequest,
           },
           response: {
-            type: responseClone.type,
-            status: responseClone.status,
-            statusText: responseClone.statusText,
-            headers: Object.fromEntries(responseClone.headers.entries()),
-            body: responseClone.body,
+            type: response.type,
+            status: response.status,
+            statusText: response.statusText,
+            headers: Object.fromEntries(response.headers.entries()),
+            body: responseClone ? responseClone.body : null,
           },
         },
       },
-      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+      responseClone && responseClone.body
+        ? [serializedRequest.body, responseClone.body]
+        : [],
     )
   }
 


### PR DESCRIPTION
Fixes #21198

## Problem

`TestNewServer_ExplicitDevModeStartsWithoutOAuth` calls `t.TempDir()`, which registers an `os.RemoveAll` cleanup. `NewServer` spawns background goroutines (KB gap sweeper, GPU utilization worker) that write to SQLite files inside that TempDir. Although `server.Shutdown()` is registered in a later `t.Cleanup` (and thus runs first per LIFO order), it only *signalled* goroutines to stop — it never *waited* for them to exit. The KB gap sweeper calls `runSweep()` eagerly on startup using `context.Background()`, so an in-flight sweep could still be writing after `Shutdown()` returned. `os.RemoveAll` then raced those writes, producing intermittent `unlinkat .../001: directory not empty` panics.

## Fix

- Add `wg sync.WaitGroup` to `serverLifecycle`; `startKBGapsSweeper` increments it before launching its goroutine and defers `Done()` on exit.
- Add `wg sync.WaitGroup` to `GPUUtilizationWorker`; `Start()` increments it, `Stop()` now calls `wg.Wait()` after signalling.
- `Shutdown()` waits on `lifecycle.wg` (with a 3 s safety timeout) after signalling all background goroutines and before closing the store, guaranteeing that all in-flight writes have completed before the data directory can be removed.