### PR TITLE
[scanner] fix: add keyboard navigation to tabs, dropdowns, and menus

### DIFF
--- a/web/src/components/landing/TabbedDeploySection.tsx
+++ b/web/src/components/landing/TabbedDeploySection.tsx
@@ -7,6 +7,7 @@ import { emitInstallCommandCopied } from '../../lib/analytics'
 import type { InstallCopySource } from '../../lib/analytics-types'
 import { InstallStepCard, type InstallStep } from './InstallStepCard'
 import { ACCENT_CLASSES, type AccentColor } from './styles'
+import { useTabKeyboardNav } from '../../hooks/useKeyboardNav'
 
 export type DeployTab = 'localhost' | 'cluster-portforward' | 'cluster-ingress'
 
@@ -39,6 +40,16 @@ export function TabbedDeploySection({
   const copiedTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
   useEffect(() => () => clearTimeout(copiedTimerRef.current), [])
+
+  const DEPLOY_TABS: readonly DeployTab[] = ['localhost', 'cluster-portforward', 'cluster-ingress']
+  const { tabListProps, getTabProps, getTabPanelProps } = useTabKeyboardNav<DeployTab>({
+    tabs: DEPLOY_TABS,
+    activeTab,
+    onChange: (tab) => {
+      setActiveTab(tab)
+      onTabSwitch?.(tab)
+    },
+  })
 
   const switchTab = (tab: DeployTab) => {
     if (tab === activeTab) return
@@ -80,8 +91,9 @@ export function TabbedDeploySection({
       </p>
 
       <div className="max-w-3xl mx-auto mb-8">
-        <div className="flex rounded-lg border border-slate-700/50 overflow-hidden">
+        <div className="flex rounded-lg border border-slate-700/50 overflow-hidden" {...tabListProps}>
           <button
+            {...getTabProps('localhost')}
             onClick={() => switchTab('localhost')}
             className={`flex-1 flex items-center justify-center gap-2.5 px-6 py-3.5 text-sm font-medium transition-colors ${
               activeTab === 'localhost'
@@ -94,6 +106,7 @@ export function TabbedDeploySection({
             <span className="text-xs px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-200">curl | bash</span>
           </button>
           <button
+            {...getTabProps('cluster-portforward')}
             onClick={() => switchTab('cluster-portforward')}
             className={`flex-1 flex items-center justify-center gap-2.5 px-6 py-3.5 text-sm font-medium transition-colors ${
               activeTab === 'cluster-portforward'
@@ -106,6 +119,7 @@ export function TabbedDeploySection({
             <span className="text-xs px-2 py-0.5 rounded-full bg-slate-700/50 text-slate-200">port-forward</span>
           </button>
           <button
+            {...getTabProps('cluster-ingress')}
             onClick={() => switchTab('cluster-ingress')}
             className={`flex-1 flex items-center justify-center gap-2.5 px-6 py-3.5 text-sm font-medium transition-colors ${
               activeTab === 'cluster-ingress'
@@ -120,7 +134,7 @@ export function TabbedDeploySection({
         </div>
       </div>
 
-      <div className="space-y-6 max-w-3xl mx-auto">
+      <div {...getTabPanelProps(activeTab)} className="space-y-6 max-w-3xl mx-auto">
         {steps.map(step => {
           const copyKey = `${activeTab}-${step.step}`
           return (

--- a/web/src/components/terminal/PodExecTerminal.tsx
+++ b/web/src/components/terminal/PodExecTerminal.tsx
@@ -10,13 +10,14 @@
  * - Automatic reconnection with exponential backoff and countdown (#3029)
  */
 
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, type RefObject } from 'react'
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { useExecSession, type ExecSessionConfig, type SessionStatus } from '../../hooks/useExecSession'
 import { Loader2, AlertCircle, RotateCcw, Power, ChevronDown, WifiOff, RefreshCw, AlertTriangle } from 'lucide-react'
 import '@xterm/xterm/css/xterm.css'
 import { useTranslation } from 'react-i18next'
+import { useKeyboardNav } from '../../hooks/useKeyboardNav'
 
 // ============================================================================
 // Constants
@@ -100,6 +101,12 @@ export default function PodExecTerminal({
   )
   const [showContainerPicker, setShowContainerPicker] = useState(false)
   const [exitCode, setExitCode] = useState<number | null>(null)
+
+  const containerMenuNav = useKeyboardNav({
+    selector: '[role="menuitem"]:not([disabled])',
+    orientation: 'vertical',
+    onEscape: () => setShowContainerPicker(false),
+  })
 
   const {
     status,
@@ -264,6 +271,8 @@ export default function PodExecTerminal({
             <div className="relative">
               <button
                 onClick={() => setShowContainerPicker(!showContainerPicker)}
+                aria-haspopup="true"
+                aria-expanded={showContainerPicker}
                 className="flex items-center gap-2 px-3 py-1 text-xs rounded bg-secondary border border-border text-foreground/80 hover:border-blue-400 transition-colors"
               >
                 <span className="text-muted-foreground">container:</span>
@@ -271,10 +280,16 @@ export default function PodExecTerminal({
                 <ChevronDown className="w-3 h-3 text-muted-foreground" />
               </button>
               {showContainerPicker && (
-                <div className="absolute top-full left-0 mt-1 z-dropdown bg-card border border-border rounded shadow-lg">
+                <div
+                  ref={containerMenuNav.containerRef as RefObject<HTMLDivElement>}
+                  role="menu"
+                  onKeyDown={containerMenuNav.handleKeyDown}
+                  className="absolute top-full left-0 mt-1 z-dropdown bg-card border border-border rounded shadow-lg"
+                >
                   {(containers || []).map((c) => (
                     <button
                       key={c}
+                      role="menuitem"
                       onClick={() => {
                         setSelectedContainer(c)
                         setShowContainerPicker(false)


### PR DESCRIPTION
Fixes #21301
Fixes #21307
Fixes #21306

## Summary

Adds keyboard navigation to tab panels and dropdown/menu components using the existing `useTabKeyboardNav` and `useKeyboardNav` hooks.

### Changes

- **`TabbedDeploySection`** (`FromHeadlamp`, `FromLens`, `WhiteLabel` pages): Apply `useTabKeyboardNav` — adds `role="tablist"`, `role="tab"`, `aria-selected`, `tabIndex` roving, `aria-orientation`, and ArrowLeft/Right/Home/End navigation with `role="tabpanel"` association.

- **`PodExecTerminal`**: Apply `useKeyboardNav` to the custom container-picker dropdown — adds `role="menu"`, `role="menuitem"`, `aria-haspopup`, `aria-expanded`, ArrowUp/Down traversal, and Escape-to-close.

- **`FeedbackModal`**: Apply `useTabKeyboardNav` to the Bug/Feature type-selector — adds `role="tablist"`, `role="tab"`, `aria-selected`, and ArrowLeft/Right navigation.

- **`ComplianceFrameworks`**: Apply `useKeyboardNav` (`orientation="both"`) to the framework-picker grid — adds `role="listbox"`, `role="option"`, `aria-selected`, and arrow-key traversal across the card grid.