### PR TITLE
🐛 fix: remove unused error binding blocking build-gate on main

### DIFF
--- a/web/src/components/enterprise/EnterpriseLayout.tsx
+++ b/web/src/components/enterprise/EnterpriseLayout.tsx
@@ -179,9 +179,8 @@ function EnterpriseLayoutContent() {
     let previousSerialized: string | null = null
     try {
       previousSerialized = localStorage.getItem(activeStorageKey)
-    } catch (error) {
+    } catch {
       // Ignore storage errors (e.g. private-browsing SecurityError); treat as no previous value.
-      // error is intentionally unused - we treat all localStorage errors the same way.
     }
     const timestamp = Date.now()
     const additions: DashboardCardPlacement[] = cards.map((card, index) => ({


### PR DESCRIPTION
## Fix

Removes the unused `error` binding in the localStorage try/catch on `EnterpriseLayout.tsx:182`. This lint violation was flagged as **new** on every open PR because it exists on `main` but is not in `.eslint-baseline.json`, so build-gate fails on unrelated PRs (dependabot #21327, #21338, #21339, #21340 all blocked by this single line).

The catch block was already ignoring the error deliberately, and the file uses `} catch {` elsewhere for the same pattern — so the correct fix is to drop the binding, matching the surrounding style.

### Rule fired
`@typescript-eslint/no-unused-vars` — `'error' is defined but never used. Allowed unused caught errors must match /^_/u.`

### Verification
CI will run lint. Local lint/build are intentionally skipped per repo guidance.