### PR TITLE
🌱 fix: nightly unit-test regression

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -400,8 +400,9 @@ export default defineConfig(({ mode }) => ({
       threads: { maxThreads: 1, minThreads: 1 },
     } : undefined,
     // isolate: true ensures each test file runs in its own subprocess with a clean global environment,
-    // preventing vi.stubGlobal() cross-contamination between files (#20256)
-    isolate: true,
+    // preventing vi.stubGlobal() cross-contamination between files (#20256). Disabled in CI to prevent
+    // worker crashes from excessive memory usage when loading hundreds of split chunks per test file (#21083)
+    isolate: process.env.CI ? false : true,
     coverage: {
       provider: 'v8',
       // Disable coverage.all to prevent force-importing source files that trigger


### PR DESCRIPTION
Fixes #21083

Disables Vitest per-file `isolate` in CI to avoid "Worker exited unexpectedly" memory exhaustion introduced when the bundle was split into many small chunks (commit df9e0d18f). Local development still runs with isolation enabled.

```ts
isolate: process.env.CI ? false : true,
```