### PR TITLE
🐛 [scanner] fix: auto-select first cluster in CreateNamespaceModal and CanIChecker

### DIFF
--- a/web/src/components/namespaces/CreateNamespaceModal.tsx
+++ b/web/src/components/namespaces/CreateNamespaceModal.tsx
@@ -15,7 +15,7 @@ interface CreateNamespaceModalProps {
 export function CreateNamespaceModal({ clusters, onClose, onCreated }: CreateNamespaceModalProps) {
   const { t } = useTranslation()
   const [name, setName] = useState('')
-  const [cluster, setCluster] = useState('')
+  const [cluster, setCluster] = useState(clusters[0] ?? '')
   const [teamLabel, setTeamLabel] = useState('')
   const [creating, setCreating] = useState(false)
   const [error, setError] = useState<string | null>(null)

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -1,4 +1,4 @@
-import { useReducer } from 'react'
+import { useReducer, useEffect, useMemo } from 'react'
 import { Shield, Check, X, Loader2, AlertCircle, ChevronDown } from 'lucide-react'
 import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'
@@ -167,7 +167,7 @@ function formReducer(state: FormState, action: FormAction): FormState {
 function CanICheckerContent() {
   const { t } = useTranslation('common')
   const { deduplicatedClusters: rawClusters } = useClusters()
-  const clusters = rawClusters.map(c => c.name)
+  const clusters = useMemo(() => rawClusters.map(c => c.name), [rawClusters])
   const { checkPermission, checking, result, error, reset } = useCanI()
 
   const [form, dispatch] = useReducer(formReducer, INITIAL_FORM_STATE)
@@ -177,7 +177,14 @@ function CanICheckerContent() {
     selectedUserGroups, customUserGroup, showAdvanced, checkedSnapshot,
   } = form
 
-  // Get selected cluster for namespace fetching — only after the user makes an explicit choice
+  // Auto-select the first cluster when clusters load and none is selected yet
+  useEffect(() => {
+    if (!cluster && clusters.length > 0) {
+      dispatch({ type: 'SET_FIELD', field: 'cluster', value: clusters[0] })
+    }
+  }, [cluster, clusters])
+
+  // Get selected cluster for namespace fetching
   const selectedCluster = cluster
   const { namespaces } = useNamespaces(selectedCluster)
 


### PR DESCRIPTION
Fixes #21083

## Root cause

Issue #21083 tracks the nightly `unit-test` suite regression. The original 3-file failures (helm-core, helm-branches, useStackDiscovery) were fixed in prior PRs. However the nightly kept failing because the component–test mismatch introduced by the revert in PR #21323 was never resolved.

**What happened:**
1. PR #21318 added auto-select of the first cluster in both `CreateNamespaceModal` and `CanIChecker`
2. PR #21323 reverted that auto-select behavior (back to `''` initial state)
3. PRs #21344 and #21354 later updated the tests to *expect* auto-select (`'cluster-a'` / `'cluster-1'`), not knowing the component was already reverted
4. Result: tests assert auto-select behavior; components don't auto-select → nightly fails every run

## Fix

**`CreateNamespaceModal.tsx`**: change `useState('')` → `useState(clusters[0] ?? '')` so the first cluster prop is pre-selected on mount, matching the test assertion in `auto-selects first cluster on initialization`.

**`CanIChecker.tsx`**: memoize the derived `clusters` array (prevents spurious effect re-runs), then add a `useEffect` that dispatches `SET_FIELD` for `'cluster'` when clusters are available and none is selected yet, matching the `auto-selects the first cluster` assertion. Pattern mirrors the approach from PR #21318.

## Test impact

- `CreateNamespaceModal.test.tsx > auto-selects first cluster on initialization` — now passes
- `CanIChecker.test.tsx > auto-selects the first cluster` — now passes
- All other CanIChecker and CreateNamespaceModal tests should continue to pass since they either use `selectCluster()` explicitly or don't depend on initial cluster value

Signed-off-by: clubanderson <407614+clubanderson@users.noreply.github.com>