### PR TITLE
[scanner] fix: add loading/error states to drilldown fetchData() components

### DIFF
--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -38,6 +38,8 @@ export function ConfigMapDrillDown({ data }: Props) {
   const [describeLoading, setDescribeLoading] = useState(false)
   const [yamlOutput, setYamlOutput] = useState<string | null>(null)
   const [yamlLoading, setYamlLoading] = useState(false)
+  const [dataLoading, setDataLoading] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
   const [labels, setLabels] = useState<Record<string, string> | null>(null)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -68,7 +70,8 @@ export function ConfigMapDrillDown({ data }: Props) {
   // Fetch ConfigMap data
   const fetchData = async () => {
     if (!agentConnected || !hasRequiredContext) return
-
+    setDataLoading(true)
+    setDataError(null)
     try {
       const output = await runKubectl(['get', 'configmap', configmapName, '-n', namespace, '-o', 'json'])
       if (output) {
@@ -83,8 +86,10 @@ export function ConfigMapDrillDown({ data }: Props) {
         setConfigmapData(cm.data || {})
         setLabels(cm.metadata?.labels || {})
       }
-    } catch {
-      // Ignore parse errors
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load ConfigMap data'))
+    } finally {
+      setDataLoading(false)
     }
   }
 
@@ -251,6 +256,17 @@ export function ConfigMapDrillDown({ data }: Props) {
             {!hasRequiredContext && (
               <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400">
                 {t('drilldown.configmap.missingContext', 'Unable to load this ConfigMap because the selected resource is missing required details.')}
+              </div>
+            )}
+            {dataLoading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="w-5 h-5 animate-spin text-primary" />
+                <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
+              </div>
+            )}
+            {dataError && !dataLoading && (
+              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+                <p className="text-sm text-red-400">{dataError}</p>
               </div>
             )}
             {/* Basic Info */}

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -45,6 +45,8 @@ export function SecretDrillDown({ data }: Props) {
   const [describeLoading, setDescribeLoading] = useState(false)
   const [yamlOutput, setYamlOutput] = useState<string | null>(null)
   const [yamlLoading, setYamlLoading] = useState(false)
+  const [dataLoading, setDataLoading] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
   const [labels, setLabels] = useState<Record<string, string> | null>(null)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -60,7 +62,8 @@ export function SecretDrillDown({ data }: Props) {
   // Fetch Secret data
   const fetchData = async () => {
     if (!agentConnected) return
-
+    setDataLoading(true)
+    setDataError(null)
     try {
       const output = await runKubectl(['get', 'secret', secretName, '-n', namespace, '-o', 'json'])
       if (output) {
@@ -81,8 +84,10 @@ export function SecretDrillDown({ data }: Props) {
         setSecretType(secret.type || 'Opaque')
         setLabels(secret.metadata?.labels || {})
       }
-    } catch {
-      // Ignore parse errors
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load Secret data'))
+    } finally {
+      setDataLoading(false)
     }
   }
 
@@ -239,6 +244,17 @@ export function SecretDrillDown({ data }: Props) {
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {activeTab === 'overview' && (
           <div className="space-y-6">
+            {dataLoading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="w-5 h-5 animate-spin text-primary" />
+                <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
+              </div>
+            )}
+            {dataError && !dataLoading && (
+              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+                <p className="text-sm text-red-400">{dataError}</p>
+              </div>
+            )}
             {/* Basic Info */}
             <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20">
               <div className="flex items-center gap-3">

--- a/web/src/components/drilldown/views/ServiceAccountDrillDown.tsx
+++ b/web/src/components/drilldown/views/ServiceAccountDrillDown.tsx
@@ -34,6 +34,8 @@ export function ServiceAccountDrillDown({ data }: Props) {
   const [describeLoading, setDescribeLoading] = useState(false)
   const [yamlOutput, setYamlOutput] = useState<string | null>(null)
   const [yamlLoading, setYamlLoading] = useState(false)
+  const [dataLoading, setDataLoading] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
   const [copiedField, setCopiedField] = useState<string | null>(null)
   const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -41,7 +43,8 @@ export function ServiceAccountDrillDown({ data }: Props) {
   // Fetch ServiceAccount data
   const fetchData = async () => {
     if (!agentConnected) return
-
+    setDataLoading(true)
+    setDataError(null)
     try {
       const output = await runKubectl(['get', 'serviceaccount', serviceaccountName, '-n', namespace, '-o', 'json'])
       if (output) {
@@ -51,8 +54,10 @@ export function ServiceAccountDrillDown({ data }: Props) {
         setLabels(sa.metadata?.labels || {})
         setAnnotations(sa.metadata?.annotations || {})
       }
-    } catch {
-      // Ignore parse errors
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load ServiceAccount data'))
+    } finally {
+      setDataLoading(false)
     }
   }
 
@@ -194,6 +199,17 @@ export function ServiceAccountDrillDown({ data }: Props) {
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {activeTab === 'overview' && (
           <div className="space-y-6">
+            {dataLoading && (
+              <div className="flex items-center justify-center py-6">
+                <Loader2 className="w-5 h-5 animate-spin text-primary" />
+                <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
+              </div>
+            )}
+            {dataError && !dataLoading && (
+              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+                <p className="text-sm text-red-400">{dataError}</p>
+              </div>
+            )}
             {/* Basic Info */}
             <div className="p-4 rounded-lg bg-purple-500/10 border border-purple-500/20">
               <div className="flex items-center gap-3">


### PR DESCRIPTION
Fixes #21201 (partial — focused subset)

Addresses Auto-QA finding by adding loading and error states to the initial `fetchData()` call in three drilldown view components.

## Changes

- **`ConfigMapDrillDown.tsx`** — Add `dataLoading`/`dataError` states; show `Loader2` spinner and error message in Overview tab during/after initial kubectl fetch
- **`SecretDrillDown.tsx`** — Same fix; catch block previously silently discarded fetch errors
- **`ServiceAccountDrillDown.tsx`** — Same fix; `fetchData()` had empty `catch { // Ignore parse errors }` with no user-visible feedback

All three components already had loading spinners for the Describe and YAML tabs (`describeLoading`, `yamlLoading`) but the Overview tab was missing equivalent states for the initial data load.

## Skipped (false positives from report)

- All `.test.tsx` and `__tests__` files (test fixtures)
- `NamespaceQuotas.tsx` — already uses `useCardLoadingState` with `showSkeleton`/`showEmptyState`
- `UpgradeStatus.tsx` — same, already fully handled
- `UserManagementList.tsx` — pure presentation component, no data fetching
- `CardToolbar.tsx` — pure presentation component, no data fetching
- `StellarMissionBridge.tsx` — returns `null` by design (invisible bridge), no UI to show loading in
- `ACMMProvider.tsx` — context provider, no render output
- `AuthCallback.tsx` — already shows `Loader2` spinner and handles errors via navigation

Remaining components from the report can be addressed in follow-up PRs to keep this change reviewable.