### PR TITLE
[scanner] 🐛 fix: update CreateNamespaceModal test for auto-select cluster

### DIFF
--- a/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
+++ b/web/src/components/namespaces/__tests__/CreateNamespaceModal.test.tsx
@@ -63,7 +63,7 @@ describe('CreateNamespaceModal', () => {
     expect(screen.getAllByRole('combobox').length).toBeGreaterThan(0)
   })
 
-  it('initializes with cluster placeholder selected', () => {
+  it('auto-selects first cluster on initialization', () => {
     render(
       <CreateNamespaceModal
         clusters={clusters}
@@ -74,7 +74,7 @@ describe('CreateNamespaceModal', () => {
 
     const comboboxes = screen.getAllByRole('combobox')
     expect(comboboxes.length).toBeGreaterThan(0)
-    expect((comboboxes[0] as HTMLSelectElement).value).toBe('')
+    expect((comboboxes[0] as HTMLSelectElement).value).toBe('cluster-1')
   })
 
   it('allows cluster selection change', async () => {


### PR DESCRIPTION
Fixes #21343

Updates CreateNamespaceModal test for the auto-select-first-cluster behavior introduced in #21318. Supersedes #21350 for the CreateNamespaceModal piece (CanIChecker fixed by #21344, EnterpriseComplianceCards by #21346).

Test-only change; no component code touched.