### PR TITLE
🌱 fix: point update-guard workflow at moved pkg/agent/updater package

### DIFF
--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -8,11 +8,7 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'pkg/agent/updater_checker.go'
-      - 'pkg/agent/updater_build.go'
-      - 'pkg/agent/updater_helpers.go'
-      - 'pkg/agent/updater_poller.go'
-      - 'pkg/agent/updater_checker_test.go'
+      - 'pkg/agent/updater/**'
       - 'pkg/agent/server.go'
       - 'web/src/hooks/useUpdateProgress.ts'
       - 'startup-oauth.sh'
@@ -46,35 +42,38 @@ jobs:
           echo "=== Running full update mechanism test suite ==="
           echo ""
           echo "--- Phase 1: 5-iteration reliability loop ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdateLoop_5x" -timeout 120s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdateLoop_5x" -timeout 120s
           echo ""
           echo "--- Phase 2: Build timeout handling ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_BuildTimeout" -timeout 30s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdate_BuildTimeout" -timeout 30s
           echo ""
           echo "--- Phase 3: Build failure with output capture ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_BuildFailure" -timeout 30s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdate_BuildFailure" -timeout 30s
           echo ""
           echo "--- Phase 4: npm install retry logic ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_NpmInstallRetry" -timeout 30s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdate_NpmInstallRetry" -timeout 30s
           echo ""
           echo "--- Phase 5: Git pull failure (early abort) ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_GitPullFailure" -timeout 30s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdate_GitPullFailure" -timeout 30s
           echo ""
           echo "--- Phase 6: Heartbeat during long builds ---"
-          go test ./pkg/agent/ -v -run "TestDeveloperUpdate_HeartbeatDuringBuild" -timeout 120s
+          go test ./pkg/agent/updater/ -v -run "TestDeveloperUpdate_HeartbeatDuringBuild" -timeout 120s
           echo ""
           echo "--- Phase 7: Output capture and utilities ---"
-          go test ./pkg/agent/ -v -run "TestRunBuildCmd_OutputCapture|TestTailLines|TestBuildErrorDetail|TestMockPathResolution" -timeout 30s
+          go test ./pkg/agent/updater/ -v -run "TestRunBuildCmd_OutputCapture|TestTailLines|TestBuildErrorDetail|TestMockPathResolution" -timeout 30s
 
       - name: Run concurrency safety tests
         run: |
           echo "=== Running concurrency safety tests ==="
-          go test ./pkg/agent/ -v -run "TestTriggerNow|TestIsUpdating|TestStatus" -timeout 30s -count=3
+          go test ./pkg/agent/updater/ -v -run "TestTriggerNow|TestStatus" -timeout 30s -count=3
 
       - name: Verify update invariants in source
         run: |
           echo "=== Verifying critical update invariants ==="
-          UPDATE_FILES="pkg/agent/updater_checker.go pkg/agent/updater_build.go pkg/agent/updater_build_helpers.go pkg/agent/updater_download.go pkg/agent/updater_execute.go pkg/agent/updater_git.go pkg/agent/updater_helpers.go pkg/agent/updater_poller.go"
+          # Non-test source files of the updater package (moved from flat
+          # pkg/agent/updater_*.go files). Tests are excluded so invariant
+          # greps match production code, not test scaffolding.
+          UPDATE_FILES=$(ls pkg/agent/updater/*.go | grep -v _test.go)
           ERRORS=0
 
           # 1. Atomic flag for mutual exclusion


### PR DESCRIPTION
## Summary
The updater was refactored from flat `pkg/agent/updater_*.go` files into the `pkg/agent/updater/` package, but `update-guard.yml` still referenced the old layout. Result: every `go test` phase silently ran with **no tests to run**, and the invariant greps failed on nonexistent files (12 violations) — failing the **Update Mechanism Tests** check on any PR touching a watched path. Currently blocking dependabot PR #21339.

## Changes
- Trigger paths: `pkg/agent/updater/**` replaces the stale per-file list
- Test target: `./pkg/agent/updater/` so the phases actually run the moved tests
- `UPDATE_FILES`: derived via `ls` excluding `_test.go`, so future renames inside the package can't silently break the guard again
- Dropped `TestIsUpdating` from the concurrency pattern (test no longer exists)

All 13 invariant greps verified locally against the new file set (bash semantics, matching the runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)