### PR TITLE
[scanner] fix: repair 3 test failures from card-wrapper loading/error state changes

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -2718,7 +2718,7 @@
   {
     "file": "src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx",
     "rule": "no-restricted-syntax",
-    "line": 152,
+    "line": 161,
     "column": 5,
     "message": "Use <Input> from components/ui/Input.tsx instead of raw <input>."
   },
@@ -4832,23 +4832,23 @@
   {
     "file": "src/components/drilldown/views/ConfigMapDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 69,
+    "line": 71,
     "column": 9,
-    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 143) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
+    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 148) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ConfigMapDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 91,
+    "line": 96,
     "column": 9,
-    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 143) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
+    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 148) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ConfigMapDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 102,
+    "line": 107,
     "column": 9,
-    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 143) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
+    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 148) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/DeploymentDrillDown.tsx",
@@ -5084,44 +5084,44 @@
   {
     "file": "src/components/drilldown/views/SecretDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 61,
+    "line": 63,
     "column": 9,
-    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 126) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
+    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 131) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/SecretDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 89,
+    "line": 94,
     "column": 9,
-    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 126) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
+    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 131) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/SecretDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 97,
+    "line": 102,
     "column": 9,
-    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 126) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
+    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 131) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ServiceAccountDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 42,
+    "line": 44,
     "column": 9,
-    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 96) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
+    "message": "The 'fetchData' function makes the dependencies of useEffect Hook (at line 101) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchData' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ServiceAccountDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 59,
+    "line": 64,
     "column": 9,
-    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 96) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
+    "message": "The 'fetchDescribe' function makes the dependencies of useEffect Hook (at line 101) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchDescribe' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ServiceAccountDrillDown.tsx",
     "rule": "react-hooks/exhaustive-deps",
-    "line": 67,
+    "line": 72,
     "column": 9,
-    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 96) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
+    "message": "The 'fetchYaml' function makes the dependencies of useEffect Hook (at line 101) change on every render. Move it inside the useEffect callback. Alternatively, wrap the definition of 'fetchYaml' in its own useCallback() Hook."
   },
   {
     "file": "src/components/drilldown/views/ServiceDrillDown.tsx",

--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -14,7 +14,16 @@ import type { NodeData } from '../offlineDataTransforms'
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({
-    t: (key: string, opts?: { defaultValue?: string; count?: number }) => {
+    t: (key: string, optsOrDefault?: { defaultValue?: string; count?: number } | string, extraOpts?: Record<string, unknown>) => {
+      // Handle t(key, defaultValue, options) — interpolate the default value string
+      if (typeof optsOrDefault === 'string') {
+        const options = extraOpts ?? {}
+        return Object.entries(options).reduce(
+          (s, [k, v]) => s.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v ?? '')),
+          optsOrDefault,
+        )
+      }
+      const opts = optsOrDefault
       if (opts?.defaultValue) return String(opts.defaultValue)
       if (key.includes('allHealthy')) return 'All Healthy'
       if (key.includes('gpuIssues')) return 'GPU Issues'

--- a/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
+++ b/web/src/components/missions/__tests__/CardRequestDialog.test.tsx
@@ -37,7 +37,16 @@ vi.mock('../../ui/Toast', () => ({
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({
-    t: (key: string, opts?: Record<string, unknown>) => {
+    t: (key: string, optsOrDefault?: Record<string, unknown> | string, extraOpts?: Record<string, unknown>) => {
+      // Handle t(key, defaultValue, options) — interpolate the default value string
+      if (typeof optsOrDefault === 'string') {
+        const options = extraOpts ?? {}
+        return Object.entries(options).reduce(
+          (s, [k, v]) => s.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v ?? '')),
+          optsOrDefault,
+        )
+      }
+      const opts = optsOrDefault
       if (key === 'orbit.cardRequest') return `Request card for ${opts?.project}`
       if (key === 'orbit.cardRequestRequested') return 'Requested'
       if (key === 'orbit.cardRequestAction') return 'Request Card'


### PR DESCRIPTION
Fixes #21207

Update the `useTranslation` mock in two test files to handle the 3-argument form of `t(key, defaultValue, options)` introduced by components added in #21205.

**Root cause:** `AIAnalysisPanel` and `CardRequestDialog` both call `t()` with a string default value as the 2nd arg and an interpolation options object as the 3rd arg. The previous mocks only accepted `(key, opts?)`, so they returned the raw key instead of the interpolated default — breaking three assertions:

- `getByRole('button', { name: /Analyze 1 Issue/i })` — button text was the i18n key, not interpolated
- `showToast` called with string containing `'Prometheus'` — was the key `orbit.cardRequestSubmitted`
- `showToast` called with string containing `'Could not submit'` — was the key `orbit.cardRequestFailed`

**Fix:** Extend the mock's `t` signature to accept an optional third argument; when the second argument is a string (the default value), interpolate `{{placeholder}}` tokens from the third argument.