### PR TITLE
[scanner] fix: resolve systemic test failures from #21283 regression

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -239,12 +239,17 @@ afterEach(() => {
   vi.useRealTimers()
 })
 
-// Clear global stubs after every test file.
-// In vitest 4.x with pool:'forks'/isolate:false and maxWorkers:1 (CI), all test
-// files in a shard share one worker process, so vi.stubGlobal() calls in one
-// file's beforeAll leak into subsequent files.
-// afterAll in setupFiles runs once per worker (end of shard), not once per file.
-// Belt-and-suspenders: primary cleanup now happens in afterEach above (#20007).
+// Clear global stubs when this test file finishes.
+// With isolate:true (current setting in vite.config.ts), the setupFile runs inside
+// each test file's own subprocess, so this afterAll executes once per FILE —
+// correctly cleaning up any vi.stubGlobal() calls the file made at module scope,
+// in beforeAll, or inside test callbacks.
+//
+// WARNING: if isolate is ever set to false, afterAll in setupFiles runs only once
+// per shard (at the end of the worker), NOT once per file. That means
+// vi.stubGlobal() calls in one file leak into all subsequent files in the same
+// shard, which caused 1598 test failures in Coverage Suite run #4339 (#21284).
+// Do NOT set isolate:false — see web/vite.config.ts for the full explanation.
 afterAll(() => {
   vi.unstubAllGlobals()
 })


### PR DESCRIPTION
Fixes #21284

## Root Cause

PR #21283 (commit `294a689`) set `isolate: process.env.CI ? false : true` in `web/vite.config.ts` to work around suspected OOM crashes from chunk-splitting (#21083). With `isolate: false`, all test files in a CI shard share one Vitest worker process. The `vi.stubGlobal()` calls made at **module scope** in individual test files leaked into every subsequent file — because `afterAll` in `setup.ts` (which calls `vi.unstubAllGlobals()`) ran only once at the **end of the shard**, not once per file. This cross-file contamination caused **1598 test failures** in Coverage Suite run #4339.

## Fix

The `isolate: true` restoration was applied in commit `0f81cb019` (PR #21290). This PR completes the fix by updating `web/src/test/setup.ts` to:

1. Replace the outdated comment on the `afterAll` block (which described the broken `isolate: false` behaviour) with accurate documentation of the current `isolate: true` semantics.
2. Add an explicit **`DO NOT set isolate:false`** warning that references this issue to prevent recurrence.

## Why `isolate: false` broke 1598 tests

| `isolate:true` (correct) | `isolate:false` (broken by #21283) |
|---|---|
| Each test file runs in its own subprocess | All files in a shard share one worker |
| `setup.ts` re-imported per file → `afterAll` runs per file | `setup.ts` loaded once → `afterAll` runs once at end of shard |
| Module-scope `vi.stubGlobal()` cleaned up after each file | Stubs accumulate across all files; later files see contaminated globals |