### PR TITLE
[scanner] fix: replace single-cluster assumptions with dynamic cluster context

### DIFF
--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -15,8 +15,7 @@ interface CreateNamespaceModalProps {
 export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceModalProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
-  // clusters[0] is intentional: initial dropdown selection — user can pick any cluster from dropdown (line 87)
-  const [cluster, setCluster] = useState(clusters[0] || '')
+  const [cluster, setCluster] = useState('')
   const [teamLabel, setTeamLabel] = useState('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -116,6 +115,7 @@ export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNam
               onChange={(e) => setCluster(e.target.value)}
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-white focus:outline-hidden focus:ring-2 focus:ring-blue-500/50"
             >
+              <option value="" disabled>{t('common.selectCluster', 'Select a cluster')}</option>
               {clusters.map(c => (
                 <option key={c} value={c}>{c}</option>
               ))}

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -177,9 +177,8 @@ function CanICheckerContent() {
     selectedUserGroups, customUserGroup, showAdvanced, checkedSnapshot,
   } = form
 
-  // Get selected cluster for namespace fetching
-  // clusters[0] is intentional: user picks from dropdown (line 256-274), this is the initial default
-  const selectedCluster = cluster || clusters[0] || ''
+  // Get selected cluster for namespace fetching — only after the user makes an explicit choice
+  const selectedCluster = cluster
   const { namespaces } = useNamespaces(selectedCluster)
 
   // Available namespaces for dropdown
@@ -196,8 +195,7 @@ function CanICheckerContent() {
   }
 
   const handleCheck = async () => {
-    // clusters[0] fallback is intentional: cluster is selected via dropdown, this handles initial state
-    const targetCluster = cluster || clusters[0]
+    const targetCluster = cluster
     if (!targetCluster) return
 
     const selectedVerb = verb === 'custom' ? customVerb : verb
@@ -260,14 +258,14 @@ function CanICheckerContent() {
             {t('rbac.cluster')}
           </label>
           <div className="relative">
-            {/* clusters[0] is the initial dropdown selection — user can pick any cluster */}
             <select
               id="cluster-select"
-              value={cluster || clusters[0] || ''}
+              value={cluster}
               onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'cluster', value: e.target.value })}
               className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
               data-testid="can-i-cluster"
             >
+              <option value="" disabled>{t('common.selectCluster', 'Select a cluster')}</option>
               {clusters.map((c) => (
                 <option key={c} value={c}>{c}</option>
               ))}


### PR DESCRIPTION
Fixes #21292

Replace silent `clusters[0]` auto-selection with explicit user-driven cluster selection in two components:

- **`CreateNamespaceModal`**: initialise state to `""` (no cluster pre-selected) and add a disabled "Select a cluster" placeholder option, so the user must make an explicit choice before submitting.
- **`CanIChecker`**: remove `|| clusters[0]` fallbacks from `selectedCluster`, `targetCluster`, and the dropdown `value`; add the same "Select a cluster" placeholder.

The other files flagged by Auto-QA (`NamespaceOverview`, `Kubectl`, `OverlayComparison`, `ResourceMarshall`, `GitOps`) already have correct guards (`SINGLE_VISIBLE_CLUSTER_COUNT` / `isCurrent` checks) at this HEAD and required no changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>