### PR TITLE
[sec-check] fix: bump js-yaml 4.2.0 → 4.3.0 (CVE-2026-59869, GHSA-52cp-r559-cp3m)

### DIFF
--- a/.github/guardrails-scripts/package-lock.json
+++ b/.github/guardrails-scripts/package-lock.json
@@ -8,7 +8,7 @@
       "name": "guardrails-scripts",
       "version": "1.0.0",
       "dependencies": {
-        "js-yaml": "4.2.0"
+        "js-yaml": "4.3.0"
       }
     },
     "node_modules/argparse": {
@@ -18,9 +18,9 @@
       "license": "Python-2.0"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",

--- a/.github/guardrails-scripts/package.json
+++ b/.github/guardrails-scripts/package.json
@@ -4,6 +4,6 @@
   "description": "Dependencies for scanner-merge-guardrails.yml",
   "private": true,
   "dependencies": {
-    "js-yaml": "4.2.0"
+    "js-yaml": "4.3.0"
   }
 }


### PR DESCRIPTION
## Security Fix

Bumps `js-yaml` from `4.2.0` → `4.3.0` in `.github/guardrails-scripts/` to remediate **[GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) / CVE-2026-59869** (CVSS 7.5, CWE-400/407 — quadratic-CPU ReDoS via YAML merge-key chains).

### What changes
- `package.json`: `"js-yaml": "4.2.0"` → `"4.3.0"`
- `package-lock.json`: regenerated with `npm install --package-lock-only` (only `js-yaml` node updated; `argparse` unchanged).

### Why this matters
The `guardrails-scripts` package is executed by `scanner-merge-guardrails.yml` on every PR — including from untrusted forks. A crafted `<<:` merge-key chain (< 100 KB, ~4 000 nodes) forces O(N²) parse time on the vulnerable versions, giving an attacker a cheap DoS against the merge-guard gate. `4.3.0` caps merged-key visits, which is the upstream fix.

### Verification
- Advisory: <https://github.com/advisories/GHSA-52cp-r559-cp3m>
- Dependabot alert: [#24](https://github.com/kubestellar/console/security/dependabot/24)
- Lockfile regenerated locally with `npm install --package-lock-only --no-audit --no-fund`; diff is minimal (version + tarball URL + integrity hash on the `js-yaml` node).

Fixes #21365

---
*Filed by sec-check agent (ACMM L6 — full mode)*