### PR TITLE
[sec-check] fix(kb-scripts): bump fast-uri 3.1.2 → 3.1.4 (GHSA-v2hh-gcrm-f6hx, GHSA-4c8g-83qw-93j6)

### DIFF
--- a/.github/kb-scripts/package-lock.json
+++ b/.github/kb-scripts/package-lock.json
@@ -52,9 +52,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "funding": [
         {
           "type": "github",

--- a/.github/kb-scripts/package.json
+++ b/.github/kb-scripts/package.json
@@ -8,6 +8,7 @@
     "ajv-formats": "2.1.1"
   },
   "overrides": {
-    "fast-json-patch": "^3.1.1"
+    "fast-json-patch": "^3.1.1",
+    "fast-uri": "^3.1.4"
   }
 }


### PR DESCRIPTION
## Security Fix

Bumps `fast-uri` from **3.1.2** to **3.1.4** in `.github/kb-scripts/` (transitive dep of `ajv`) via an npm `overrides` entry. Regenerates `package-lock.json` accordingly.

Clears two open Dependabot / osv-scanner advisories against this lockfile:

| Advisory | Severity | Summary |
|---|---|---|
| [GHSA-v2hh-gcrm-f6hx](https://github.com/advisories/GHSA-v2hh-gcrm-f6hx) / CVE-2026-16221 | high | Literal `\` treated as authority delimiter → host-parser desync vs Node `URL`/`fetch` → SSRF / policy bypass. Fixed in 3.1.4. |
| [GHSA-4c8g-83qw-93j6](https://github.com/advisories/GHSA-4c8g-83qw-93j6) / CVE-2026-13676 | high | IDN canonicalization failure (`URL.domainToASCII` missing) → host-parser desync → SSRF / policy bypass. Fixed in 3.1.3. |

Blast radius is limited: `.github/kb-scripts/` runs only in CI workflows that validate KB JSON via `ajv`, so exposure is CI runners consuming attacker-controlled URLs — no impact on the production console. Bumping regardless to keep supply-chain posture clean and to clear Scorecard alert #16 (rule `VulnerabilitiesID`).

Note: this PR does **not** address the third finding in #21373 (`golang.org/x/text` v0.38.0 → v0.39.0). That bump needs `go get golang.org/x/text@v0.39.0 && go mod tidy` which requires the Go toolchain to regenerate `go.sum`; leaving it to a maintainer or a follow-up.

Fixes part of #21373 (fast-uri portion).
Related Dependabot alerts: [#25](https://github.com/kubestellar/console/security/dependabot/25), [#26](https://github.com/kubestellar/console/security/dependabot/26).

Verification: `npm install --package-lock-only --ignore-scripts` in a clean copy of `.github/kb-scripts/` with these files produces exactly this lockfile (verified locally with npm 11.16.0 / Node 22).

---
*Filed by sec-check agent (ACMM L6 — full mode). Do not merge automatically; awaiting human or automerge agent review.*