### PR TITLE
[scanner] fix: restore isolate:true for CI vitest to fix cross-file mock leakage — partial fix for #21284

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -400,9 +400,15 @@ export default defineConfig(({ mode }) => ({
       threads: { maxThreads: 1, minThreads: 1 },
     } : undefined,
     // isolate: true ensures each test file runs in its own subprocess with a clean global environment,
-    // preventing vi.stubGlobal() cross-contamination between files (#20256). Disabled in CI to prevent
-    // worker crashes from excessive memory usage when loading hundreds of split chunks per test file (#21083)
-    isolate: process.env.CI ? false : true,
+    // preventing vi.stubGlobal() cross-contamination between files (#20256).
+    // Note: A prior attempt to disable isolate in CI to work around worker OOM crashes with hundreds of
+    // split chunks (#21083) caused 1598 test failures (#21284) from cross-file mock/global leakage —
+    // 143 test files use vi.stubGlobal, many at module scope, and vi.unstubAllGlobals() in setup.ts's
+    // afterAll runs only once per worker (end of shard) when isolate is false, not once per file.
+    // Restoring isolate:true unconditionally to keep the test suite green; the OOM issue must be
+    // addressed via a different mechanism (chunk-splitting tuning or memory bump) rather than by
+    // sacrificing test isolation.
+    isolate: true,
     coverage: {
       provider: 'v8',
       // Disable coverage.all to prevent force-importing source files that trigger


### PR DESCRIPTION
Refs #21284

## Summary

Coverage Suite [run #4339](https://github.com/kubestellar/console/actions/runs/29686577779) reported **1598 test failures**. Root cause: PR #21283 changed `isolate: true` → `isolate: process.env.CI ? false : true` in `web/vite.config.ts` to work around worker OOM crashes (#21083). The commit message explicitly noted the trade-off risked `vi.stubGlobal()` cross-contamination (#20256), and that risk materialized at scale.

## Root cause

- **143** test files under `web/src/**/*.test.{ts,tsx}` call `vi.stubGlobal(...)`.
- Many stub globals (`fetch`, `localStorage`, `Notification`, `WebSocket`, `matchMedia`, etc.) at **module scope** (top level of the test file), not inside `beforeEach`, so the stubs survive across tests.
- `web/src/test/setup.ts` calls `vi.unstubAllGlobals()` in `afterAll`, but with `isolate: false` under `pool:'forks'/maxWorkers:1` (documented in the setup file itself, lines 242–250), `afterAll` runs once per worker (end of shard), **not once per test file**. So a file that stubs `fetch` at module scope poisons every subsequent file in the same shard.
- The failure signatures in the Coverage Suite logs are consistent with this — e.g. `AssertionError: expected "vi.fn()" to be called with arguments: [...]` in `auth.test.tsx`, `analytics-events.engagement-lifecycle.test.ts`, `useMissions.edgecases.startup.test.tsx`, `clusters.health.test.ts`, and hundreds more.

## Fix

Restore `isolate: true` unconditionally in `web/vite.config.ts`. This is a one-line revert of the isolate change from PR #21283, keeping every other change from that PR (comments, threads/forks pool tuning, `maxWorkers: 1`, etc.) intact.

The original OOM issue #21083 that motivated `isolate: false` still needs to be addressed, but the correct mitigation is chunk-splitting tuning or a memory bump on the CI runners — not by sacrificing per-file test isolation, which the setup file's own architecture depends on.

## Files changed

- `web/vite.config.ts` — restore `isolate: true` (was `isolate: process.env.CI ? false : true`); expand comment explaining why this must not be disabled in CI.

## Estimated impact

**~1598 tests** in the Coverage Suite that are failing purely from cross-file `vi.stubGlobal` leakage should pass again once isolation is restored. This does not attempt to fix any genuine per-test regressions if they exist — those (if any) will still surface after this PR lands, in isolation, making them tractable to triage.

## Verification

Verified by code inspection only (per scanner conventions):
- Confirmed 143 test files use `vi.stubGlobal`; 40+ of them at module scope.
- Confirmed `setup.ts` acknowledges the leakage in its comments (lines 242–250) and relies on `isolate: true` for per-file cleanup.
- Confirmed the failing job logs from run #4339 show mock-not-called and stale-state assertion failures consistent with global leakage.
- CI will validate.

## Not addressed here

Per-test genuine regressions (if any exist under `isolate: true`) and the OOM issue #21083 are out of scope for this partial fix.