### PR TITLE
✨ feat: add data freshness indicators to 5 cached-data components

### DIFF
--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -14,6 +14,7 @@ import { cn } from '../../lib/cn'
 import { useACMM, DEFAULT_REPO, normalizeRepoInput } from './ACMMProvider'
 import { ALL_CRITERIA } from '../../lib/acmm/sources'
 import { useToast } from '../ui/Toast'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 /** ACMM-source criteria only — used for the badge preview to match the
  *  shields.io badge endpoint which counts only ACMM criteria, not criteria
@@ -346,7 +347,14 @@ export function RepoPicker() {
           </div>
         ) : (
           <div>
-            Scanned {scannedLabel} · {detected}/{totalCriteria} criteria detected · L{scan.level.level} ({scan.level.levelName})
+            <div className="flex items-center gap-1.5">
+              <RefreshIndicator
+                isRefreshing={scan.isRefreshing}
+                lastUpdated={scan.lastRefresh ? new Date(scan.lastRefresh) : null}
+                size="xs"
+              />
+              <span>· {detected}/{totalCriteria} criteria detected · L{scan.level.level} ({scan.level.levelName})</span>
+            </div>
           </div>
         )}
       </div>

--- a/web/src/components/acmm/RepoPicker.tsx
+++ b/web/src/components/acmm/RepoPicker.tsx
@@ -133,9 +133,6 @@ export function RepoPicker() {
     [scan.data.detectedIds],
   )
   const acmmTotal = useMemo(() => ACMM_CRITERIA.length, [])
-  const scannedLabel = scan.data.scannedAt
-    ? new Date(scan.data.scannedAt).toLocaleTimeString()
-    : '—'
 
   return (
     // Issue 8857 — the `border-b` used to live on this outer sticky wrapper,

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -22,6 +22,7 @@ import { useComplianceFrameworks, useFrameworkEvaluation, type Framework, type C
 import { clusterCache, subscribeClusterData } from '../../hooks/mcp/shared'
 import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useTranslation } from 'react-i18next'
 
 /* ────────── status badge helpers ────────── */
@@ -207,10 +208,16 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
   const [selectedFwId, setSelectedFwId] = useState<string | null>(null)
   const [selectedCluster, setSelectedCluster] = useState<string>('')
   const [autoRefresh, setAutoRefresh] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   // Stable ID of the first framework — avoids re-running the effect when the
   // frameworks array gets a new reference but its contents haven't changed.
   const firstFwId = frameworks.length > 0 ? frameworks[0].id : null
+
+  // Record timestamp when evaluation result arrives so the freshness indicator updates
+  useEffect(() => {
+    if (result) setLastUpdated(new Date())
+  }, [result])
 
   // Auto-select first framework when loaded
   useEffect(() => {
@@ -342,6 +349,12 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
               <p className="text-xs text-muted-foreground">
                 Evaluated at {new Date(result.evaluated_at).toLocaleString()}
               </p>
+              <RefreshIndicator
+                isRefreshing={isEvaluating}
+                lastUpdated={lastUpdated}
+                size="xs"
+                className="mt-1"
+              />
             </div>
           </div>
 

--- a/web/src/components/compliance/OIDCDashboard.tsx
+++ b/web/src/components/compliance/OIDCDashboard.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback, memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { oidcDashboardConfig } from '../../config/dashboards/oidc'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 import {
   CheckCircle2, XCircle, AlertTriangle, Loader2,
   Users, ShieldCheck, Fingerprint, Clock,
@@ -57,6 +58,7 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
     isLoading: summaryLoading,
     isRefreshing: summaryRefreshing,
     refetch: refetchSummary,
+    lastRefresh: summaryLastRefresh,
   } = useCache<OIDCSummary | null>({
     key: OIDC_SUMMARY_CACHE_KEY,
     category: 'rbac',
@@ -264,10 +266,14 @@ export const OIDCDashboardContent = memo(function OIDCDashboardContent() {
         </div>
       )}
 
-      {/* Evaluated At */}
+      {/* Freshness indicator */}
       {summary && (
-        <div className="text-xs text-muted-foreground text-right">
-          Last evaluated: {new Date(summary.evaluated_at).toLocaleString()}
+        <div className="flex justify-end">
+          <RefreshIndicator
+            isRefreshing={summaryRefreshing}
+            lastUpdated={summaryLastRefresh ? new Date(summaryLastRefresh) : null}
+            size="xs"
+          />
         </div>
       )}
     </div>

--- a/web/src/components/stellar/DigestCard.tsx
+++ b/web/src/components/stellar/DigestCard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { StellarNotification, StellarSolve } from '../../types/stellar'
+import { RefreshIndicator } from '../ui/RefreshIndicator'
 
 interface DigestCardProps {
   notification: StellarNotification
@@ -46,6 +47,12 @@ export function DigestCard({ notification, solves, onDismiss, onOpenEvent }: Dig
             color: 'var(--s-info)',
           }}
         >{t('stellar.digest.dailyRecap')}</span>
+        <RefreshIndicator
+          isRefreshing={false}
+          lastUpdated={new Date(notification.createdAt)}
+          size="xs"
+          className="mr-1"
+        />
         <div style={{ flex: 1 }} />
         <button
           onClick={() => setExpanded(e => !e)}


### PR DESCRIPTION
Fixes #21260 (partial — 4 of ~20 files from the Auto-QA freshness report)

Adds 'Updated X ago' indicators so users can see when data was last refreshed. Reuses the existing `RefreshIndicator` component — no new abstractions.

## Files touched

| File | Change |
|------|--------|
| `stellar/DigestCard.tsx` | Show freshness from `notification.createdAt` |
| `compliance/OIDCDashboard.tsx` | Replace static 'Last evaluated' text with `RefreshIndicator` driven by `useCache`'s `lastRefresh` |
| `compliance/ComplianceFrameworks.tsx` | Track evaluation result timestamp in state; show `RefreshIndicator` next to evaluated-at line |
| `acmm/RepoPicker.tsx` | Replace absolute 'Scanned HH:MM:SS' label with `RefreshIndicator` using `scan.lastRefresh` |

`EnterpriseSidebar.tsx` was skipped — pure navigation sidebar with no data fetching.

Demo-mode subscription work (also flagged in #21260) is left for follow-up PRs.