### PR TITLE
🐛 [scanner] fix: bump js-yaml (CVE-2026-59869)

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -157,7 +157,7 @@
       "three-mesh-bvh": "^0.8.0"
     },
     "@istanbuljs/load-nyc-config": {
-      "js-yaml": "^5.0.0"
+      "js-yaml": "^5.2.1"
     },
     "minimatch": "^10.2.3",
     "follow-redirects": "^1.15.12",


### PR DESCRIPTION
Fixes #21361

This PR updates the js-yaml override in package.json to ensure all transitive dependencies use the patched version (≥4.3.0) to fix CVE-2026-59869.

The vulnerability affects js-yaml versions:
- 3.0.0 to < 3.15.0
- 4.0.0 to < 4.3.0

Patched by updating the override for @istanbuljs/load-nyc-config to use js-yaml ^5.2.1.