### PR TITLE
fix: stabilize flaky NamespaceAccessPanel refetch test

### DIFF
--- a/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx
@@ -34,12 +34,18 @@ vi.mock('../../ui/Toast', () => ({
   }),
 }))
 
-vi.mock('react-i18next', () => ({
-  initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({
-    t: (key: string, fallback?: string) => fallback || key,
-  }),
-}))
+vi.mock('react-i18next', () => {
+  // Stable reference: a new arrow function on every useTranslation() call has a
+  // different identity, which causes useCallback (depending on `t`) to recreate
+  // fetchAccess on every render, re-triggering useEffect and making extra api.get
+  // calls. Defining `t` once inside the factory closure gives a single stable
+  // reference across all useTranslation() invocations.
+  const t = (key: string, fallback?: string): string => fallback ?? key
+  return {
+    initReactI18next: { type: '3rdParty', init: () => {} },
+    useTranslation: () => ({ t }),
+  }
+})
 
 // ── Test Data ──────────────────────────────────────────────────────────────
 
@@ -307,13 +313,15 @@ describe('NamespaceAccessPanel', () => {
       />
     )
 
-    // Wait for second call with new namespace
+    // Wait for the component to refetch for the new namespace. We check the
+    // URL argument directly rather than an exact call count because:
+    // 1. Vitest retries (CI retry:2) accumulate mock call counts across attempts
+    //    since vi.clearAllMocks() only runs in beforeEach (between test cases).
+    // 2. Extra renders caused by async state updates can result in >2 calls.
+    // Asserting the URL was fetched is sufficient and retry-safe.
     await waitFor(() => {
-      expect(api.get).toHaveBeenCalledTimes(2)
+      const urls = vi.mocked(api.get).mock.calls.map(call => String(call[0]))
+      expect(urls.some(url => url.includes('another-namespace'))).toBe(true)
     })
-
-    // Verify the last call used the new namespace
-    const lastCall = vi.mocked(api.get).mock.calls[vi.mocked(api.get).mock.calls.length - 1]
-    expect(lastCall[0]).toContain('another-namespace')
   })
 })


### PR DESCRIPTION
Fixes #21319

## Root cause

The Coverage Suite was reporting ~40% failure rate, with shard 11 consistently failing on:

```
NamespaceAccessPanel > refetches access entries after namespace changes
AssertionError: expected "vi.fn()" to be called 2 times, but got 6 times
```

Two compounding issues caused this:

### 1. Unstable `t` reference in `react-i18next` mock

The mock was defined as:
```ts
vi.mock('react-i18next', () => ({
  useTranslation: () => ({
    t: (key: string, fallback?: string) => fallback || key,  // new fn each call!
  }),
}))
```

A new arrow function is created on every `useTranslation()` call, giving it a different object identity on each render. Because `t` is listed in `useCallback`'s dependency array for `fetchAccess`, this causes `fetchAccess` to be recreated on every render. Since `fetchAccess` is in `useEffect`'s dependency array, the effect re-fires on every render, making extra `api.get` calls.

**Fix:** define `t` once inside the `vi.mock` factory closure so all `useTranslation()` invocations share the same stable reference.

### 2. Exact call-count assertion breaks under Vitest retries

`vite.config.ts` sets `retry: process.env.CI ? 2 : 0`. `vi.clearAllMocks()` runs in `beforeEach` (between test *cases*), not between *retries*. So a flaky test that fails on attempt 1 accumulates call counts:

```
attempt 1: 2 calls → fails (timing race, count briefly >2)
attempt 2: +2 calls → total 4 → fails (expected 2, got 4)
attempt 3: +2 calls → total 6 → fails (expected 2, got 6)
```

**Fix:** replace `toHaveBeenCalledTimes(2)` with a URL-based check — assert that `api.get` was called *with a URL containing the new namespace name*. This tests the same behavior (component re-fetched for the new namespace) without being sensitive to accumulated call counts.

## Changes

`web/src/components/namespaces/__tests__/NamespaceAccessPanel.test.tsx`
- Stabilize the `react-i18next` mock `t` function reference
- Replace `toHaveBeenCalledTimes(2)` with a retry-safe URL assertion