### PR TITLE
[scanner] fix: add loading/error states to card-wrapper components

### DIFF
--- a/web/src/components/cards/card-wrapper/CardActionMenu.tsx
+++ b/web/src/components/cards/card-wrapper/CardActionMenu.tsx
@@ -10,8 +10,8 @@ import { copyToClipboard } from '../../../lib/clipboard'
 import { useDashboardContextOptional } from '../../../hooks/useDashboardContext'
 import { useModalState } from '../../../lib/modals'
 
-// Pure UI component — renders dropdown menu for card actions; no data fetching.
-// Demo data not applicable (UI controls only).
+// Auto-QA #21201: pure UI component — no async data fetch; loading/error state not applicable.
+// All interactions are synchronous event handlers and portal positioning (no network calls).
 
 // Card width options (in grid columns out of 12)
 const WIDTH_OPTIONS = [

--- a/web/src/components/cards/card-wrapper/InfoTooltip.tsx
+++ b/web/src/components/cards/card-wrapper/InfoTooltip.tsx
@@ -4,8 +4,8 @@ import { Info } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useModalState } from '../../../lib/modals'
 
-// Pure UI component — renders info tooltip with keyboard navigation; no data fetching.
-// Demo data not applicable (displays static card metadata).
+// Auto-QA #21201: pure UI component — no async data fetch; loading/error state not applicable.
+// Position is computed synchronously from DOM geometry; no network calls in this component.
 
 // #6227: shared Escape-key coordinator. Multiple InfoTooltips (one per
 // CardWrapper) used to each register their own document-level keydown

--- a/web/src/components/cards/card-wrapper/PendingSwapNotification.tsx
+++ b/web/src/components/cards/card-wrapper/PendingSwapNotification.tsx
@@ -2,8 +2,8 @@ import { Clock } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../../ui/Button'
 
-// Pure UI component — renders pending swap notification banner; no data fetching.
-// Demo data not applicable (displays card swap actions).
+// Auto-QA #21201: pure UI component — no async data fetch; loading/error state not applicable.
+// All data is received via props; no network calls or async operations in this component.
 
 interface PendingSwap {
   newType: string


### PR DESCRIPTION
Fixes #21201

Part of #21201 — Auto-QA Resilience scan: loading/error states in card-wrapper components.

## Analysis

All three target files were read and analyzed against the pattern established in #21202. **None of the three components perform async data fetching**, so loading/error state machinery (`dataLoading`/`dataError` + Loader2 spinner + red error banner) is not applicable.

Each file has been annotated with a `// Auto-QA #21201:` comment documenting this finding:

| File | Finding |
|------|---------|
| `CardActionMenu.tsx` | **Skipped** — synchronous event handlers + portal positioning only; `useDashboardContextOptional()` is a context read, not a fetch |
| `PendingSwapNotification.tsx` | **Skipped** — presentational component; all data received via props, no `useEffect` data calls |
| `InfoTooltip.tsx` | **Skipped** — DOM geometry calculations only (`getBoundingClientRect`); no network calls |

## Pattern reference

The loading/error pattern from #21202:
```tsx
const [dataLoading, setDataLoading] = useState(false)
const [dataError, setDataError] = useState<string | null>(null)
// in fetchData():
setDataLoading(true); setDataError(null)
try { ... } catch (err) { setDataError(...) } finally { setDataLoading(false) }
```
This pattern requires an actual `async fetchData()` function. None of the three files contain one.

Follows the pattern established in #21202.