### PR TITLE
[scanner] fix: complete refresh icon animation consistency

### DIFF
--- a/web/src/components/security/Security.tsx
+++ b/web/src/components/security/Security.tsx
@@ -366,6 +366,7 @@ export function Security() {
           stats={stats}
           complianceByCategory={complianceByCategory}
           handleRefresh={handleRefresh}
+          isRefreshing={dataRefreshing || securityLoading || securityRefreshing}
         />
       )}
     </>

--- a/web/src/components/security/SecurityComplianceTab.tsx
+++ b/web/src/components/security/SecurityComplianceTab.tsx
@@ -17,9 +17,10 @@ interface SecurityComplianceTabProps {
   }
   complianceByCategory: ComplianceByCategory
   handleRefresh: () => void
+  isRefreshing?: boolean
 }
 
-export function SecurityComplianceTab({ stats, complianceByCategory, handleRefresh }: SecurityComplianceTabProps) {
+export function SecurityComplianceTab({ stats, complianceByCategory, handleRefresh, isRefreshing = false }: SecurityComplianceTabProps) {
   const { t } = useTranslation('cards')
   const { t: tc } = useTranslation()
 
@@ -78,7 +79,7 @@ export function SecurityComplianceTab({ stats, complianceByCategory, handleRefre
             onClick={handleRefresh}
             className="flex items-center gap-2 px-4 py-2 rounded-lg bg-secondary hover:bg-secondary/80 text-sm text-foreground transition-colors"
           >
-            <RefreshCw className="w-4 h-4" />
+            <RefreshCw className={cn('w-4 h-4', isRefreshing && 'animate-spin')} />
             {tc('common.refresh')}
           </button>
         </div>


### PR DESCRIPTION
Fixes #21261

Completes the work started in #21264 by applying the same refresh icon animation pattern to the one remaining component that had a real gap.

## Changes

### `web/src/components/security/SecurityComplianceTab.tsx`
Added `isRefreshing?: boolean` prop to the component interface and used it to conditionally apply `animate-spin` to the `RefreshCw` icon in the compliance refresh button. This is the only file from the issue's list that had both a clickable refresh button **and** an available loading state that was not being reflected in the icon animation.

### `web/src/components/security/Security.tsx`
Passes `isRefreshing={dataRefreshing || securityLoading || securityRefreshing}` to `SecurityComplianceTab` so the parent's combined refresh state drives the icon spin.

## Audit of remaining files from #21261

All other files flagged in the issue were audited and are already consistent:

| File | Status |
|------|--------|
| `feedback/FeatureRequestList.tsx` | ✅ `cn('w-3 h-3', isLoading && 'animate-spin')` |
| `feedback/UpdatesTabGitHubContributionsSection.tsx` | ✅ `isGitHubRefreshing ? 'animate-spin' : ''` |
| `feedback/UpdatesTab.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `events/Events.tsx` | ✅ `refreshingAll && 'animate-spin'` |
| `rewards/RewardsPanel.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `compliance/SegregationOfDuties.tsx` | ✅ `loading && 'animate-spin'` |
| `compliance/ChangeControlAudit.tsx` | ✅ `isRetrying && 'animate-spin'` |
| `compliance/DataResidency.tsx` | ✅ `isRetrying && 'animate-spin'` |
| `history/CardHistory.tsx` | ✅ Static semantic icon (history entry type) |
| `settings/UpdateSettingsForm.tsx` | ✅ Browser-reload button (synchronous) |
| `settings/sections/PersistenceSection.tsx` | ✅ `syncing ? 'animate-spin' : ''` |
| `settings/sections/ProfileSection.tsx` | ✅ `isSaving && 'animate-spin'` |
| `settings/sections/AgentSection.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `settings/sections/TokenUsageSection.tsx` | ✅ Synchronous reset action |
| `settings/sections/AgentBackendSettings.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `settings/sections/LocalClustersSection.tsx` | ✅ `isLoading ? 'animate-spin' : ''` |
| `settings/sections/GitHubTokenSection.tsx` | ✅ `tokenTesting ? 'animate-spin' : ''` |
| `acmm/RepoPicker.tsx` | ✅ `scan.isRefreshing ? 'animate-spin' : ''` |
| `widget/MiniDashboard.tsx` | ✅ `isRefreshing && 'animate-spin'` |
| `gitops/GitOps.tsx` | ✅ Sync-dialog trigger (not async fetch) |
| `terminal/PodExecTerminal.tsx` | ✅ Always-spinning reconnect indicator |
| `PageErrorBoundary.tsx` | ✅ Page-reload button (synchronous) |
| `dashboard/ReplaceCardModal.tsx` | ✅ Header icon only |
| `dashboard/ResetDialog.tsx` | ✅ Option visual icon |
| `drilldown/DrillDownModal.tsx` | ✅ Error-state retry button |
| `drilldown/RemediationConsole.tsx` | ✅ `isExecuting ? 'animate-spin' : ''` |
| `drilldown/views/ArgoAppDrillDown.tsx` | ✅ Section heading icon |
| `drilldown/views/RBACDrillDown.tsx` | ✅ `refreshing && 'animate-spin'` |
| `drilldown/views/DeploymentDrillDown.tsx` | ✅ `isRefreshing && 'animate-spin'` |
| `drilldown/views/HelmReleaseDrillDown.tsx` | ✅ Metadata label icon ("Revision") |
| `drilldown/views/OperatorDrillDown.tsx` | ✅ Metadata label icon ("Channel") |
| `drilldown/views/KustomizationDrillDown.tsx` | ✅ No clickable RefreshCw button |
| `drilldown/views/PodDrillDown.tsx` | ✅ `isRefreshing && 'animate-spin'` |
| `drilldown/views/YAMLDrillDown.tsx` | ✅ `isLoading ? 'animate-spin' : ''` |
| `drilldown/views/LogsDrillDown.tsx` | ✅ `isLoading ? 'animate-spin' : ''` |
| `drilldown/views/pod-drilldown/PodRelatedTab.tsx` | ✅ `relatedLoading && 'animate-spin'` |
| `drilldown/views/pod-drilldown/PodAiAnalysis.tsx` | ✅ `aiAnalysisLoading && 'animate-spin'` |
| `drilldown/views/pod-drilldown/PodOutputTab.tsx` | ✅ No RefreshCw button |
| `drilldown/views/EventsDrillDown.tsx` | ✅ `isLoading ? 'animate-spin' : ''` |
| `drilldown/views/PolicyDrillDown.tsx` | ✅ Metadata label icon ("Action") |
| `drilldown/views/BuildpackDrillDown.tsx` | ✅ Metadata label icon ("Status") |
| `setup/DeveloperSetupDialog.tsx` | ✅ Collapsible-section label icon |
| `cards/karmada_status/KarmadaStatus.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `cards/openyurt_status/OpenYurtStatus.tsx` | ✅ Fixed in #21264 |
| `cards/otel_status/index.tsx` | ✅ `isRefreshing ? 'animate-spin' : ''` |
| `cards/failover_timeline/FailoverTimeline.tsx` | ✅ Static event-type icon ("Rebalance") |