### PR TITLE
🐛 fix: tie refresh icon spin animation to loading state (FeatureRequestList retry button)

### DIFF
--- a/web/src/components/feedback/FeatureRequestList.tsx
+++ b/web/src/components/feedback/FeatureRequestList.tsx
@@ -188,7 +188,7 @@ export function FeatureRequestList() {
           onClick={() => loadRequests()}
           className="text-sm text-purple-400 hover:text-purple-300 flex items-center gap-1 mx-auto"
         >
-          <RefreshCw className="w-3 h-3" />
+          <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
           Retry
         </button>
       </div>


### PR DESCRIPTION
Fixes part of #21261 — audit of 5 targeted files from the Auto-QA report.

## What changed

**FeatureRequestList.tsx** — the error-state retry button had a bare `<RefreshCw className="w-3 h-3" />` with no `animate-spin` conditional. Fixed to use the existing `isLoading` state from `useFeatureRequests()`:

```tsx
- <RefreshCw className="w-3 h-3" />
+ <RefreshCw className={cn('w-3 h-3', isLoading && 'animate-spin')} />
```

## Audit findings for the other 4 targeted files

| File | Status |
|------|--------|
| UpdatesTab.tsx | ✅ Already fixed: `isRefreshing ? 'animate-spin' : ''` |
| Events.tsx | ✅ Already fixed: `cn('w-4 h-4', refreshingAll && 'animate-spin')` |
| RewardsPanel.tsx | ✅ Already fixed: `isRefreshing ? 'animate-spin' : ''` |
| UpdateSettingsForm.tsx | ⏭️ Line 137 already has `isVisuallySpinning`; line 757 is a browser-reload button (`handleReloadWindow`) — page reloads immediately so no loading-state spin is meaningful |

Part of #21261 — remaining unfixed files will be addressed in follow-up PRs to keep review focused.