### PR TITLE
[scanner] 🐛 fix: repair Coverage Suite failures on main

### DIFF
--- a/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
+++ b/web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx
@@ -60,7 +60,7 @@ describe('EnterpriseComplianceCards', () => {
 
       const loadingText = screen.getByText('Loading…');
       expect(loadingText).toBeInTheDocument();
-      expect(loadingText.className).toContain('text-gray-500');
+      expect(loadingText.className).toContain('text-muted-foreground');
     });
 
     it('renders success state and navigates on click', async () => {

--- a/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
+++ b/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
@@ -63,7 +63,7 @@ describe('CreateNamespaceModal', () => {
     expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0)
   })
 
-  it('initializes with cluster placeholder selected', () => {
+  it('auto-selects first cluster on initialization', () => {
     render(
       <CreateNamespaceModal
         clusters={clusters}
@@ -74,7 +74,7 @@ describe('CreateNamespaceModal', () => {
 
     const comboboxes = screen.getAllByRole('combobox')
     expect(comboboxes.length).toBeGreaterThan(0)
-    expect((comboboxes[0] as HTMLSelectElement).value).toBe('')
+    expect((comboboxes[0] as HTMLSelectElement).value).toBe('cluster-1')
   })
 
   it('allows cluster selection change', async () => {

--- a/web/src/components/rbac/__tests__/CanIChecker.test.tsx
+++ b/web/src/components/rbac/__tests__/CanIChecker.test.tsx
@@ -102,10 +102,9 @@ describe('CanIChecker — Initial Rendering', () => {
     const clusterSelect = screen.getByTestId('can-i-cluster') as HTMLSelectElement
     const options = Array.from(clusterSelect.options)
 
-    expect(options).toHaveLength(3)
-    expect(options[0].value).toBe('')
-    expect(options[1].value).toBe('cluster-a')
-    expect(options[2].value).toBe('cluster-b')
+    expect(options).toHaveLength(2)
+    expect(options[0].value).toBe('cluster-a')
+    expect(options[1].value).toBe('cluster-b')
   })
 
   it('populates namespace dropdown with fetched namespaces', () => {
@@ -120,11 +119,11 @@ describe('CanIChecker — Initial Rendering', () => {
     expect(options.some(opt => opt.value === 'kube-system')).toBe(true)
   })
 
-  it('starts with no cluster selected', () => {
+  it('auto-selects first cluster on load', () => {
     render(<CanIChecker />)
 
     const clusterSelect = screen.getByTestId('can-i-cluster') as HTMLSelectElement
-    expect(clusterSelect.value).toBe('')
+    expect(clusterSelect.value).toBe('cluster-a')
   })
 
   it('defaults verb and resource to common values', () => {


### PR DESCRIPTION
Fixes #21343
Fixes #21348

## Root cause

Three test assertions became stale after intentional component changes were merged:

### CanIChecker (2 failures — shard 6)

PR #21318 ("auto-select first cluster") added a `useEffect` that dispatches the first cluster into state when clusters load, and removed the empty placeholder `<option>`. The stabilise PR #21299 had already updated the tests to the *opposite* behaviour (3 options with empty first slot; initial value `''`), creating a conflict.

**Fix:** Update the two stale assertions to match the current auto-select design:
- `populates cluster dropdown with provided clusters` → expects 2 options (no empty slot)
- `starts with no cluster selected` → renamed `auto-selects first cluster on load`, asserts value `'cluster-a'`

### CreateNamespaceModal (1 failure — shard 3)

Same root cause: PR #21318 also changed `CreateNamespaceModal` to initialise cluster state with `clusters[0]` instead of `''`.

**Fix:** Rename `initializes with cluster placeholder selected` → `auto-selects first cluster on initialization`, assert `'cluster-1'`.

### EnterpriseComplianceCards HIPAACard (1 failure — shard 8)

The component's loading-state paragraph was updated to use the semantic token `text-muted-foreground` (dark mode support) instead of the hardcoded `text-gray-500`. The test still asserted `text-gray-500`.

**Fix:** Update assertion to `toContain('text-muted-foreground')`.

## Files changed

- `web/src/components/rbac/__tests__/CanIChecker.test.tsx`
- `web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx`
- `web/src/components/cards/__tests__/EnterpriseComplianceCards.test.tsx`