### PR TITLE
[scanner] fix: repair CanIChecker test blocking build-gate on main

### DIFF
--- a/web/src/components/rbac/__tests__/CanIChecker.test.tsx
+++ b/web/src/components/rbac/__tests__/CanIChecker.test.tsx
@@ -102,10 +102,9 @@ describe('CanIChecker — Initial Rendering', () => {
     const clusterSelect = screen.getByTestId('can-i-cluster') as HTMLSelectElement
     const options = Array.from(clusterSelect.options)
 
-    expect(options).toHaveLength(3)
-    expect(options[0].value).toBe('')
-    expect(options[1].value).toBe('cluster-a')
-    expect(options[2].value).toBe('cluster-b')
+    expect(options).toHaveLength(2)
+    expect(options[0].value).toBe('cluster-a')
+    expect(options[1].value).toBe('cluster-b')
   })
 
   it('populates namespace dropdown with fetched namespaces', () => {
@@ -120,11 +119,11 @@ describe('CanIChecker — Initial Rendering', () => {
     expect(options.some(opt => opt.value === 'kube-system')).toBe(true)
   })
 
-  it('starts with no cluster selected', () => {
+  it('auto-selects first available cluster', () => {
     render(<CanIChecker />)
 
     const clusterSelect = screen.getByTestId('can-i-cluster') as HTMLSelectElement
-    expect(clusterSelect.value).toBe('')
+    expect(clusterSelect.value).toBe('cluster-a')
   })
 
   it('defaults verb and resource to common values', () => {


### PR DESCRIPTION
Fixes #21348
Fixes #21355

CanIChecker.test.tsx assertions at lines 105 and 127 are stale relative to current component behavior, causing every PR's build-gate to fail and Coverage Suite to fail on main. This PR realigns the test with the intended component behavior.

Commit 9ec6f2ed0c (PR #21318) intentionally changed CanIChecker to auto-select the first available cluster and removed the blank placeholder `<option>`. Two test assertions were not updated alongside that component change:

- **Line 105**: `expect(options).toHaveLength(3)` → corrected to `toHaveLength(2)` (no blank placeholder option any more)
- **Lines 106-108**: option indices shifted — corrected to match cluster-a at [0], cluster-b at [1]
- **Line 127**: `expect(clusterSelect.value).toBe('')` → corrected to `toBe('cluster-a')` (auto-selection via useEffect)
- Test description updated: "starts with no cluster selected" → "auto-selects first available cluster"

Signed-off-by trailer included on commit (DCO).