### PR TITLE
🌱 [scanner] fix(test): deflake TestNewServer_ExplicitDevMode*

### DIFF
--- a/pkg/api/shutdown_test.go
+++ b/pkg/api/shutdown_test.go
@@ -3,12 +3,78 @@ package api
 import (
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gofiber/fiber/v2"
 
 	"github.com/kubestellar/console/pkg/api/transport"
 	"github.com/kubestellar/console/pkg/store"
 )
+
+// TestShutdown_DrainsBackgroundWorkers is a regression test for #21198.
+// Previously Shutdown() closed lifecycle.done and returned without waiting for
+// background goroutines (KB gap sweeper, GPU utilization worker) to finish their
+// in-flight writes. If an in-flight SQLite write raced with t.TempDir cleanup
+// (os.RemoveAll), the test failed intermittently with:
+//
+//	testing.go:1464: TempDir RemoveAll cleanup: unlinkat .../001: directory not empty
+//
+// The fix adds lifecycle.wg tracking: Shutdown() calls lifecycle.wg.Wait() (with
+// a timeout) before closing the store so all goroutine writes complete before the
+// data directory can be removed.
+func TestShutdown_DrainsBackgroundWorkers(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "drain-test.db")
+	sqliteStore, err := store.NewSQLiteStore(dbPath)
+	if err != nil {
+		t.Fatalf("failed to open sqlite store: %v", err)
+	}
+
+	lc := newServerLifecycle(nil)
+
+	// Simulate a background goroutine (e.g. KB gap sweeper) that holds the
+	// WaitGroup open for a brief window after it receives the done signal,
+	// modelling an in-flight write that outlasts the signal.
+	unblock := make(chan struct{})
+	lc.wg.Add(1)
+	go func() {
+		defer lc.wg.Done()
+		<-lc.done   // wait for the shutdown signal
+		<-unblock   // simulate in-flight write that completes asynchronously
+	}()
+
+	s := &Server{
+		app:        fiber.New(),
+		store:      sqliteStore,
+		hub:        transport.NewHub(),
+		lifecycle:  lc,
+		background: newBackgroundServices(),
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		defer close(shutdownDone)
+		_ = s.Shutdown()
+	}()
+
+	// Allow Shutdown to signal done and start waiting on the WaitGroup.
+	time.Sleep(50 * time.Millisecond)
+
+	// Shutdown must NOT have returned yet — the simulated worker is still running.
+	select {
+	case <-shutdownDone:
+		t.Fatal("Shutdown returned before background worker exited (#21198 regression)")
+	default:
+	}
+
+	// Unblock the worker; Shutdown should complete promptly.
+	close(unblock)
+	select {
+	case <-shutdownDone:
+		// expected: Shutdown waited for the worker before returning
+	case <-time.After(2 * time.Second):
+		t.Fatal("Shutdown did not complete after worker exited (#21198)")
+	}
+}
 
 // TestShutdown_Idempotent is a regression test for #6478. Previously
 // Server.Shutdown closed the lifecycle done channel directly, so a second call


### PR DESCRIPTION
Fixes #21198

Add `TestShutdown_DrainsBackgroundWorkers` to `pkg/api/shutdown_test.go` as a deterministic regression guard for the `TempDir RemoveAll cleanup: directory not empty` flake.

**Root cause:** `Shutdown()` closed `lifecycle.done` and returned without waiting for background goroutines (KB gap sweeper, GPU utilization worker) to finish their in-flight SQLite writes. When `t.TempDir` cleanup then ran `os.RemoveAll`, it raced with those writes and intermittently failed with `unlinkat .../001: directory not empty`.

**Production fix already applied:** `lifecycle.wg` tracking was added to `serverLifecycle` and `GPUUtilizationWorker`. `Shutdown()` now calls `lifecycle.wg.Wait()` (with a 3 s timeout) before closing the store, ensuring all writes complete before the data directory can be removed.

**This PR adds the regression test** that locks in the drain contract:
1. Injects a fake background goroutine that holds `lifecycle.wg` open past the `done` signal
2. Asserts `Shutdown()` blocks while the goroutine is in-flight
3. Unblocks the goroutine and asserts `Shutdown()` then completes promptly

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>