### PR TITLE
[scanner] fix: Release workflow failure

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -24,6 +24,7 @@ import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { useAuth } from '../../lib/auth'
 import { useToast } from '../ui/Toast'
 import { cn } from '../../lib/cn'
+import { Input } from '../ui/Input'
 import { useGPUReservations } from '../../hooks/useGPUReservations'
 import { useGPUUtilizations } from '../../hooks/useGPUUtilizations'
 import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
@@ -393,7 +394,7 @@ export function GPUReservations() {
     }
 
     return weeks
-  }, [filteredReservations, startingDay, daysInMonth, currentMonth, getReservationDayRange])
+  }, [filteredReservations, startingDay, daysInMonth, getReservationDayRange])
 
   // Get GPU count reserved on a specific day
   const getGPUCountForDay = (day: number) => {
@@ -564,7 +565,7 @@ export function GPUReservations() {
                   : 'border-border bg-secondary text-muted-foreground hover:text-foreground'
               )}
             >
-              <input
+              <Input
                 type="checkbox"
                 checked={showOnlyMine}
                 onChange={toggleShowOnlyMine}


### PR DESCRIPTION
Fixes #21244

## Summary
Fixed two lint violations in `src/components/gpu/GPUReservations.tsx` that were causing the Release workflow to fail:

1. **Line 396** — Removed unnecessary `currentMonth` dependency from useMemo. The dependency is already captured through `getReservationDayRange`, which is included in the deps array.

2. **Line 567** — Replaced raw `<input type="checkbox">` with the `<Input>` component from `components/ui/Input.tsx` to comply with the `no-restricted-syntax` linting rule.

## Related Issues
- Fixes #21244 (this Release workflow failure)
- Related to #21071 (broader nightly release issues)