### PR TITLE
[scanner] fix: silence exhaustive-deps for stable notifyListeners ref

### DIFF
--- a/web/.eslint-baseline.json
+++ b/web/.eslint-baseline.json
@@ -9667,13 +9667,6 @@
     "message": "'act' is defined but never used. Allowed unused vars must match /^_/u."
   },
   {
-    "file": "src/hooks/mcp/buildpacks.ts",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 265,
-    "column": 5,
-    "message": "React Hook useCallback has a missing dependency: 'notifyListeners'. Either include it or remove the dependency array."
-  },
-  {
     "file": "src/hooks/mcp/compute.ts",
     "rule": "null",
     "line": 1,
@@ -9686,13 +9679,6 @@
     "line": 385,
     "column": 6,
     "message": "React Hook useEffect has an unnecessary dependency: 'gpuNodeCache.consecutiveFailures'. Either exclude it or remove the dependency array. Outer scope values like 'gpuNodeCache.consecutiveFailures' aren't valid dependencies because mutating them doesn't re-render the component."
-  },
-  {
-    "file": "src/hooks/mcp/crossplane.ts",
-    "rule": "react-hooks/exhaustive-deps",
-    "line": 268,
-    "column": 5,
-    "message": "React Hook useCallback has a missing dependency: 'notifyListeners'. Either include it or remove the dependency array."
   },
   {
     "file": "src/hooks/mcp/useClusterResourceQuery.ts",

--- a/web/src/hooks/mcp/buildpacks.ts
+++ b/web/src/hooks/mcp/buildpacks.ts
@@ -262,6 +262,7 @@ export function useBuildpackImages(cluster?: string) {
         if (!cluster) notifyListeners(false)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- notifyListeners is a stable ref (notifyListenersRef.current)
     [cluster]
   )
 

--- a/web/src/hooks/mcp/crossplane.ts
+++ b/web/src/hooks/mcp/crossplane.ts
@@ -265,6 +265,7 @@ export function useCrossplaneManagedResources(cluster?: string) {
         if (!cluster) notifyListeners(false)
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- notifyListeners is a stable ref (notifyListenersRef.current)
     [cluster]
   )
 


### PR DESCRIPTION
Fixes #21071

The nightly Release workflow (run 29392453528) failed at `npm run lint:check` with 2 new `react-hooks/exhaustive-deps` violations:

- `src/hooks/mcp/buildpacks.ts:265:5` — missing dep `notifyListeners`
- `src/hooks/mcp/crossplane.ts:268:5` — missing dep `notifyListeners`

In both files, `notifyListeners` is assigned from `notifyListenersRef.current` (a `useRef`), so its identity is stable across renders and does not belong in the `useCallback` deps array. Added `// eslint-disable-next-line react-hooks/exhaustive-deps` with a short justification, matching the existing convention used elsewhere in `src/hooks/` (e.g. `useDiagnoseRepairLoop.ts`, `useMissionSuggestions.ts`, `useStackDiscovery.ts`).