### PR TITLE
[scanner] fix: nightly unit-test regression

### DIFF
--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -15,7 +15,7 @@ interface CreateNamespaceModalProps {
 export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceModalProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
-  const [cluster, setCluster] = useState('')
+  const [cluster, setCluster] = useState(clusters[0] ?? '')
   const [teamLabel, setTeamLabel] = useState('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -1,4 +1,4 @@
-import { useReducer } from 'react'
+import { useReducer, useEffect } from 'react'
 import { Shield, Check, X, Loader2, AlertCircle, ChevronDown } from 'lucide-react'
 import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'
@@ -177,6 +177,13 @@ function CanICheckerContent() {
     selectedUserGroups, customUserGroup, showAdvanced, checkedSnapshot,
   } = form
 
+  // Auto-select first cluster when clusters load and none is selected yet
+  useEffect(() => {
+    if (cluster === '' && clusters.length > 0) {
+      dispatch({ type: 'SET_FIELD', field: 'cluster', value: clusters[0] })
+    }
+  }, [clusters, cluster])
+
   // Get selected cluster for namespace fetching — only after the user makes an explicit choice
   const selectedCluster = cluster
   const { namespaces } = useNamespaces(selectedCluster)
@@ -265,7 +272,6 @@ function CanICheckerContent() {
               className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
               data-testid="can-i-cluster"
             >
-              <option value="" disabled>{t('common.selectCluster', 'Select a cluster')}</option>
               {clusters.map((c) => (
                 <option key={c} value={c}>{c}</option>
               ))}


### PR DESCRIPTION
Fixes #21083

## Root cause

Two components initialised their cluster `<select>` state to `""`:

- **`CreateNamespaceModal`**: cluster state stayed `""` so the Create button stayed disabled and `agentFetch` was never called → 4 tests failed.
- **`CanIChecker`**: `INITIAL_FORM_STATE` had `cluster: ""` and rendered a disabled placeholder `<option>`, giving 3 options instead of the expected 2, and `clusterSelect.value` was `""` instead of the first cluster → 18 tests failed.

## Fix

- `CreateNamespaceModal`: initialise `useState` with `clusters[0] ?? ""` so the first cluster is pre-selected on mount.
- `CanIChecker`: add a `useEffect` that dispatches `SET_FIELD/cluster` to the first available cluster when clusters load and none is selected yet; remove the now-redundant disabled placeholder `<option>` from the cluster dropdown.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>