### PR TITLE
[scanner] fix: add missing cleanup in component effects

### DIFF
--- a/web/src/components/namespaces/NamespaceAccessPanel.tsx
+++ b/web/src/components/namespaces/NamespaceAccessPanel.tsx
@@ -23,12 +23,13 @@ export function NamespaceAccessPanel({
   const [accessEntries, setAccessEntries] = useState<NamespaceAccessEntry[]>([])
   const [accessLoading, setAccessLoading] = useState(false)
 
-  const fetchAccess = useCallback(async (ns: NamespaceDetails) => {
+  const fetchAccess = useCallback(async (ns: NamespaceDetails, signal?: AbortSignal) => {
     setAccessLoading(true)
     try {
-      const response = await api.get<{ bindings: typeof accessEntries }>(`/api/namespaces/${encodeURIComponent(ns.name)}/access?cluster=${encodeURIComponent(ns.cluster)}`)
+      const response = await api.get<{ bindings: typeof accessEntries }>(`/api/namespaces/${encodeURIComponent(ns.name)}/access?cluster=${encodeURIComponent(ns.cluster)}`, { signal })
       setAccessEntries(response.data?.bindings || [])
     } catch (err: unknown) {
+      if (err instanceof Error && err.name === 'AbortError') return
       console.error('Failed to fetch access:', err)
       setAccessEntries([])
       const message = err instanceof Error && err.message?.includes('403')
@@ -70,7 +71,9 @@ export function NamespaceAccessPanel({
 
   useEffect(() => {
     if (namespace && isAdmin) {
-      fetchAccess(namespace)
+      const controller = new AbortController()
+      fetchAccess(namespace, controller.signal)
+      return () => controller.abort()
     }
   }, [namespace, fetchAccess, isAdmin])
 

--- a/web/src/components/updates/WhatsNewModal.tsx
+++ b/web/src/components/updates/WhatsNewModal.tsx
@@ -1,6 +1,6 @@
 import { COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
 import { formatTimeAgo } from '../../lib/formatters'
-import { useState, useMemo, useCallback } from 'react'
+import { useState, useMemo, useCallback, useEffect, useRef } from 'react'
 import { Download, ChevronDown, Copy, Check } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
@@ -43,6 +43,13 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const [updating, setUpdating] = useState(false)
   const [showManualUpdate, setShowManualUpdate] = useState(false)
   const [copiedCommand, setCopiedCommand] = useState<string | null>(null)
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
+    }
+  }, [])
 
   const markdownComponents = useMemo(() => buildReleaseNotesComponents('sm'), [])
   const hasReleaseNotes = !!latestRelease?.releaseNotes?.trim()
@@ -101,7 +108,8 @@ export function WhatsNewModal({ isOpen, onClose }: WhatsNewModalProps) {
   const handleCopyCommand = useCallback(async (cmd: string) => {
     await copyToClipboard(cmd)
     setCopiedCommand(cmd)
-    setTimeout(() => setCopiedCommand(null), COPY_FEEDBACK_TIMEOUT_MS)
+    if (copyTimeoutRef.current) clearTimeout(copyTimeoutRef.current)
+    copyTimeoutRef.current = setTimeout(() => setCopiedCommand(null), COPY_FEEDBACK_TIMEOUT_MS)
   }, [])
 
   const manualCommands: { label: string; command: string }[] = useMemo(() => {


### PR DESCRIPTION
Fixes #21271

## Summary

Adds missing cleanup to two components that had potential memory leaks:

### `WhatsNewModal.tsx`
- Track the copy-feedback `setTimeout` in a `useRef` (`copyTimeoutRef`)
- Clear the timer on unmount via a `useEffect` cleanup function
- Also clear any pending timer before starting a new one in `handleCopyCommand`

### `NamespaceAccessPanel.tsx`
- Pass an `AbortSignal` to `api.get()` so the in-flight request is cancelled when the effect re-runs or the component unmounts
- Silently ignore `AbortError` to avoid surfacing spurious error toasts on cleanup

## Files changed
- `web/src/components/updates/WhatsNewModal.tsx`
- `web/src/components/namespaces/NamespaceAccessPanel.tsx`