### PR TITLE
[scanner] fix: refresh icon consistency in cards (partial #21261)

### DIFF
--- a/web/src/components/cards/DynamicCard.tsx
+++ b/web/src/components/cards/DynamicCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { AlertTriangle, Loader2, Database } from 'lucide-react'
+import { AlertTriangle, Loader2, Database, RefreshCw } from 'lucide-react'
 import { getStoredAuthToken } from '../../lib/authToken'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
 import { getDynamicCard } from '../../lib/dynamic-cards/dynamicCardRegistry'
@@ -291,6 +291,11 @@ export function Tier1CardRuntime({ cardDefinition }: Tier1Props) {
 
   return (
     <div className="h-full flex flex-col min-h-card">
+      {isApiSource && apiRefreshing && (
+        <div className="flex justify-end mb-1">
+          <RefreshCw className="w-3 h-3 text-muted-foreground animate-spin" />
+        </div>
+      )}
       {/* Stats */}
       {showStats && cardDefinition.stats && cardDefinition.stats.length > 0 && (
         <div className={cn(

--- a/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
+++ b/web/src/components/cards/keycloak_status/KeycloakStatus.tsx
@@ -9,6 +9,7 @@ import {
   Users,
   Globe,
   Key,
+  RefreshCw,
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Skeleton, SkeletonStats, SkeletonList } from '../../ui/Skeleton'
@@ -119,7 +120,7 @@ function RealmRow({ realm }: { realm: KeycloakRealm }) {
 
 export function KeycloakStatus() {
   const { t } = useTranslation('cards')
-  const { data, isFailed, showSkeleton, showEmptyState } =
+  const { data, isRefreshing, isFailed, showSkeleton, showEmptyState } =
     useKeycloakStatus()
 
   const realms = data.realms || []
@@ -251,6 +252,9 @@ export function KeycloakStatus() {
             {operatorPods.ready}/{operatorPods.total}{' '}
             {t('keycloak.pods')}
           </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
         </div>
       </div>
 

--- a/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
+++ b/web/src/components/cards/openyurt_status/OpenYurtStatus.tsx
@@ -167,7 +167,7 @@ function GatewayRow({ gw }: { gw: OpenYurtGateway }) {
 
 export function OpenYurtStatus() {
   const { t } = useTranslation('cards')
-  const { data, error, showSkeleton, showEmptyState } = useOpenYurtStatus()
+  const { data, isRefreshing, error, showSkeleton, showEmptyState } = useOpenYurtStatus()
   const [search, setSearch] = useState('')
 
   // Guard against undefined nested data
@@ -269,6 +269,9 @@ export function OpenYurtStatus() {
             {controllerPods.ready}/{controllerPods.total}{' '}
             {t('openyurt.controllerPods', 'pods')}
           </span>
+        </div>
+        <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <RefreshCw className={`w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}`} />
         </div>
       </div>
 


### PR DESCRIPTION
Partial fix for #21261 — cards subset only. Other files in the issue remain to be addressed in follow-up PRs.

### Changes

- **OpenYurtStatus**: destructure `isRefreshing` from hook and add `RefreshCw` icon with `animate-spin` in card header
- **KeycloakStatus**: add `RefreshCw` import and spin indicator in card header  
- **DynamicCard (Tier1)**: add `RefreshCw` spin indicator when `apiRefreshing`

### No changes needed

- `KarmadaStatus` — already had `animate-spin` on RefreshCw
- `OtelStatus` — already had `animate-spin` on RefreshCw  
- `FailoverTimeline` — already uses `RefreshIndicator` component with `isRefreshing`

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>