### PR TITLE
[scanner] fix: add missing ARIA labels and roles to interactive elements

### DIFF
--- a/web/src/components/cards/rss/FeedFilterEditor.tsx
+++ b/web/src/components/cards/rss/FeedFilterEditor.tsx
@@ -36,6 +36,7 @@ export const FeedFilterEditor = memo(function FeedFilterEditor({
         <button
           onClick={onClose}
           className="p-1 rounded hover:bg-secondary text-muted-foreground"
+          aria-label={t('common:common.close')}
         >
           <X className="w-3 h-3" />
         </button>

--- a/web/src/components/cards/rss/FeedSettingsPanel.tsx
+++ b/web/src/components/cards/rss/FeedSettingsPanel.tsx
@@ -67,12 +67,18 @@ export const FeedSettingsPanel = memo(function FeedSettingsPanel({
   const nonAggregateFeeds = feeds.filter(f => !f.isAggregate)
 
   return (
-    <div className="absolute inset-x-3 top-16 bottom-3 p-3 bg-card border border-border rounded-lg shadow-lg z-40 flex flex-col overflow-hidden">
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('cards:rssFeed.manageFeeds')}
+      className="absolute inset-x-3 top-16 bottom-3 p-3 bg-card border border-border rounded-lg shadow-lg z-40 flex flex-col overflow-hidden"
+    >
       <div className="flex flex-wrap items-center justify-between gap-y-2 mb-3">
         <span className="text-sm font-medium">{t('cards:rssFeed.manageFeeds')}</span>
         <button
           onClick={onClose}
           className="p-1 rounded hover:bg-secondary text-muted-foreground"
+          aria-label={t('common:common.close')}
         >
           <X className="w-4 h-4" />
         </button>

--- a/web/src/components/feedback/FeatureRequestModal.tsx
+++ b/web/src/components/feedback/FeatureRequestModal.tsx
@@ -426,6 +426,7 @@ export function FeatureRequestModal({ isOpen, onClose, initialTab, initialReques
           onClick={handleClose}
           disabled={isSubmitting}
           className="p-1 rounded hover:bg-secondary/50 text-muted-foreground disabled:opacity-50"
+          aria-label={t('actions.close')}
         >
           <X className="w-5 h-5" />
         </button>


### PR DESCRIPTION
Fixes #21311

Add missing ARIA attributes to interactive elements detected by Auto-QA scan:

- **FeedSettingsPanel**: add `role="dialog"`, `aria-modal="true"`, `aria-label` to absolute-positioned flyout panel; `aria-label` to icon-only close button
- **FeedFilterEditor**: add `aria-label` to icon-only close button
- **FeatureRequestModal**: add `aria-label` to icon-only close button