### PR TITLE
[scanner] fix: React efficiency improvements (named imports)

### DIFF
--- a/web/src/config/cards/__tests__/cubefs-status.test.ts
+++ b/web/src/config/cards/__tests__/cubefs-status.test.ts
@@ -1,4 +1,4 @@
-import * as moduleExports from '../cubefs-status'
+import { cubefsStatusConfig } from '../cubefs-status'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
-registerCardConfigTest('cubefs-status', moduleExports)
+registerCardConfigTest('cubefs-status', { cubefsStatusConfig })

--- a/web/src/config/cards/__tests__/flatcar-status.test.ts
+++ b/web/src/config/cards/__tests__/flatcar-status.test.ts
@@ -1,4 +1,4 @@
-import * as moduleExports from '../flatcar-status'
+import { flatcarStatusConfig } from '../flatcar-status'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
-registerCardConfigTest('flatcar-status', moduleExports)
+registerCardConfigTest('flatcar-status', { flatcarStatusConfig })

--- a/web/src/config/cards/__tests__/github-ci-monitor.test.ts
+++ b/web/src/config/cards/__tests__/github-ci-monitor.test.ts
@@ -1,4 +1,4 @@
-import * as moduleExports from '../github-ci-monitor'
+import { githubCiMonitorConfig } from '../github-ci-monitor'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
-registerCardConfigTest('github-ci-monitor', moduleExports)
+registerCardConfigTest('github-ci-monitor', { githubCiMonitorConfig })

--- a/web/src/config/cards/__tests__/kube-doom.test.ts
+++ b/web/src/config/cards/__tests__/kube-doom.test.ts
@@ -1,4 +1,4 @@
-import * as moduleExports from '../kube-doom'
+import { kubeDoomConfig } from '../kube-doom'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
-registerCardConfigTest('kube-doom', moduleExports)
+registerCardConfigTest('kube-doom', { kubeDoomConfig })

--- a/web/src/config/cards/__tests__/sudoku-game.test.ts
+++ b/web/src/config/cards/__tests__/sudoku-game.test.ts
@@ -1,4 +1,4 @@
-import * as moduleExports from '../sudoku-game'
+import { sudokuGameConfig } from '../sudoku-game'
 import { registerCardConfigTest } from './card-config-test-helpers'
 
-registerCardConfigTest('sudoku-game', moduleExports)
+registerCardConfigTest('sudoku-game', { sudokuGameConfig })


### PR DESCRIPTION
Fixes #21273

Replace `import * as moduleExports` with named imports in 5 card config test files to improve tree-shaking compatibility, as flagged by Auto-QA issue #21273.

## Changes

- `github-ci-monitor.test.ts`: use `{ githubCiMonitorConfig }` named import
- `kube-doom.test.ts`: use `{ kubeDoomConfig }` named import
- `flatcar-status.test.ts`: use `{ flatcarStatusConfig }` named import
- `sudoku-game.test.ts`: use `{ sudokuGameConfig }` named import
- `cubefs-status.test.ts`: use `{ cubefsStatusConfig }` named import

Each test file previously imported all module exports via namespace import (`import *`). Since each card module exports a single named config constant, we can use a named import and pass it as an object literal to `registerCardConfigTest`, which iterates `Object.values()` to find card configs. This is functionally equivalent but allows bundlers to tree-shake unused exports.

The remaining 5 files from the issue (`alert-rules`, `contour-status`, `cert-manager`, `node-status`, `cluster-network`) are left for follow-up to keep this PR focused.