### PR TITLE
🐛 [scanner] fix: document catch-binding convention to prevent lint regressions

### DIFF
--- a/web/eslint.config.js
+++ b/web/eslint.config.js
@@ -28,6 +28,11 @@ export default tseslint.config(
         'warn',
         { allowConstantExport: true },
       ],
+      // When you don't need the error value, use `catch { }` (no binding).
+      // Using a named binding like `catch (err)` when err is never referenced
+      // is flagged as a new baseline violation and will block the nightly
+      // release (see issues #21352/#21353). Prefix with _ (e.g. `catch (_err)`)
+      // only when you need the type annotation but not the value.
       '@typescript-eslint/no-unused-vars': ['warn', {
         argsIgnorePattern: '^_',
         varsIgnorePattern: '^_',

--- a/web/scripts/lint-baseline-check.mjs
+++ b/web/scripts/lint-baseline-check.mjs
@@ -113,6 +113,8 @@ if (newEntries.length > 0) {
     }
   });
   console.log('\n❌ CI fails on new violations. Fix them or update baseline after review.');
+  console.log('   Tip: For unused catch bindings (no-unused-vars), use `catch { }` instead');
+  console.log('   of `catch (err)` when you don\'t need the error value. See eslint.config.js.');
   process.exit(1);
 }
 


### PR DESCRIPTION
Fixes #21352
Fixes #21353

## Root cause

The nightly Release workflow failed at commit `2ea59dd25` (2026-07-21) because a new `@typescript-eslint/no-unused-vars` lint violation was introduced in `EnterpriseLayout.tsx` by #21342. The catch binding `catch (error)` was declared but never referenced, exceeding the lint baseline count and causing the **Lint frontend** step to fail.

The failing jobs in run [#29805735617](https://github.com/kubestellar/console/actions/runs/29805735617):
- ✅ Run Go tests (passed)
- ❌ Lint frontend (`npm run lint:check`) — **actual failure step**

## Existing code fixes (already merged to main)

| PR | Fix |
|----|-----|
| #21345 | Drop unused `error` binding in `EnterpriseLayout.tsx` — core lint fix |
| #21344 | CanIChecker test alignment (stale assertion) |
| #21346 | EnterpriseComplianceCards semantic color token (stale assertion) |
| #21354 | CreateNamespaceModal auto-select assertion (stale assertion) |

## This PR — regression guard

To prevent the same class of mistake (naming a catch binding you never use) from silently slipping through again:

1. **`web/eslint.config.js`** — adds an inline comment on the `no-unused-vars` rule explaining the correct pattern: use `catch { }` (no binding) when the error value is not needed; prefix with `_` only when a type annotation is required.

2. **`web/scripts/lint-baseline-check.mjs`** — improves the CI failure message with a targeted tip for the most common offender (unused catch bindings), pointing developers directly to the fix.

No rule severity or baseline changes — documentation-only, zero new lint violations.