### PR TITLE
🌱 fix: enforce 44px minimum touch targets (WCAG 2.5.5)

### DIFF
--- a/web/src/components/teams/TeamAccessGrants.tsx
+++ b/web/src/components/teams/TeamAccessGrants.tsx
@@ -118,7 +118,7 @@ export function TeamAccessGrants({ teamName, grants, onGrantChanged }: TeamAcces
         <h3 className="text-sm font-medium text-foreground">
           {t('teams.accessGrants')}
         </h3>
-        <Button variant="ghost" size="sm" icon={<Plus className="w-3 h-3" />} onClick={() => setShowGrant(true)}>
+        <Button variant="ghost" size="sm" className="min-h-11 min-w-11" icon={<Plus className="w-3 h-3" />} onClick={() => setShowGrant(true)}>
           {t('teams.grantAccess')}
         </Button>
       </div>

--- a/web/src/components/teams/TeamDetail.tsx
+++ b/web/src/components/teams/TeamDetail.tsx
@@ -29,7 +29,7 @@ export function TeamDetail({ team, onBack, onUpdateTeam: _onUpdateTeam, onDelete
   return (
     <div>
       <div className="flex items-center gap-2 mb-4">
-        <button onClick={onBack} className="flex items-center gap-1 px-2 py-1 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm">
+        <button onClick={onBack} className="flex items-center gap-1 px-2 py-1 min-h-11 min-w-11 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm">
           <ArrowLeft className="w-4 h-4" />
           {t('common.back')}
         </button>


### PR DESCRIPTION
Fixes #21213

Add `min-h-11 min-w-11` to interactive buttons in `TeamDetail` (back button) and `TeamAccessGrants` (Grant Access button) that were missing the WCAG 2.5.5 minimum 44×44px touch target size.

**Verified as already fixed:** `SegregationOfDuties`, `ChangeControlAudit`, `DataResidency`, `Events`, and `ResourceBadges` (both `NamespaceBadge` and `ResourceKindBadge`) already have conditional `min-h-11 min-w-11` applied. No changes needed there.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>