### PR TITLE
[scanner] fix: use shared Button component for consistency

### DIFF
--- a/web/src/components/nodes/Nodes.tsx
+++ b/web/src/components/nodes/Nodes.tsx
@@ -8,6 +8,7 @@ import { formatMemoryStat } from '../../lib/formatStats'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
+import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 import { useModal } from '../../hooks/useModal'
 import { useGPUTaintFilter, GPUTaintFilterControl } from '../cards/GPUTaintFilter'
@@ -169,7 +170,7 @@ export function Nodes() {
               <div className="flex items-center justify-center gap-2 text-amber-400 text-sm bg-amber-500/10 p-3 rounded-lg border border-amber-500/20">
                 <ShieldAlert className="w-4 h-4" />
                 <span>{t('gpuReservations.inventory.hiddenGpus', '{{count}} GPUs hidden', { count: hiddenGPUCount })}</span>
-                <button onClick={clear} className="underline hover:text-amber-300 ml-2">{t('common:nodes.clearFilters')}</button>
+                <Button variant="ghost" size="sm" onClick={clear} className="underline hover:text-amber-300 ml-2">{t('common:nodes.clearFilters')}</Button>
               </div>
             )}
           </div>


### PR DESCRIPTION
Fixes #21239

Replace raw `<button>` element in `web/src/components/nodes/Nodes.tsx` (line 172) with the shared `Button` component from `../ui/Button`.

**Changes:**
- Import `Button` from `../ui/Button`
- Replace `<button onClick={clear} className="underline hover:text-amber-300 ml-2">` with `<Button variant="ghost" size="sm" ...>`, preserving all existing styling, onClick handler, and translated label

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>