### PR TITLE
[scanner] fix: add loading states to drasi and mission dialog components

### DIFF
--- a/web/src/components/mission-control/RequestApprovalModal.tsx
+++ b/web/src/components/mission-control/RequestApprovalModal.tsx
@@ -39,7 +39,8 @@ export function RequestApprovalModal({
   const [issueUrl, setIssueUrl] = useState<string | null>(null)
   const [hasGitHubToken, setHasGitHubToken] = useState(false)
   const [checkingGitHubToken, setCheckingGitHubToken] = useState(false)
-  const [tokenCheckError, setTokenCheckError] = useState(false)
+  // Canonical string|null pattern (per #21202): stores actual error message for inline display
+  const [tokenCheckError, setTokenCheckError] = useState<string | null>(null)
   const tokenCheckedRef = useRef(false)
   const submittingRef = useRef(false)
 
@@ -47,18 +48,18 @@ export function RequestApprovalModal({
 
   const checkGitHubTokenStatus = useCallback(async () => {
     setCheckingGitHubToken(true)
-    setTokenCheckError(false)
+    setTokenCheckError(null)
     try {
       const res = await fetch('/api/github/token/status', { headers: token ? { Authorization: `Bearer ${token}` } : {}, signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
       setHasGitHubToken(Boolean((await res.json() as { hasToken?: boolean }).hasToken))
-    } catch {
+    } catch (err) {
       setHasGitHubToken(false)
-      setTokenCheckError(true)
+      setTokenCheckError(err instanceof Error ? err.message : t('common.fetchFailed', 'Could not verify GitHub access'))
     } finally {
       setCheckingGitHubToken(false)
     }
-  }, [token])
+  }, [token, t])
 
   // Check whether GitHub token is configured via /api/github/token/status
   useEffect(() => {
@@ -144,7 +145,7 @@ export function RequestApprovalModal({
     setSubmitting(false)
     setHasGitHubToken(false)
     setCheckingGitHubToken(false)
-    setTokenCheckError(false)
+    setTokenCheckError(null)
     onClose()
   }, [onClose])
 
@@ -224,7 +225,10 @@ export function RequestApprovalModal({
                 </p>
               ) : tokenCheckError ? (
                 <p className="rounded-lg border border-red-500/30 bg-red-500/10 p-3 text-xs text-red-300">
-                  Could not verify GitHub access. <button type="button" className="underline underline-offset-2" onClick={() => void checkGitHubTokenStatus()}>Retry</button>
+                  {tokenCheckError}{' '}
+                  <button type="button" className="underline underline-offset-2" onClick={() => void checkGitHubTokenStatus()}>
+                    {t('common.retry', 'Retry')}
+                  </button>
                 </p>
               ) : !hasGitHubToken && (
                 <p className="text-xs text-amber-400">
@@ -265,7 +269,7 @@ export function RequestApprovalModal({
                 disabled={!isValidRepo || submitting || checkingGitHubToken || !hasGitHubToken}
                 icon={submitting ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <GitPullRequestArrow className="w-3.5 h-3.5" />}
               >
-                {submitting ? 'Creating…' : 'Create Issue'}
+                {submitting ? 'Creating\u2026' : 'Create Issue'}
               </Button>
             </>
           ) : (

--- a/web/src/components/missions/CardRequestDialog.tsx
+++ b/web/src/components/missions/CardRequestDialog.tsx
@@ -22,10 +22,13 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
   const [submittingProjects, setSubmittingProjects] = useState<Set<string>>(new Set())
   const [submitted, setSubmitted] = useState<Set<string>>(new Set())
   const [failedProjects, setFailedProjects] = useState<Set<string>>(new Set())
+  // Per-project error messages (canonical string|null pattern per #21202)
+  const [failedMessages, setFailedMessages] = useState<Map<string, string>>(new Map())
 
   const handleRequest = useCallback(async (project: string) => {
     setSubmittingProjects(prev => new Set(prev).add(project))
     setFailedProjects(prev => { const next = new Set(prev); next.delete(project); return next })
+    setFailedMessages(prev => { const next = new Map(prev); next.delete(project); return next })
     try {
       await api.post('/api/feedback/requests', {
         title: `Card Request: ${project} monitoring card`,
@@ -34,14 +37,16 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
       })
       emitGroundControlCardRequestOpened(project)
       setSubmitted(prev => new Set(prev).add(project))
-      showToast(`Card request submitted for ${project}`, 'success')
-    } catch {
+      showToast(t('orbit.cardRequestSubmitted', 'Card request submitted for {{project}}', { project }), 'success')
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : t('common.fetchFailed', 'Request failed')
       setFailedProjects(prev => new Set(prev).add(project))
-      showToast('Could not submit request — try opening a GitHub issue directly', 'warning')
+      setFailedMessages(prev => new Map(prev).set(project, msg))
+      showToast(t('orbit.cardRequestFailed', 'Could not submit request — try opening a GitHub issue directly'), 'warning')
     } finally {
       setSubmittingProjects(prev => { const next = new Set(prev); next.delete(project); return next })
     }
-  }, [showToast])
+  }, [showToast, t])
 
   if ((missingProjects || []).length === 0) return null
 
@@ -71,15 +76,22 @@ export function CardRequestDialog({ missingProjects, onClose }: CardRequestDialo
             ) : failedProjects.has(project) ? (
               // Auto-QA #9036 — explicit inline error + retry affordance so
               // the failed state persists beyond the one-shot toast.
-              <button
-                onClick={() => handleRequest(project)}
-                disabled={submittingProjects.has(project)}
-                className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:bg-red-500/10 rounded transition-colors"
-                title="Request failed — click to retry"
-              >
-                <AlertTriangle className="w-2.5 h-2.5" />
-                {t('orbit.cardRequestRetry')}
-              </button>
+              <div className="flex flex-col items-end gap-0.5">
+                {failedMessages.get(project) && (
+                  <span className="text-[9px] text-red-400 max-w-[160px] truncate" title={failedMessages.get(project)}>
+                    {failedMessages.get(project)}
+                  </span>
+                )}
+                <button
+                  onClick={() => handleRequest(project)}
+                  disabled={submittingProjects.has(project)}
+                  className="flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-red-400 hover:bg-red-500/10 rounded transition-colors"
+                  title={t('orbit.cardRequestRetryTitle', 'Request failed — click to retry')}
+                >
+                  <AlertTriangle className="w-2.5 h-2.5" />
+                  {t('orbit.cardRequestRetry')}
+                </button>
+              </div>
             ) : (
               <button
                 onClick={() => handleRequest(project)}


### PR DESCRIPTION
Fixes #21201

Part of the Auto-QA Resilience scan remediation. Follows the `dataLoading`/`dataError` canonical pattern established in #21202.

## Changes

### `CardRequestDialog.tsx`
- Add `failedMessages: Map<string, string>` state to capture and display the actual per-project API error message inline under the retry button (previously only a toast was shown)
- Wrap all user-visible strings in `t()` — removes hard-coded English from `showToast` calls and button titles

### `RequestApprovalModal.tsx`
- Upgrade `tokenCheckError` from `boolean` to `string | null` (canonical pattern per #21202) so the actual HTTP/network error from `checkGitHubTokenStatus()` is surfaced in the modal UI instead of a static hard-coded message
- `setTokenCheckError(null)` on retry/close; catch block stores `err.message`
- Retry button label now uses `t('common.retry', 'Retry')` for i18n consistency

## Skipped files (pure UI — no data fetching)

- **`DrasiFlowLine.tsx`** — file header documents: *"Pure UI component — renders SVG paths based on props; no data fetching."* No loading state is applicable.
- **`DrasiNodeCard.tsx`** — file header documents: *"Pure UI components — render props provided by parent; no data fetching."* No loading state is applicable.

Both Drasi files receive all their data via props from `DrasiReactiveGraph`/`useDrasiResources`; loading state lives there, not here.