### PR TITLE
[scanner] fix: add keyboard navigation to feedback + compliance dropdowns

### DIFF
--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -14,7 +14,7 @@
  * that subscribes via useSyncExternalStore and only re-renders when the
  * actual list of cluster names changes.
  */
-import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo } from 'react'
+import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo, type KeyboardEvent } from 'react'
 import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2 } from 'lucide-react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
@@ -24,6 +24,7 @@ import { DashboardHeader } from '../shared/DashboardHeader'
 import { RotatingTip } from '../ui/RotatingTip'
 import { RefreshIndicator } from '../ui/RefreshIndicator'
 import { useTranslation } from 'react-i18next'
+import { moveFocusByKey } from '../../lib/a11y/rovingFocus'
 
 /* ────────── status badge helpers ────────── */
 
@@ -138,16 +139,18 @@ function ControlAccordion({ control }: { control: ControlResult }) {
 
 /* ────────── framework card ────────── */
 
-function FrameworkCard({ fw, selected, onSelect }: { fw: Framework; selected: boolean; onSelect: () => void }) {
+function FrameworkCard({ fw, selected, onSelect, isFirst = false }: { fw: Framework; selected: boolean; onSelect: () => void; isFirst?: boolean }) {
   return (
     <button
-      className={`text-left p-4 rounded-lg border transition-all ${
+      className={`text-left p-4 rounded-lg border transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/70 ${
         selected
           ? 'border-blue-500/60 bg-blue-500/10 shadow-lg shadow-blue-500/5'
           : 'border-border bg-card hover:border-blue-500/30'
       }`}
       onClick={onSelect}
       type="button"
+      aria-pressed={selected}
+      tabIndex={selected || isFirst ? 0 : -1}
     >
       <div className="flex items-center gap-2 mb-1">
         <Shield className="w-4 h-4 text-blue-400" />
@@ -282,14 +285,22 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
         rightExtra={<RotatingTip page="compliance" />}
       />
 
-      {/* Framework picker */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-        {frameworks.map(fw => (
+      {/* Framework picker — arrow key navigation (#21301) */}
+      <div
+        className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
+        role="group"
+        aria-label={t('compliance.selectFramework', 'Select a compliance framework')}
+        onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+          moveFocusByKey(e, { selector: 'button:not([disabled])', orientation: 'both' })
+        }}
+      >
+        {frameworks.map((fw, index) => (
           <FrameworkCard
             key={fw.id}
             fw={fw}
             selected={fw.id === selectedFwId}
             onSelect={() => setSelectedFwId(fw.id)}
+            isFirst={index === 0}
           />
         ))}
       </div>

--- a/web/src/components/compliance/ComplianceFrameworks.tsx
+++ b/web/src/components/compliance/ComplianceFrameworks.tsx
@@ -14,7 +14,7 @@
  * that subscribes via useSyncExternalStore and only re-renders when the
  * actual list of cluster names changes.
  */
-import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo, type KeyboardEvent } from 'react'
+import { useState, useMemo, useEffect, useCallback, useSyncExternalStore, memo } from 'react'
 import { Shield, ChevronDown, ChevronRight, CheckCircle2, XCircle, AlertTriangle, MinusCircle, Loader2 } from 'lucide-react'
 import { UnifiedDashboard } from '../../lib/unified/dashboard/UnifiedDashboard'
 import { complianceFrameworksDashboardConfig } from '../../config/dashboards/compliance-frameworks'
@@ -290,7 +290,7 @@ export const ComplianceFrameworksContent = memo(function ComplianceFrameworksCon
         className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"
         role="group"
         aria-label={t('compliance.selectFramework', 'Select a compliance framework')}
-        onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+        onKeyDown={(e) => {
           moveFocusByKey(e, { selector: 'button:not([disabled])', orientation: 'both' })
         }}
       >

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -9,7 +9,7 @@
  * in the created issue as markdown images.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
+import { useState, useEffect, useRef, useCallback, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { X, Bug, Lightbulb, Send, CheckCircle2, ExternalLink, ImagePlus, Trash2, Copy, Check, AlertTriangle, Loader2, Film } from 'lucide-react'
@@ -37,6 +37,7 @@ import {
   isFeedbackRequestBodyLimitError,
 } from './FeatureRequestTypes'
 import { safeRemove, safeSetJSON } from '../../lib/safeLocalStorage'
+import { moveFocusByKey } from '../../lib/a11y/rovingFocus'
 
 type FeedbackType = 'bug' | 'feature'
 
@@ -497,12 +498,25 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </div>
               )}
 
-              {/* Type selector */}
-              <div className="flex gap-2 mb-4">
+              {/* Type selector — radiogroup with arrow-key navigation (#21301) */}
+              <div
+                role="radiogroup"
+                aria-label={t('feedback.feedbackType', 'Feedback type')}
+                className="flex gap-2 mb-4"
+                onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+                  const next = moveFocusByKey(e, { selector: '[role="radio"]:not([disabled])', orientation: 'horizontal' })
+                  const nextType = next?.dataset.radioValue as FeedbackType | undefined
+                  if (nextType) setType(nextType)
+                }}
+              >
                 <button
                   type="button"
+                  role="radio"
+                  aria-checked={type === 'bug'}
+                  tabIndex={type === 'bug' ? 0 : -1}
+                  data-radio-value="bug"
                   onClick={() => setType('bug')}
-                  className={`flex-1 flex items-center justify-center gap-2 p-3 rounded-lg border transition-colors ${
+                  className={`flex-1 flex items-center justify-center gap-2 p-3 rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500/70 ${
                     type === 'bug'
                       ? 'bg-red-500/10 border-red-500/30 text-red-400'
                       : 'bg-secondary/30 border-border text-muted-foreground hover:text-foreground'
@@ -514,8 +528,12 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 </button>
                 <button
                   type="button"
+                  role="radio"
+                  aria-checked={type === 'feature'}
+                  tabIndex={type === 'feature' ? 0 : -1}
+                  data-radio-value="feature"
                   onClick={() => setType('feature')}
-                  className={`flex-1 flex items-center justify-center gap-2 p-3 rounded-lg border transition-colors ${
+                  className={`flex-1 flex items-center justify-center gap-2 p-3 rounded-lg border transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-green-500/70 ${
                     type === 'feature'
                       ? 'bg-green-500/10 border-green-500/30 text-green-400'
                       : 'bg-secondary/30 border-border text-muted-foreground hover:text-foreground'

--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -9,7 +9,7 @@
  * in the created issue as markdown images.
  */
 
-import { useState, useEffect, useRef, useCallback, type KeyboardEvent } from 'react'
+import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { X, Bug, Lightbulb, Send, CheckCircle2, ExternalLink, ImagePlus, Trash2, Copy, Check, AlertTriangle, Loader2, Film } from 'lucide-react'
@@ -503,7 +503,7 @@ export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: Feed
                 role="radiogroup"
                 aria-label={t('feedback.feedbackType', 'Feedback type')}
                 className="flex gap-2 mb-4"
-                onKeyDown={(e: KeyboardEvent<HTMLDivElement>) => {
+                onKeyDown={(e) => {
                   const next = moveFocusByKey(e, { selector: '[role="radio"]:not([disabled])', orientation: 'horizontal' })
                   const nextType = next?.dataset.radioValue as FeedbackType | undefined
                   if (nextType) setType(nextType)


### PR DESCRIPTION
Part of #21301

Adds arrow key + Home/End + Enter/Space keyboard navigation to dropdown/menu widgets in:
- `web/src/components/feedback/FeedbackModal.tsx`
- `web/src/components/compliance/ComplianceFrameworks.tsx`

### Changes

**FeedbackModal.tsx** — Bug/Feature type selector
- Wrapped the two toggle buttons in `role="radiogroup"` with an `aria-label`
- Each button now has `role="radio"`, `aria-checked`, roving `tabIndex`, and `data-radio-value`
- `onKeyDown` on the group uses `moveFocusByKey` (existing `lib/a11y/rovingFocus`) with `orientation: 'horizontal'`; moving focus also activates the radio (WAI-ARIA radio group pattern)
- Added `focus-visible:ring-2` on each button for visible focus

**ComplianceFrameworks.tsx** — Framework picker grid
- Grid container gains `role="group"`, `aria-label`, and `onKeyDown` using `moveFocusByKey` with `orientation: 'both'` (all four arrow keys + Home/End)
- `FrameworkCard` button gains `aria-pressed={selected}`, roving `tabIndex` (selected card = 0, first card = 0 when nothing selected), and `focus-visible:ring-2`
- Native `<select>` for cluster is already fully keyboard-accessible — no changes needed

**FeatureRequestButton.tsx** — single trigger button, no dropdown/menu widget present → skipped

### Implementation notes
- Uses the project's existing `moveFocusByKey` utility from `lib/a11y/rovingFocus.ts` — no new abstractions
- Enter/Space already work natively on `<button>` elements

Remaining files in #21301 will be addressed in follow-up PRs.