### PR TITLE
[scanner] fix: use semantic status color tokens for consistency

### DIFF
--- a/web/src/components/feedback/SubmitTabSuccessView.tsx
+++ b/web/src/components/feedback/SubmitTabSuccessView.tsx
@@ -14,7 +14,7 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
   return (
     <div className="p-6 text-center flex-1 overflow-y-auto min-h-0">
       <div className="w-12 h-12 mx-auto mb-4 rounded-full bg-green-500/20 flex items-center justify-center">
-        <Sparkles className="w-6 h-6 text-green-400" />
+        <Sparkles className="w-6 h-6 text-status-success" />
       </div>
       <h3 className="text-lg font-medium text-foreground mb-2">
         {t('feedback.requestSubmitted')}
@@ -49,7 +49,7 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
       {/* Attachment status */}
       {screenshots.length > 0 && (success.screenshotsUploaded ?? 0) > 0 && (
         <div className="mt-4 p-3 rounded-lg bg-green-500/10 border border-green-500/20">
-          <p className="text-xs text-green-400 font-medium">
+          <p className="text-xs text-status-success font-medium">
             {(success.screenshotsUploaded ?? 0) === 1
               ? 'Attachment uploaded to the issue successfully.'
               : `${success.screenshotsUploaded} attachments uploaded to the issue successfully.`}
@@ -58,7 +58,7 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
       )}
       {screenshots.length > 0 && (success.screenshotsFailed ?? 0) > 0 && (
         <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-          <p className="text-xs text-yellow-400 font-medium">
+          <p className="text-xs text-status-warning font-medium">
             {success.screenshotsFailed === 1
               ? 'Attachment could not be uploaded — unsupported format or too large.'
               : `${success.screenshotsFailed} attachments could not be uploaded — unsupported format or too large.`}
@@ -67,7 +67,7 @@ export function SuccessView({ success, screenshots, onViewUpdates }: SuccessView
       )}
       {success.warning && (
         <div className="mt-4 p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-          <p className="text-xs text-yellow-400 font-medium">{success.warning}</p>
+          <p className="text-xs text-status-warning font-medium">{success.warning}</p>
         </div>
       )}
     </div>

--- a/web/src/components/settings/sections/EmailNotificationSettings.tsx
+++ b/web/src/components/settings/sections/EmailNotificationSettings.tsx
@@ -128,7 +128,7 @@ export function EmailNotificationSettings({
             className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
           />
           {portError && (
-            <p id="email-smtp-port-error" role="alert" className="mt-1 text-xs text-red-400">{portError}</p>
+            <p id="email-smtp-port-error" role="alert" className="mt-1 text-xs text-status-error">{portError}</p>
           )}
         </div>
       </div>
@@ -197,7 +197,7 @@ export function EmailNotificationSettings({
             className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
           />
           {hasStoredPassword && (
-            <p className="mt-1 text-xs text-green-400">
+            <p className="mt-1 text-xs text-status-success">
               {t('settings.notifications.secretConfigured')}
             </p>
           )}
@@ -219,11 +219,11 @@ export function EmailNotificationSettings({
           }`}
         >
           {testResult.success ? (
-            <Check className="w-4 h-4 text-green-400 shrink-0 mt-0.5" />
+            <Check className="w-4 h-4 text-status-success shrink-0 mt-0.5" />
           ) : (
-            <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+            <X className="w-4 h-4 text-status-error shrink-0 mt-0.5" />
           )}
-          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+          <p className={`text-sm ${testResult.success ? 'text-status-success' : 'text-status-error'}`}>
             {testResult.message}
           </p>
         </div>

--- a/web/src/components/settings/sections/PersistenceSection.tsx
+++ b/web/src/components/settings/sections/PersistenceSection.tsx
@@ -70,11 +70,11 @@ export function PersistenceSection() {
   const getHealthIcon = (health: ClusterHealth) => {
     switch (health) {
       case 'healthy':
-        return <Check className="w-4 h-4 text-green-400" />
+        return <Check className="w-4 h-4 text-status-success" />
       case 'degraded':
-        return <AlertCircle className="w-4 h-4 text-yellow-400" />
+        return <AlertCircle className="w-4 h-4 text-status-warning" />
       case 'unreachable':
-        return <X className="w-4 h-4 text-red-400" />
+        return <X className="w-4 h-4 text-status-error" />
       default:
         return <AlertCircle className="w-4 h-4 text-muted-foreground" />
     }
@@ -120,7 +120,7 @@ export function PersistenceSection() {
 
       {error && (
         <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 mb-4">
-          <p className="text-sm text-red-400">{error}</p>
+          <p className="text-sm text-status-error">{error}</p>
         </div>
       )}
 
@@ -181,7 +181,7 @@ export function PersistenceSection() {
               </button>
             </div>
             {testResult && testResult.cluster === localConfig.primaryCluster && (
-              <p className={cn('text-xs mt-1', testResult.success ? 'text-green-400' : 'text-red-400')}>
+              <p className={cn('text-xs mt-1', testResult.success ? 'text-status-success' : 'text-status-error')}>
                 {testResult.success ? t('settings.persistence.connectionSuccess') : t('settings.persistence.connectionFailed')}
               </p>
             )}
@@ -253,7 +253,7 @@ export function PersistenceSection() {
                 </button>
               </div>
               {testResult && testResult.cluster === localConfig.secondaryCluster && (
-                <p className={cn('text-xs mt-1', testResult.success ? 'text-green-400' : 'text-red-400')}>
+                <p className={cn('text-xs mt-1', testResult.success ? 'text-status-success' : 'text-status-error')}>
                   {testResult.success ? t('settings.persistence.connectionSuccess') : t('settings.persistence.connectionFailed')}
                 </p>
               )}
@@ -304,7 +304,7 @@ export function PersistenceSection() {
                   <span className="text-foreground">
                     {status.activeCluster || t('settings.persistence.none')}
                     {status.failoverActive && (
-                      <span className="ml-2 text-xs text-yellow-400">{t('settings.persistence.failover')}</span>
+                      <span className="ml-2 text-xs text-status-warning">{t('settings.persistence.failover')}</span>
                     )}
                   </span>
                 </div>

--- a/web/src/components/settings/sections/SlackNotificationSettings.tsx
+++ b/web/src/components/settings/sections/SlackNotificationSettings.tsx
@@ -96,10 +96,10 @@ export function SlackNotificationSettings({
           className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
         />
         {urlError && (
-          <p id="slack-webhook-url-error" role="alert" className="mt-1 text-xs text-red-400">{urlError}</p>
+          <p id="slack-webhook-url-error" role="alert" className="mt-1 text-xs text-status-error">{urlError}</p>
         )}
         {hasStoredWebhook && (
-          <p className="text-xs text-green-400 mt-1">
+          <p className="text-xs text-status-success mt-1">
             {t('settings.notifications.secretConfigured')}
           </p>
         )}
@@ -140,11 +140,11 @@ export function SlackNotificationSettings({
           }`}
         >
           {testResult.success ? (
-            <Check className="w-4 h-4 text-green-400 shrink-0 mt-0.5" />
+            <Check className="w-4 h-4 text-status-success shrink-0 mt-0.5" />
           ) : (
-            <X className="w-4 h-4 text-red-400 shrink-0 mt-0.5" />
+            <X className="w-4 h-4 text-status-error shrink-0 mt-0.5" />
           )}
-          <p className={`text-sm ${testResult.success ? 'text-green-400' : 'text-red-400'}`}>
+          <p className={`text-sm ${testResult.success ? 'text-status-success' : 'text-status-error'}`}>
             {testResult.message}
           </p>
         </div>


### PR DESCRIPTION
Fixes #21300

Replace hardcoded Tailwind color classes with semantic design tokens across notification settings and feedback components:

- `text-green-400` → `text-status-success`
- `text-red-400` → `text-status-error`
- `text-yellow-400` → `text-status-warning`

**Files changed (4):**
- `web/src/components/feedback/SubmitTabSuccessView.tsx`
- `web/src/components/settings/sections/PersistenceSection.tsx`
- `web/src/components/settings/sections/EmailNotificationSettings.tsx`
- `web/src/components/settings/sections/SlackNotificationSettings.tsx`