### PR TITLE
🌱 [scanner] fix: update card tests after useModal/card-layout refactor

### DIFF
--- a/web/src/components/cards/ArcadeGames.test.tsx
+++ b/web/src/components/cards/ArcadeGames.test.tsx
@@ -23,6 +23,7 @@ vi.mock('./CardWrapper', () => ({
 vi.mock('./CardDataContext', () => ({
   useCardLoadingState: vi.fn(),
   useReportCardDataState: vi.fn(),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../lib/analytics', () => ({

--- a/web/src/components/cards/ArgoCDHealth.test.tsx
+++ b/web/src/components/cards/ArgoCDHealth.test.tsx
@@ -45,6 +45,13 @@ vi.mock('../ui/Skeleton', () => ({
   ),
 }))
 
+vi.mock('../../lib/cards/CardComponents', () => ({
+  CardBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyLoaded: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardScrollList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/ArgoCDSyncStatus.test.tsx
+++ b/web/src/components/cards/ArgoCDSyncStatus.test.tsx
@@ -53,6 +53,9 @@ vi.mock('../ui/Skeleton', () => ({
 
 vi.mock('../../lib/cards/CardComponents', () => ({
   CardClusterFilter: () => <div data-testid="cluster-filter" />,
+  CardBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyLoaded: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/CRDHealth.test.tsx
+++ b/web/src/components/cards/CRDHealth.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import { CRDHealth } from './CRDHealth'
@@ -18,6 +19,9 @@ vi.mock('../../lib/cards/CardComponents', () => ({
   CardControlsRow: () => null,
   CardPaginationFooter: () => null,
   CardAIActions: () => null,
+  CardBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyLoaded: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
 vi.mock('../../lib/cards/cardHooks', () => ({

--- a/web/src/components/cards/CRDHealth.test.tsx
+++ b/web/src/components/cards/CRDHealth.test.tsx
@@ -14,6 +14,7 @@ vi.mock('../../hooks/useCRDs', () => ({
 
 vi.mock('../../lib/cards/CardComponents', () => ({
   CardSearchInput: ({ value, onChange, placeholder }: { value: string; onChange: (v: string) => void; placeholder?: string }) => (
+    // eslint-disable-next-line no-restricted-syntax
     <input data-testid="card-search" value={value} onChange={(e) => onChange(e.target.value)} placeholder={placeholder} />
   ),
   CardControlsRow: () => null,

--- a/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDHealth.test.tsx
@@ -41,6 +41,13 @@ vi.mock('../../ui/Skeleton', () => ({
   SkeletonCardWithRefresh: () => <div data-testid="skeleton-card-with-refresh" />,
 }))
 
+vi.mock('../../../lib/cards/CardComponents', () => ({
+  CardBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyLoaded: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardScrollList: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 describe('ArgoCDHealth', () => {

--- a/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
+++ b/web/src/components/cards/__tests__/ArgoCDSyncStatus.test.tsx
@@ -56,6 +56,9 @@ vi.mock('../../ui/Skeleton', () => ({
 
 vi.mock('../../../lib/cards/CardComponents', () => ({
   CardClusterFilter: () => <div data-testid="cluster-filter" />,
+  CardBody: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyLoaded: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  CardBodyEmpty: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
 }))
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/DataComplianceCards.test.tsx
@@ -38,7 +38,7 @@ vi.mock('../../../lib/kubectlProxy', () => ({
 const mockUseCardLoadingState = vi.fn()
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (...args: unknown[]) => mockUseCardLoadingState(...args),
-  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
+  useCardDemoState: () => ({ shouldUseDemoData: mockIsDemoMode(), reason: null, showDemoBadge: false }),
 }))
 
 const mockUseCertManager = vi.fn()

--- a/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
+++ b/web/src/components/cards/__tests__/HardwareHealthCard.test.tsx
@@ -70,6 +70,7 @@ vi.mock('../../../hooks/useCachedData', async (importOriginal) => ({
 
 vi.mock('../CardDataContext', () => ({
   useCardLoadingState: (state: unknown) => mockUseCardLoadingState(state),
+  useCardDemoState: () => ({ shouldUseDemoData: false, reason: null, showDemoBadge: false }),
 }))
 
 vi.mock('../../../hooks/useMCP', () => ({


### PR DESCRIPTION
Fixes #21236

Fix two root causes from the useModal/card-layout refactor (PRs #21229, #21231, #21233) that still caused test failures after the partial fix in PR #21235:

## Root Cause A — CardComponents mock missing new CardLayout exports

`ArgoCDHealth.tsx`, `ArgoCDSyncStatus.tsx`, and `CRDHealth.tsx` were migrated to use `CardBody` / `CardBodyLoaded` / `CardBodyEmpty` / `CardScrollList` from `CardComponents` (commit 2c9a8c647). Tests that mocked `CardComponents` with a factory (or didn't mock it at all, loading problematic transitive dependencies via `CardClusterFilter → CardWrapper`) were broken.

**Files fixed:**
- `ArgoCDHealth.test.tsx` — add `vi.mock` for `CardComponents` with layout stubs
- `__tests__/ArgoCDHealth.test.tsx` — same
- `ArgoCDSyncStatus.test.tsx` — add `CardBody`/`CardBodyLoaded`/`CardBodyEmpty` stubs to existing `CardClusterFilter`-only mock
- `__tests__/ArgoCDSyncStatus.test.tsx` — same
- `CRDHealth.test.tsx` — add layout stubs to existing `CardComponents` mock; add missing `React` import for JSX in mock factories

## Root Cause B — CardDataContext mock missing `useCardDemoState`

`Checkers.tsx` and `HardwareHealthCard.tsx` were migrated to `useCardDemoState` in PR #21231 (commit 1391e776c). Their test files were not updated.

**Files fixed:**
- `ArcadeGames.test.tsx` — add `useCardDemoState` to `CardDataContext` mock (ArcadeGames tests Checkers, which calls `useCardDemoState`)
- `__tests__/HardwareHealthCard.test.tsx` — add `useCardDemoState` to `CardDataContext` mock