### PR TITLE
🐛 [scanner] fix: update card tests after useModal/card-layout refactor (#21229)

### DIFF
--- a/web/src/components/cards/NamespaceOverview.test.tsx
+++ b/web/src/components/cards/NamespaceOverview.test.tsx
@@ -45,6 +45,7 @@ const mockUseCardLoadingState = vi.fn()
 vi.mock('./CardDataContext', () => ({
   useCardLoadingState: (opts: Record<string, unknown>) => mockUseCardLoadingState(opts),
   useReportCardDataState: () => {},
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../lib/constants/storage', () => ({

--- a/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.states.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 const mockUseCertManager = vi.fn()

--- a/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
@@ -38,6 +38,7 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 const mockUseCertManager = vi.fn()

--- a/web/src/components/cards/__tests__/NamespaceOverview.multicluster.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceOverview.multicluster.test.tsx
@@ -24,6 +24,7 @@ vi.mock('../../../hooks/useCachedData', () => ({
 
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (args: Record<string, unknown>) => mockUseCardLoadingState(args),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../../hooks/useGlobalFilters', () => ({

--- a/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
+++ b/web/src/components/cards/__tests__/NamespaceOverview.test.tsx
@@ -61,6 +61,7 @@ vi.mock('../../../hooks/useDrillDown', () => ({
 
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: vi.fn(() => ({ showSkeleton: false, showEmptyState: false })),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../ui/Toast', () => ({

--- a/web/src/components/cards/__tests__/VaultSecrets.test.tsx
+++ b/web/src/components/cards/__tests__/VaultSecrets.test.tsx
@@ -48,6 +48,7 @@ const mockUseCardLoadingState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useReportCardDataState: vi.fn(),
   useCardLoadingState: (opts: unknown) => mockUseCardLoadingState(opts),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 const mockUseClusters = vi.fn()


### PR DESCRIPTION
Fixes #21234

## Root Cause

PRs #21229 (useModal refactor in CardWrapper) and #21230 (useCardDemoState migration) together introduced `useCardDemoState()` calls in:
- `NamespaceOverview.tsx`
- `DataComplianceVaultSecrets.tsx`
- `DataComplianceExternalSecrets.tsx`

Six test files mocked `CardDataContext` with only `useCardLoadingState`, leaving `useCardDemoState` as `undefined`. Every render of those components threw `TypeError: useCardDemoState is not a function`, causing 66 test failures in Coverage Suite run #4319.

## Fix

Added `useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false })` to the `vi.mock('../CardDataContext', ...)` factory in each of the 6 affected test files:

| File | Tests fixed |
|------|-------------|
| `cards/NamespaceOverview.test.tsx` | 7 |
| `cards/__tests__/NamespaceOverview.test.tsx` | 12 |
| `cards/__tests__/NamespaceOverview.multicluster.test.tsx` | 7 |
| `cards/__tests__/DataComplianceCards.test.tsx` | 26 (VaultSecrets + ExternalSecrets; CertManager unaffected) |
| `cards/__tests__/DataComplianceCards.states.test.tsx` | 9 (VaultSecrets + ExternalSecrets) |
| `cards/__tests__/VaultSecrets.test.tsx` | 5 |

**Total: 66 tests restored.**

No source components were modified — this is a pure test-mock update.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>