### PR TITLE
🐛 fix: log caught errors with console.error instead of console.warn

### DIFF
--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -23,7 +23,7 @@ function safeJsonParse<T>(value: string, fallback: T, context: string): T {
   try {
     return JSON.parse(value) as T
   } catch (err) {
-    console.warn(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
+    console.error(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
     return fallback
   }
 }

--- a/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
+++ b/web/src/lib/unified/dashboard/UnifiedDashboard.tsx
@@ -183,7 +183,7 @@ export function UnifiedDashboard({
         localStorage.setItem(config.storageKey, JSON.stringify(cards))
         setDashboardError(null)
       } catch (error) {
-        console.warn('Failed to persist unified dashboard cards', error)
+        console.error('Failed to persist unified dashboard cards', error)
         setDashboardError(t('errors.storagePersistFailed'))
       }
     }
@@ -207,7 +207,7 @@ export function UnifiedDashboard({
         localStorage.setItem(slot, JSON.stringify(placements))
         setDashboardError(null)
       } catch (error) {
-        console.warn('Failed to persist unified dashboard tab cards', error)
+        console.error('Failed to persist unified dashboard tab cards', error)
         setDashboardError(t('errors.storagePersistFailed'))
       }
     }
@@ -350,7 +350,7 @@ export function UnifiedDashboard({
         setDashboardError(null)
         showToast(t('dashboard.resetSuccess', 'Dashboard layout reset to defaults'), 'success')
       } catch (error) {
-        console.warn('Failed to reset unified dashboard layout', error)
+        console.error('Failed to reset unified dashboard layout', error)
         setDashboardError(t('errors.storagePersistFailed'))
       }
     }
@@ -375,7 +375,7 @@ export function UnifiedDashboard({
             setDashboardError(null)
           }
         } catch (error) {
-          console.warn('Failed to sync unified dashboard cards from storage event', error)
+          console.error('Failed to sync unified dashboard cards from storage event', error)
           setDashboardError(t('errors.storageRestoreFailed'))
         }
         return
@@ -393,7 +393,7 @@ export function UnifiedDashboard({
             setDashboardError(null)
           }
         } catch (error) {
-          console.warn('Failed to sync unified dashboard tab cards from storage event', error)
+          console.error('Failed to sync unified dashboard tab cards from storage event', error)
           setDashboardError(t('errors.storageRestoreFailed'))
         }
       }


### PR DESCRIPTION
Fixes #21212

Changes 6 `console.warn` calls in catch blocks to `console.error` across two files:
- `web/src/lib/unified/dashboard/UnifiedDashboard.tsx` (5 catch blocks)
- `web/src/hooks/useStackDiscovery.ts` (1 catch block)

This ensures caught errors surface in browser devtools error logs rather than being hidden in warnings.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>