### PR TITLE
[scanner] fix: navigation and routing improvements

### DIFF
--- a/web/src/components/AppErrorBoundary.tsx
+++ b/web/src/components/AppErrorBoundary.tsx
@@ -3,6 +3,7 @@ import { AlertTriangle, RefreshCw, Home } from 'lucide-react'
 import i18next from 'i18next'
 import { emitError, markErrorReported } from '../lib/analytics'
 import { Button } from './ui/Button'
+import { ROUTES } from '../config/routes'
 
 interface Props {
   children: ReactNode
@@ -59,7 +60,7 @@ export class AppErrorBoundary extends Component<Props, State> {
   handleGoHome = () => {
     // Full navigation (not client-side) so any bad state in the SPA —
     // including router/query caches — is cleared before landing on "/".
-    window.location.href = '/'
+    window.location.href = ROUTES.HOME
   }
 
   handleRecover = () => {

--- a/web/src/components/PageErrorBoundary.tsx
+++ b/web/src/components/PageErrorBoundary.tsx
@@ -4,6 +4,7 @@ import i18next from 'i18next'
 import { emitError, markErrorReported } from '../lib/analytics'
 import { isChunkLoadError } from '../lib/chunkErrors'
 import { Button } from './ui/Button'
+import { ROUTES } from '../config/routes'
 
 interface Props {
   children: ReactNode
@@ -60,7 +61,7 @@ export class PageErrorBoundary extends Component<Props, State> {
   }
 
   handleGoHome = () => {
-    window.location.href = '/'
+    window.location.href = ROUTES.HOME
   }
 
   handleReload = () => {

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -50,6 +50,7 @@ import {
 } from './submitTab.utils'
 
 import { SubmitTabAttachments } from './SubmitTabAttachments'
+import { getSettingsWithHash } from '../../config/routes'
 
 export { SuccessView } from './SubmitTabSuccessView'
 
@@ -443,7 +444,7 @@ export function SubmitForm({
                 <span>{' · '}</span>
                 <button
                   type="button"
-                  onClick={() => { window.location.href = '/settings#github-token' }}
+                  onClick={() => { window.location.href = getSettingsWithHash('github-token') }}
                   className="text-purple-400 hover:text-purple-300 underline underline-offset-2 p-0 h-auto bg-transparent border-none"
                 >
                   Console Settings

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import {
   shouldMarkBackendUnavailable,
 } from './backendHealthEvents'
 import { reportAppError } from './errors/handleError'
+import { ROUTES } from '../config/routes'
 
 const API_BASE = ''
 const DEFAULT_TIMEOUT = MCP_HOOK_TIMEOUT_MS
@@ -201,7 +202,7 @@ function performSessionExpiry(): void {
 
   // Redirect to login after a delay so the user sees the banner
   setTimeout(() => {
-    window.location.href = '/login?reason=session_expired'
+    window.location.href = `${ROUTES.LOGIN}?reason=session_expired`
   }, SESSION_EXPIRY_REDIRECT_MS)
 }
 


### PR DESCRIPTION
Fixes #21272

## Summary

Replace hardcoded route strings with `ROUTES` constants from `config/routes.ts` — the centralized route registry already present in the codebase.

### Changes

| File | Before | After |
|------|--------|-------|
| `AppErrorBoundary.tsx` | `window.location.href = '/'` | `ROUTES.HOME` |
| `PageErrorBoundary.tsx` | `window.location.href = '/'` | `ROUTES.HOME` |
| `SubmitTab.tsx` | `'/settings#github-token'` | `getSettingsWithHash('github-token')` |
| `lib/api.ts` | `'/login?reason=session_expired'` | `${ROUTES.LOGIN}?reason=session_expired` |

These were the remaining cases where navigation used hardcoded string literals instead of the ROUTES constants, which means a route rename would silently break them. The `config/routes.ts` file already documents this convention ("Always use ROUTES constants instead of hardcoding paths").