### PR TITLE
[scanner] fix: add loading states to async button handlers

### DIFF
--- a/web/src/components/cards/UserManagement.types.ts
+++ b/web/src/components/cards/UserManagement.types.ts
@@ -27,7 +27,7 @@ export interface ConsoleUsersTabProps {
   expandedUser: string | null
   setExpandedUser: (id: string | null) => void
   onRoleChange: (userId: string, role: UserRole) => void
-  onDeleteUser: (userId: string) => void
+  onDeleteUser: (userId: string) => Promise<void>
   getRoleBadgeClass: (role: UserRole) => string
 }
 

--- a/web/src/components/cards/UserManagementList.tsx
+++ b/web/src/components/cards/UserManagementList.tsx
@@ -161,10 +161,7 @@ export const ConsoleUsersTab = memo(function ConsoleUsersTab({
       <DeleteUserConfirmModal
         userId={deleteConfirmUserId}
         onClose={() => setDeleteConfirmUserId(null)}
-        onConfirm={(userId) => {
-          onDeleteUser(userId)
-          setDeleteConfirmUserId(null)
-        }}
+        onConfirm={(userId) => onDeleteUser(userId)}
       />
     </div>
   )

--- a/web/src/components/cards/UserManagementModal.tsx
+++ b/web/src/components/cards/UserManagementModal.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { ConfirmDialog } from '../../lib/modals'
 
@@ -6,11 +7,12 @@ import { ConfirmDialog } from '../../lib/modals'
 interface DeleteUserConfirmModalProps {
   userId: string | null
   onClose: () => void
-  onConfirm: (userId: string) => void
+  onConfirm: (userId: string) => Promise<void>
 }
 
 export function DeleteUserConfirmModal({ userId, onClose, onConfirm }: DeleteUserConfirmModalProps) {
   const { t } = useTranslation(['cards', 'common'])
+  const [isDeleting, setIsDeleting] = useState(false)
   const isOpen = userId !== null
 
   if (!isOpen) return null
@@ -19,10 +21,16 @@ export function DeleteUserConfirmModal({ userId, onClose, onConfirm }: DeleteUse
     <ConfirmDialog
       isOpen={isOpen}
       onClose={onClose}
-      onConfirm={() => {
+      isLoading={isDeleting}
+      onConfirm={async () => {
         if (userId) {
-          onConfirm(userId)
-          onClose()
+          setIsDeleting(true)
+          try {
+            await onConfirm(userId)
+          } finally {
+            setIsDeleting(false)
+            onClose()
+          }
         }
       }}
       title={t('userManagement.deleteUser')}

--- a/web/src/components/namespaces/NamespaceAccessPanel.tsx
+++ b/web/src/components/namespaces/NamespaceAccessPanel.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback } from 'react'
-import { Shield, Trash2, UserPlus } from 'lucide-react'
+import { Shield, Trash2, UserPlus, Loader2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { api, authFetch } from '../../lib/api'
 import { useToast } from '../ui/Toast'
@@ -22,6 +22,7 @@ export function NamespaceAccessPanel({
   const { showToast } = useToast()
   const [accessEntries, setAccessEntries] = useState<NamespaceAccessEntry[]>([])
   const [accessLoading, setAccessLoading] = useState(false)
+  const [revokingBindingName, setRevokingBindingName] = useState<string | null>(null)
 
   const fetchAccess = useCallback(async (ns: NamespaceDetails, signal?: AbortSignal) => {
     setAccessLoading(true)
@@ -49,6 +50,7 @@ export function NamespaceAccessPanel({
       return
     }
 
+    setRevokingBindingName(binding.bindingName)
     try {
       const params = new URLSearchParams({
         cluster: namespace.cluster,
@@ -66,6 +68,8 @@ export function NamespaceAccessPanel({
     } catch (err: unknown) {
       console.error('Failed to revoke access:', err)
       showToast('Failed to revoke access', 'error')
+    } finally {
+      setRevokingBindingName(null)
     }
   }
 
@@ -133,10 +137,13 @@ export function NamespaceAccessPanel({
               </div>
               <button
                 onClick={() => handleRevokeAccess(entry)}
-                className="p-1.5 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors"
+                disabled={revokingBindingName === entry.bindingName}
+                className="p-1.5 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                 title={t('namespaces.revokeAccess', 'Revoke access')}
               >
-                <Trash2 className="w-4 h-4" />
+                {revokingBindingName === entry.bindingName
+                  ? <Loader2 className="w-4 h-4 animate-spin" />
+                  : <Trash2 className="w-4 h-4" />}
               </button>
             </div>
           ))}


### PR DESCRIPTION
Fixes #21293

## Changes

Add missing `isLoading`/disabled states to three async button handlers that lacked visual feedback during in-flight operations:

### `NamespaceAccessPanel` — revoke access button
- Add `revokingBindingName` state (per-entry) to `handleRevokeAccess`
- Disable the revoke button and show a `Loader2` spinner while the DELETE rolebinding call is in flight
- Prevents double-submission on the RBAC revoke action

### `UserManagementModal` — delete user confirmation
- Change `onConfirm` type to `(userId: string) => Promise<void>`
- Add `isDeleting` state; pass `isLoading={isDeleting}` to `ConfirmDialog`
- Confirm button is now disabled while the async delete resolves

### `UserManagementList` + `UserManagement.types`
- Update `onDeleteUser` type to `Promise<void>` to match the async `handleDeleteUser` implementation
- Remove premature `setDeleteConfirmUserId(null)` so the modal stays open until the operation completes