### PR TITLE
🐛 fix: restore ACMM L5 badge (#21218)

### DIFF
--- a/pkg/api/handlers/compliance/acmm_scan.go
+++ b/pkg/api/handlers/compliance/acmm_scan.go
@@ -185,6 +185,7 @@ var acmmCriteria = []acmmCriterion{
 	{ID: "acmm:public-metrics", Patterns: []string{"web/netlify/functions/analytics-accm.mts", "web/public/analytics.js", "docs/metrics/"}},
 	{ID: "acmm:policy-as-code", Patterns: []string{"policies/", ".github/policies/", "kyverno/", "conftest.yaml", "opa/"}},
 	{ID: "acmm:reflection-log", Patterns: []string{".claude/reflections/", "memory/", ".memory/", "docs/reflections/", "REFLECTIONS.md"}},
+	{ID: "acmm:audit-trail", Patterns: []string{".github/workflows/audit-trail.yml", ".github/workflows/ai-attribution.yml"}},
 	// ACMM L6 — Autonomous
 	{ID: "acmm:auto-issue-gen", Patterns: []string{".github/workflows/auto-issues.yml", ".github/workflows/auto-issue.yml", ".github/workflows/issue-gen.yml", ".github/workflows/auto-generate-issues.yml", "scripts/generate-issues.mjs"}},
 	{ID: "acmm:multi-agent-orchestration", Patterns: []string{".github/workflows/dispatcher.yml", ".github/workflows/orchestrate.yml", "scripts/orchestrate.mjs", "docs/multi-agent.md", ".claude/dispatcher/", "orchestrator/"}},

--- a/web/netlify/functions/acmm-scan/criteria.ts
+++ b/web/netlify/functions/acmm-scan/criteria.ts
@@ -76,6 +76,7 @@ export const CRITERIA: Criterion[] = [
   { id: "acmm:public-metrics", source: "acmm", level: 5, category: "observability", name: "Public metrics", detection: { type: "any-of", pattern: ["web/netlify/functions/analytics-accm.mts", "web/public/analytics.js", "docs/metrics/"] } },
   { id: "acmm:policy-as-code", source: "acmm", level: 5, category: "governance", name: "Policy-as-code", detection: { type: "any-of", pattern: ["policies/", ".github/policies/", "kyverno/", "conftest.yaml", "opa/"] } },
   { id: "acmm:reflection-log", source: "acmm", level: 5, category: "feedback-loop", name: "Reflection log", detection: { type: "any-of", pattern: [".claude/reflections/", "memory/", ".memory/", "docs/reflections/", "REFLECTIONS.md"] } },
+  { id: "acmm:audit-trail", source: "acmm", level: 5, category: "traceability", name: "Audit trail workflow", detection: { type: "any-of", pattern: [".github/workflows/audit-trail.yml", ".github/workflows/ai-attribution.yml"] } },
 
   // ACMM L6 — Autonomous (moved from old L5 + new items)
   { id: "acmm:auto-issue-gen", source: "acmm", level: 6, category: "autonomy", name: "Auto issue generation", detection: { type: "any-of", pattern: [".github/workflows/auto-issues.yml", ".github/workflows/auto-issue.yml", ".github/workflows/issue-gen.yml", ".github/workflows/auto-generate-issues.yml", "scripts/generate-issues.mjs"] } },


### PR DESCRIPTION
Fixes #21218

## Summary

The ACMM badge dropped from L5 to L4 because the `acmm:audit-trail` criterion was missing from the Netlify function and Go backend scan implementations, even though the file `.github/workflows/ai-attribution.yml` exists and the frontend source (`acmm.ts`) has the criterion.

## Root Cause

When the frontend ACMM source was created (commit 4c5733df6), the `acmm:audit-trail` criterion was included with detection patterns:
- `.github/workflows/audit-trail.yml`
- `.github/workflows/ai-attribution.yml`

However, the Netlify function (`web/netlify/functions/acmm-scan/criteria.ts`) and Go backend (`pkg/api/handlers/compliance/acmm_scan.go`) only had the AEF (Agentic Engineering Framework) version `aef:audit-trail` with different patterns.

Since `.github/workflows/ai-attribution.yml` exists in the repo, the missing ACMM criterion prevented L5 from being achieved.

## Changes

- `web/netlify/functions/acmm-scan/criteria.ts`: Added `acmm:audit-trail` to L5 criteria
- `pkg/api/handlers/compliance/acmm_scan.go`: Added `acmm:audit-trail` to L5 criteria

Both now correctly detect `.github/workflows/ai-attribution.yml`.

## Verification

After this fix, the scan will detect:
- `acmm:audit-trail` ✅ (via ai-attribution.yml)
- `acmm:github-actions-ai` ✅
- `acmm:auto-qa-self-tuning` ✅
- `acmm:public-metrics` ✅
- `acmm:policy-as-code` ✅
- `acmm:reflection-log` ✅

L5 threshold: 70% of scannable criteria → 6/6 = 100% → L5 restored ✅