### PR TITLE
🌱 [scanner] fix: WCAG AA color contrast

### DIFF
--- a/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
+++ b/web/src/components/cards/insights/DeploymentRolloutTracker.tsx
@@ -39,7 +39,7 @@ function getProgressColor(status: string): string {
 function getStatusIcon(status: string) {
   if (status === 'complete') return <CheckCircle2 className="w-3 h-3 text-green-400" />
   if (status === 'failed') return <AlertTriangle className="w-3 h-3 text-red-400" />
-  if (status === 'pending') return <Clock className="w-3 h-3 text-gray-400" />
+  if (status === 'pending') return <Clock className="w-3 h-3 text-gray-300" />
   return <Rocket className="w-3 h-3 text-blue-400" />
 }
 

--- a/web/src/components/cards/quantum/CustomQASMModal.tsx
+++ b/web/src/components/cards/quantum/CustomQASMModal.tsx
@@ -130,7 +130,7 @@ const MemoizedCustomQASMModal = React.memo(function MemoizedCustomQASMModal({
             onClick={handleCancel}
             className="p-1 hover:bg-gray-100 dark:hover:bg-gray-800 rounded transition-colors"
           >
-            <X className="w-5 h-5 text-gray-500 dark:text-gray-400" />
+            <X className="w-5 h-5 text-gray-500 dark:text-gray-300" />
           </button>
         </div>
 
@@ -145,7 +145,7 @@ const MemoizedCustomQASMModal = React.memo(function MemoizedCustomQASMModal({
               'px-4 py-3 font-medium text-sm border-b-2 transition-colors',
               mode === 'paste'
                 ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                : 'border-transparent text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-200'
             )}
           >
             <div className="flex items-center gap-2">
@@ -162,7 +162,7 @@ const MemoizedCustomQASMModal = React.memo(function MemoizedCustomQASMModal({
               'px-4 py-3 font-medium text-sm border-b-2 transition-colors',
               mode === 'upload'
                 ? 'border-blue-500 text-blue-600 dark:text-blue-400'
-                : 'border-transparent text-gray-600 dark:text-gray-400 hover:text-gray-900 dark:hover:text-gray-200'
+                : 'border-transparent text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-gray-200'
             )}
           >
             <div className="flex items-center gap-2">
@@ -176,7 +176,7 @@ const MemoizedCustomQASMModal = React.memo(function MemoizedCustomQASMModal({
         <div className="flex-1 overflow-auto p-4">
           {mode === 'paste' ? (
             <div className="space-y-2">
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 Paste your QASM circuit code below. Must start with "OPENQASM".
               </p>
               <TextArea
@@ -188,23 +188,23 @@ const MemoizedCustomQASMModal = React.memo(function MemoizedCustomQASMModal({
                 error={!!error}
               />
               {content && (
-                <div className="text-xs text-gray-500 dark:text-gray-400">
+                <div className="text-xs text-gray-500 dark:text-gray-300">
                   {content.length} / {MAX_SIZE_BYTES} bytes
                 </div>
               )}
             </div>
           ) : (
             <div className="space-y-4">
-              <p className="text-sm text-gray-600 dark:text-gray-400">
+              <p className="text-sm text-gray-600 dark:text-gray-300">
                 Select a .qasm file from your computer.
               </p>
               <div
                 className="border-2 border-dashed border-gray-300 dark:border-gray-600 rounded-lg p-8 text-center hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
                 onClick={() => fileInputRef.current?.click()}
               >
-                <Upload className="w-8 h-8 text-gray-400 dark:text-gray-500 mx-auto mb-2" />
+                <Upload className="w-8 h-8 text-gray-300 dark:text-gray-500 mx-auto mb-2" />
                 <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Click to upload or drag & drop</p>
-                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">QASM files up to 50KB</p>
+                <p className="text-xs text-gray-500 dark:text-gray-300 mt-1">QASM files up to 50KB</p>
               </div>
               <Input
                 ref={fileInputRef}

--- a/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
+++ b/web/src/components/cards/quantum/QuantumCircuitViewer.tsx
@@ -146,7 +146,7 @@ export const QuantumCircuitViewer: React.FC<QuantumCircuitViewerProps> = ({ isDe
   if (!isAuthenticated) {
     return (
       <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
-        <p className="text-gray-500">Please log in to view quantum data</p>
+        <p className="text-muted-foreground">Please log in to view quantum data</p>
         <button
           type="button"
           onClick={() => login()}

--- a/web/src/components/cards/quantum/QuantumControlPanel.tsx
+++ b/web/src/components/cards/quantum/QuantumControlPanel.tsx
@@ -428,7 +428,7 @@ export const QuantumControlPanel: React.FC = () => {
   if (!isAuthenticated) {
     return (
       <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
-        <p className="text-gray-500">Please log in to view quantum data</p>
+        <p className="text-muted-foreground">Please log in to view quantum data</p>
         <button
           onClick={() => login()}
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"

--- a/web/src/components/cards/quantum/QuantumQubitGrid.tsx
+++ b/web/src/components/cards/quantum/QuantumQubitGrid.tsx
@@ -266,7 +266,7 @@ export const QuantumQubitGrid: React.FC = () => {
   if (!isAuthenticated) {
     return (
       <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
-        <p className="text-gray-500">Please log in to view quantum data</p>
+        <p className="text-muted-foreground">Please log in to view quantum data</p>
         <button
           onClick={() => login()}
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"

--- a/web/src/components/cards/quantum/QuantumStatus.tsx
+++ b/web/src/components/cards/quantum/QuantumStatus.tsx
@@ -61,7 +61,7 @@ export const QuantumStatus: React.FC<QuantumStatusProps> = ({ isDemoData = false
   if (!isAuthenticated) {
     return (
       <div className="flex flex-col items-center justify-center p-8 gap-4 text-center">
-        <p className="text-gray-500">Please log in to view quantum data</p>
+        <p className="text-muted-foreground">Please log in to view quantum data</p>
         <button
           onClick={() => login()}
           className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 transition"

--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -145,7 +145,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
   if (error) return (
     <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-lg space-y-3">
       <p className="text-red-400 font-medium">Unable to load risk matrix data</p>
-      <p className="text-sm text-gray-400">{error}</p>
+      <p className="text-sm text-gray-300">{error}</p>
       <button
         onClick={fetchData}
         className="px-4 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 rounded text-sm text-red-300 transition-colors"
@@ -173,38 +173,38 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
           <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-400">Total Risks</p>
+            <p className="text-sm text-gray-300">Total Risks</p>
             <p className="text-2xl font-bold text-white">{summary.total_risks}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-red-900/30">
-            <p className="text-sm text-gray-400">Critical</p>
+            <p className="text-sm text-gray-300">Critical</p>
             <p className="text-2xl font-bold text-red-400">{summary.critical}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-red-700/30">
-            <p className="text-sm text-gray-400">High</p>
+            <p className="text-sm text-gray-300">High</p>
             <p className="text-2xl font-bold text-red-300">{summary.high}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-orange-700/30">
-            <p className="text-sm text-gray-400">Medium</p>
+            <p className="text-sm text-gray-300">Medium</p>
             <p className="text-2xl font-bold text-orange-400">{summary.medium}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-green-700/30">
-            <p className="text-sm text-gray-400">Low</p>
+            <p className="text-sm text-gray-300">Low</p>
             <p className="text-2xl font-bold text-green-400">{summary.low}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-400">Trend</p>
+            <p className="text-sm text-gray-300">Trend</p>
             <div className="flex items-center gap-1">
               {summary.trend_direction === 'down' ? (
                 <TrendingDown className="w-5 h-5 text-green-400" />
               ) : summary.trend_direction === 'up' ? (
                 <TrendingUp className="w-5 h-5 text-red-400" />
               ) : (
-                <ArrowRight className="w-5 h-5 text-gray-400" />
+                <ArrowRight className="w-5 h-5 text-gray-300" />
               )}
               <span className={`text-lg font-bold ${
                 summary.trend_direction === 'down' ? 'text-green-400' :
-                summary.trend_direction === 'up' ? 'text-red-400' : 'text-gray-400'
+                summary.trend_direction === 'up' ? 'text-red-400' : 'text-gray-300'
               }`}>{summary.trend_percentage}%</span>
             </div>
           </div>
@@ -215,11 +215,11 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
         {/* Heat Map */}
         <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-6">
           <h2 className="text-lg font-semibold text-white mb-4">Risk Heat Map</h2>
-          <p className="text-xs text-gray-400 mb-3">Click a cell to view risks in that zone</p>
+          <p className="text-xs text-gray-300 mb-3">Click a cell to view risks in that zone</p>
           <div className="flex">
             {/* Y-axis label */}
             <div className="flex flex-col justify-center mr-2">
-              <span className="text-xs text-gray-400 -rotate-90 whitespace-nowrap">← Likelihood →</span>
+              <span className="text-xs text-gray-300 -rotate-90 whitespace-nowrap">← Likelihood →</span>
             </div>
             <div className="flex-1">
               {/* Grid rows — highest likelihood at top */}
@@ -227,7 +227,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 const likelihood = MATRIX_SIZE - rowIdx
                 return (
                   <div key={likelihood} className="flex items-center gap-1 mb-1">
-                    <span className="text-xs text-gray-400 w-20 text-right pr-2 truncate">{AXIS_LABELS[likelihood - 1]}</span>
+                    <span className="text-xs text-gray-300 w-20 text-right pr-2 truncate">{AXIS_LABELS[likelihood - 1]}</span>
                     {Array.from({ length: MATRIX_SIZE }, (_, colIdx) => {
                       const impact = colIdx + 1
                       const cell = heatmapLookup.get(`${likelihood}-${impact}`)
@@ -252,10 +252,10 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
               {/* X-axis labels */}
               <div className="flex gap-1 mt-1 ml-20">
                 {IMPACT_LABELS.map(label => (
-                  <span key={label} className="flex-1 text-center text-xs text-gray-400 truncate">{label}</span>
+                  <span key={label} className="flex-1 text-center text-xs text-gray-300 truncate">{label}</span>
                 ))}
               </div>
-              <p className="text-xs text-gray-400 text-center mt-1">← Impact →</p>
+              <p className="text-xs text-gray-300 text-center mt-1">← Impact →</p>
             </div>
           </div>
         </div>
@@ -270,7 +270,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 </h2>
                 <button
                   onClick={() => setSelectedCell(null)}
-                  className="text-xs text-gray-400 hover:text-white"
+                  className="text-xs text-gray-300 hover:text-white"
                 >{i18next.t('common:clearSelection', 'Clear selection')}</button>
               </div>
               {selectedRisks.length === 0 ? (
@@ -283,7 +283,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                         <span className="text-sm font-medium text-white">{risk.name}</span>
                         {severityBadge(risk.score)}
                       </div>
-                      <div className="flex gap-4 text-xs text-gray-400">
+                      <div className="flex gap-4 text-xs text-gray-300">
                         <span>{risk.category}</span>
                         <span>Owner: {risk.owner}</span>
                         <span className={risk.status === 'Open' ? 'text-yellow-400' : 'text-green-400'}>{risk.status}</span>
@@ -302,7 +302,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                     <span className="text-xs text-gray-500 w-6">{idx + 1}.</span>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm text-white truncate">{risk.name}</p>
-                      <p className="text-xs text-gray-400">{risk.category} · {risk.owner}</p>
+                      <p className="text-xs text-gray-300">{risk.category} · {risk.owner}</p>
                     </div>
                     <div className="text-right">
                       <span className="text-lg font-bold text-white">{risk.score}</span>
@@ -327,7 +327,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 className="w-full rounded-t bg-gradient-to-t from-orange-600 to-orange-400 transition-all"
                 style={{ height: `${(val / 50) * 100}%` }}
               />
-              <span className="text-xs text-gray-400">M{idx + 1}</span>
+              <span className="text-xs text-gray-300">M{idx + 1}</span>
             </div>
           ))}
         </div>
@@ -340,13 +340,13 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
       {/* All risks table */}
       <div className="bg-gray-800/50 rounded-lg border border-gray-700 overflow-hidden">
         <div className="p-4 border-b border-gray-700 flex items-center gap-2">
-          <ChevronDown className="w-4 h-4 text-gray-400" />
+          <ChevronDown className="w-4 h-4 text-gray-300" />
           <h2 className="text-lg font-semibold text-white">All Risks</h2>
           <span className="text-xs text-gray-500 ml-2">({risks.length} total)</span>
         </div>
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-gray-400 border-b border-gray-700">
+            <tr className="text-gray-300 border-b border-gray-700">
               <th className="text-left p-3">ID</th>
               <th className="text-left p-3">Name</th>
               <th className="text-left p-3">Category</th>
@@ -371,7 +371,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                   <span className={`text-xs font-medium ${
                     r.status === 'Open' ? 'text-yellow-400' :
                     r.status === 'Mitigating' ? 'text-blue-400' :
-                    r.status === 'Accepted' ? 'text-gray-400' : 'text-green-400'
+                    r.status === 'Accepted' ? 'text-gray-300' : 'text-green-400'
                   }`}>{r.status}</span>
                 </td>
               </tr>


### PR DESCRIPTION
Fixes #21382

Addresses Auto-QA color contrast findings by improving text contrast ratios:
- RiskMatrixDashboard: text-gray-400 → text-gray-300 (better contrast on dark backgrounds)
- DeploymentRolloutTracker: pending icon text-gray-400 → text-gray-300
- Quantum components: text-gray-500 → text-muted-foreground for login prompts
- CustomQASMModal: text-gray-400 → text-gray-300 in dark mode

These changes improve WCAG AA compliance without altering visual hierarchy.