### PR TITLE
[scanner] fix: wrap GPU tab components in CompactErrorBoundary

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -53,6 +53,7 @@ import { GPUReservationsTab } from './GPUReservationsTab'
 import { GPUInventoryTab } from './GPUInventoryTab'
 import { GPUDashboardTab } from './GPUDashboardTab'
 import { computeGPUOverviewStats } from './gpuOverviewStats'
+import { CompactErrorBoundary } from '../CompactErrorBoundary'
 
 type ViewTab = 'overview' | 'calendar' | 'quotas' | 'inventory' | 'dashboard'
 
@@ -585,6 +586,7 @@ export function GPUReservations() {
 
       {/* Overview Tab */}
       {activeTab === 'overview' && (
+        <CompactErrorBoundary context="GPUOverviewTab">
         <GPUOverviewTab
           stats={stats}
           filteredReservations={filteredReservations}
@@ -593,10 +595,12 @@ export function GPUReservations() {
           showOnlyMine={showOnlyMine}
           onSelectReservation={goToReservation}
         />
+        </CompactErrorBoundary>
       )}
 
       {/* Calendar Tab */}
       {activeTab === 'calendar' && (
+        <CompactErrorBoundary context="GPUCalendarTab">
         <GPUCalendarTab
           currentMonth={currentMonth}
           calendarWeeks={calendarWeeks}
@@ -608,10 +612,12 @@ export function GPUReservations() {
           onAddReservation={openCreateFormForDate}
           getGPUCountForDay={getGPUCountForDay}
         />
+        </CompactErrorBoundary>
       )}
 
       {/* Reservations Tab */}
       {activeTab === 'quotas' && (
+        <CompactErrorBoundary context="GPUReservationsTab">
         <GPUReservationsTab
           filteredReservations={filteredReservations}
           utilizations={utilizations}
@@ -630,20 +636,24 @@ export function GPUReservations() {
           onDeleteReservation={setDeleteConfirmId}
           onCreateReservation={openCreateForm}
         />
+        </CompactErrorBoundary>
       )}
 
       {/* Inventory Tab */}
       {activeTab === 'inventory' && (
+        <CompactErrorBoundary context="GPUInventoryTab">
         <GPUInventoryTab
           gpuClusters={gpuClusters}
           nodes={nodes}
           nodesLoading={nodesLoading}
           effectiveDemoMode={effectiveDemoMode}
         />
+        </CompactErrorBoundary>
       )}
 
       {/* Dashboard Tab */}
       {activeTab === 'dashboard' && (
+        <CompactErrorBoundary context="GPUDashboardTab">
         <GPUDashboardTab
           dashboardCards={dashboardCards}
           dashCardIds={dashCardIds}
@@ -656,6 +666,7 @@ export function GPUReservations() {
           onTriggerRefresh={triggerRefresh}
           onShowAddCardModal={openAddCardModal}
         />
+        </CompactErrorBoundary>
       )}
 
       {/* Add Card Modal */}


### PR DESCRIPTION
Fixes #21240

Wraps each GPU tab component (`GPUOverviewTab`, `GPUCalendarTab`, `GPUReservationsTab`, `GPUInventoryTab`, `GPUDashboardTab`) in `CompactErrorBoundary` within `GPUReservations.tsx`.

This prevents a render crash in one tab from propagating to the entire GPU Reservations page. The `CompactErrorBoundary` already handles logging via `emitError` and `console.error`, addressing the Auto-QA finding about complex components without error boundaries.

**Change:** 1 file, 11 insertions.