### PR TITLE
🌱 [scanner] refactor: split large drill-down views

### DIFF
--- a/web/src/components/drilldown/views/ClusterDrillDown.tsx
+++ b/web/src/components/drilldown/views/ClusterDrillDown.tsx
@@ -1,20 +1,16 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useEffect, useState, useRef, useCallback, useMemo } from 'react'
-import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, HardDrive, Search, AlertTriangle, XCircle } from 'lucide-react'
+import { ChevronRight } from 'lucide-react'
 import { StatusBadge } from '../../ui/StatusBadge'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaces, useNamespaceStats, useDeployments, useServices, useEvents, useClusters, type ClusterInfo } from '../../../hooks/useMCP'
 import { useCachedPVCs } from '../../../hooks/useCachedData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { Gauge } from '../../charts/Gauge'
-import { NamespaceResources } from '../../clusters/components'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../../lib/cn'
 import { LOADING_TIMEOUT_MS } from '../../../lib/constants/network'
-
-// Resource tree lens/view options
-type TreeLens = 'all' | 'issues' | 'nodes' | 'workloads' | 'storage' | 'network'
-type ClusterTab = 'events' | 'resources'
+import { ClusterResourceTree } from './cluster-drilldown/ClusterResourceTree'
+import type { TreeLens, ClusterTab } from './cluster-drilldown/types'
 
 /** Scroll delay (ms) to let the DOM update after switching tabs */
 const SCROLL_AFTER_TAB_SWITCH_MS = 100
@@ -634,368 +630,30 @@ export function ClusterDrillDown({ data }: Props) {
 
         {/* Resources Tab */}
         {activeTab === 'resources' && (
-          <div className="space-y-4">
-            {/* Search and Filters */}
-            <div className="flex flex-col md:flex-row gap-3">
-              {/* Search */}
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-                <input
-                  type="text"
-                  value={searchFilter}
-                  onChange={(e) => setSearchFilter(e.target.value)}
-                  placeholder={t('common.searchResources')}
-                  className="w-full pl-10 pr-4 py-2 bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500/50"
-                />
-              </div>
-
-              {/* Lens/View Buttons */}
-              <div className="flex flex-wrap gap-2">
-                {[
-                  { id: 'all' as TreeLens, label: 'All', icon: Layers },
-                  { id: 'issues' as TreeLens, label: 'Issues', icon: AlertTriangle, count: issueCounts.total },
-                  { id: 'nodes' as TreeLens, label: 'Nodes', icon: Server, count: filteredNodes.length },
-                  { id: 'workloads' as TreeLens, label: 'Workloads', icon: Box, count: filteredNamespaceStats.length },
-                  { id: 'storage' as TreeLens, label: 'Storage', icon: HardDrive, count: filteredPVCs.length },
-                  { id: 'network' as TreeLens, label: 'Network', icon: Network, count: filteredServices.length },
-                ].map(lens => (
-                  <button
-                    key={lens.id}
-                    onClick={() => setActiveLens(lens.id)}
-                    className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors ${
-                      activeLens === lens.id
-                        ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                        : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    <lens.icon className="w-3.5 h-3.5" />
-                    {lens.label}
-                    {lens.count !== undefined && lens.count > 0 && (
-                      <span className={`ml-1 px-1.5 py-0.5 rounded-full text-2xs ${
-                        lens.id === 'issues' ? 'bg-red-500/20 text-red-400' : 'bg-secondary text-muted-foreground'
-                      }`}>
-                        {lens.count}
-                      </span>
-                    )}
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Tree Content */}
-            <div className="bg-card/30 rounded-lg border border-border p-4">
-              {/* Cluster Root */}
-              <div className="relative">
-                {/* Cluster Header */}
-                <div
-                  onClick={() => toggleSection('cluster')}
-                  className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                >
-                  {expandedSections.has('cluster') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                  <Server className="w-4 h-4 text-cyan-400" />
-                  <span className="font-medium text-foreground">{clusterDisplayName}</span>
-                  <StatusIndicator status={
-                    health?.reachable === false ? 'unreachable' :
-                    (health?.nodeCount && health.nodeCount > 0)
-                      ? (health.readyNodes === health.nodeCount ? 'healthy' : 'warning')
-                      : (health?.healthy ? 'healthy' : 'error')
-                  } />
-                </div>
-
-                {expandedSections.has('cluster') && (
-                  <div className="ml-6 border-l-2 border-cyan-500/30 pl-4 mt-2 space-y-2">
-                    {/* Nodes Branch */}
-                    {(activeLens === 'all' || activeLens === 'nodes' || activeLens === 'issues') && filteredNodes.length > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('nodes')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('nodes') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <Server className="w-4 h-4 text-blue-400" />
-                          <span className="text-sm font-medium text-foreground">{t('common.nodes')}</span>
-                          <span className="text-xs text-muted-foreground">({filteredNodes.length})</span>
-                          {issueCounts.nodes > 0 && (
-                            <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
-                              {issueCounts.nodes} not ready
-                            </StatusBadge>
-                          )}
-                        </div>
-
-                        {expandedSections.has('nodes') && (
-                          <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
-                            {filteredNodes.slice(0, 20).map((node) => (
-                              <button
-                                key={node.name}
-                                onClick={() => drillToNode(effectiveClusterName, node.name, { status: node.status, roles: node.roles, unschedulable: node.unschedulable })}
-                                type="button"
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group w-full text-left bg-transparent border-none"
-                              >
-                                <div className={`w-2 h-2 rounded-full ${node.status === 'Ready' ? 'bg-green-400' : 'bg-red-400'}`} />
-                                <span className="text-sm text-foreground group-hover:text-primary transition-colors">{node.name}</span>
-                                <span className={`text-xs ${node.status === 'Ready' ? 'text-green-400' : 'text-red-400'}`}>
-                                  {node.status}
-                                </span>
-                                {node.roles?.length > 0 && (
-                                  <span className="text-xs text-muted-foreground">
-                                    [{(node.roles || []).join(', ')}]
-                                  </span>
-                                )}
-                                <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </button>
-                            ))}
-                            {filteredNodes.length > 20 && (
-                              <div className="text-xs text-muted-foreground p-2">
-                                +{filteredNodes.length - 20} more nodes...
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Namespaces Branch */}
-                    {(activeLens === 'all' || activeLens === 'workloads') && filteredNamespaces.length > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('namespaces')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('namespaces') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <Database className="w-4 h-4 text-purple-400" />
-                          <span className="text-sm font-medium text-foreground">Namespaces</span>
-                          <span className="text-xs text-muted-foreground">({filteredNamespaces.length})</span>
-                        </div>
-
-                        {expandedSections.has('namespaces') && (
-                          <div className="ml-6 border-l-2 border-purple-500/30 pl-4 mt-1 space-y-1">
-                            {filteredNamespaceStats.slice(0, 15).map((namespaceStat, i) => {
-                              const ns = namespaceStat.name
-                              const nsKey = `ns-${ns}`
-                              const nsPodIssues = namespaceResources.podIssueCounts[ns] || 0
-                              const nsDeploymentIssues = namespaceResources.deploymentIssueCounts[ns] || 0
-                              const totalIssues = nsPodIssues + nsDeploymentIssues
-
-
-                              return (
-                                <div key={i}>
-                                  <div
-                                    onClick={() => toggleSection(nsKey)}
-                                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                                  >
-                                    {expandedSections.has(nsKey) ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
-                                    <span className="text-sm text-foreground">{ns}</span>
-                                    {namespaceStat.podCount > 0 && (
-                                      <span className="text-xs text-muted-foreground">
-                                        {namespaceStat.runningPods}/{namespaceStat.podCount} pods
-                                      </span>
-                                    )}
-                                    {namespaceStat.pendingPods > 0 && (
-                                      <StatusBadge color="yellow" size="xs" rounded="full" className="ml-1">
-                                        {namespaceStat.pendingPods} pending
-                                      </StatusBadge>
-                                    )}
-                                    {totalIssues > 0 && (
-                                      <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
-                                        {totalIssues}
-                                      </StatusBadge>
-                                    )}
-                                  </div>
-
-                                  {expandedSections.has(nsKey) && (
-                                    <div className="ml-6 border-l-2 border-muted/30 pl-4 mt-1 space-y-2">
-                                      <NamespaceResources clusterName={effectiveClusterName} namespace={ns} />
-                                      <button
-                                        onClick={() => drillToNamespace(effectiveClusterName, ns)}
-                                        className="text-xs text-purple-400 hover:text-purple-300 p-1.5 transition-colors"
-                                      >
-                                        View all in {ns} →
-                                      </button>
-                                    </div>
-                                  )}
-                                </div>
-                              )
-                            })}
-                            {filteredNamespaces.length > 15 && (
-                              <div className="text-xs text-muted-foreground p-2">
-                                +{filteredNamespaces.length - 15} more namespaces...
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Deployments with Issues (when issues lens active) */}
-                    {activeLens === 'issues' && issueCounts.deployments > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('deployment-issues')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('deployment-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <AlertTriangle className="w-4 h-4 text-orange-400" />
-                          <span className="text-sm font-medium text-foreground">Deployment Issues</span>
-                          <StatusBadge color="orange" size="xs" rounded="full">
-                            {issueCounts.deployments}
-                          </StatusBadge>
-                        </div>
-
-                        {expandedSections.has('deployment-issues') && (
-                          <div className="ml-6 border-l-2 border-orange-500/30 pl-4 mt-1 space-y-1">
-                            {unhealthyDeployments.map((dep, i) => (
-                              <div
-                                key={i}
-                                onClick={() => drillToNamespace(effectiveClusterName, dep.namespace)}
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                              >
-                                <XCircle className="w-3 h-3 text-orange-400" />
-                                <span className="text-sm text-foreground">{dep.name}</span>
-                                <span className="text-xs text-muted-foreground">{dep.namespace}</span>
-                                <span className="text-xs text-orange-400">{dep.readyReplicas}/{dep.replicas}</span>
-                                <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </div>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Pod Issues (when issues lens active) */}
-                    {activeLens === 'issues' && issueCounts.pods > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('pod-issues')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('pod-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <AlertTriangle className="w-4 h-4 text-red-400" />
-                          <span className="text-sm font-medium text-foreground">Pod Issues</span>
-                          <StatusBadge color="red" size="xs" rounded="full">
-                            {issueCounts.pods}
-                          </StatusBadge>
-                        </div>
-
-                        {expandedSections.has('pod-issues') && (
-                          <div className="ml-6 border-l-2 border-red-500/30 pl-4 mt-1 space-y-1">
-                            {podIssues.slice(0, 10).map((issue, i) => (
-                              <div
-                                key={i}
-                                onClick={() => drillToPod(effectiveClusterName, issue.namespace, issue.name, { ...issue })}
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                              >
-                                <XCircle className="w-3 h-3 text-red-400" />
-                                <span className="text-sm text-foreground">{issue.name}</span>
-                                <span className="text-xs text-muted-foreground">{issue.namespace}</span>
-                                <span className="text-xs text-red-400">{issue.status}</span>
-                                <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </div>
-                            ))}
-                            {podIssues.length > 10 && (
-                              <div className="text-xs text-muted-foreground p-2">
-                                +{podIssues.length - 10} more pod issues...
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Storage Resources */}
-                    {(activeLens === 'storage' || (activeLens === 'all' && filteredPVCs.length > 0)) && filteredPVCs.length > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('storage')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('storage') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <HardDrive className="w-4 h-4 text-green-400" />
-                          <span className="text-sm font-medium text-foreground">{t('common.pvcs')}</span>
-                          <span className="text-xs text-muted-foreground">({filteredPVCs.length})</span>
-                          {issueCounts.pvcs > 0 && (
-                            <StatusBadge color="yellow" size="xs" rounded="full" className="ml-1">
-                              {issueCounts.pvcs} pending
-                            </StatusBadge>
-                          )}
-                        </div>
-
-                        {expandedSections.has('storage') && (
-                          <div className="ml-6 border-l-2 border-green-500/30 pl-4 mt-1 space-y-1">
-                            {filteredPVCs.slice(0, 10).map((pvc, i) => (
-                              <div
-                                key={i}
-                                onClick={() => drillToNamespace(effectiveClusterName, pvc.namespace)}
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                              >
-                                <div className={`w-2 h-2 rounded-full ${pvc.status === 'Bound' ? 'bg-green-400' : 'bg-yellow-400'}`} />
-                                <span className="text-sm text-foreground">{pvc.name}</span>
-                                <span className="text-xs text-muted-foreground">{pvc.namespace}</span>
-                                <span className={`text-xs ${pvc.status === 'Bound' ? 'text-green-400' : 'text-yellow-400'}`}>
-                                  {pvc.status}
-                                </span>
-                                {pvc.capacity && <span className="text-xs text-muted-foreground">{pvc.capacity}</span>}
-                                <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </div>
-                            ))}
-                            {filteredPVCs.length > 10 && (
-                              <div className="text-xs text-muted-foreground p-2">
-                                +{filteredPVCs.length - 10} more PVCs...
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Network Resources */}
-                    {activeLens === 'network' && filteredServices.length > 0 && (
-                      <div>
-                        <div
-                          onClick={() => toggleSection('network')}
-                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
-                        >
-                          {expandedSections.has('network') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
-                          <Network className="w-4 h-4 text-blue-400" />
-                          <span className="text-sm font-medium text-foreground">{t('common.services')}</span>
-                          <span className="text-xs text-muted-foreground">({filteredServices.length})</span>
-                        </div>
-
-                        {expandedSections.has('network') && (
-                          <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
-                            {filteredServices.slice(0, 15).map((svc, i) => (
-                              <div
-                                key={i}
-                                onClick={() => drillToNamespace(effectiveClusterName, svc.namespace)}
-                                className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                              >
-                                <Network className="w-3 h-3 text-blue-400" />
-                                <span className="text-sm text-foreground">{svc.name}</span>
-                                <span className="text-xs text-muted-foreground">{svc.namespace}</span>
-                                <StatusBadge color="blue" size="xs">{svc.type}</StatusBadge>
-                                <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                              </div>
-                            ))}
-                            {filteredServices.length > 15 && (
-                              <div className="text-xs text-muted-foreground p-2">
-                                +{filteredServices.length - 15} more services...
-                              </div>
-                            )}
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Empty state for filters */}
-                    {!hasVisibleResourceData && (
-                      <div className="text-center text-muted-foreground text-sm py-4">
-                        No resources match the current filter
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
+          <ClusterResourceTree
+            effectiveClusterName={effectiveClusterName}
+            clusterDisplayName={clusterDisplayName}
+            health={health}
+            filteredNodes={filteredNodes}
+            filteredNamespaces={filteredNamespaces}
+            filteredNamespaceStats={filteredNamespaceStats}
+            unhealthyDeployments={unhealthyDeployments}
+            filteredServices={filteredServices}
+            filteredPVCs={filteredPVCs}
+            namespaceResources={namespaceResources}
+            issueCounts={issueCounts}
+            hasVisibleResourceData={hasVisibleResourceData}
+            activeLens={activeLens}
+            setActiveLens={setActiveLens}
+            searchFilter={searchFilter}
+            setSearchFilter={setSearchFilter}
+            expandedSections={expandedSections}
+            toggleSection={toggleSection}
+            podIssues={podIssues}
+            drillToNode={drillToNode}
+            drillToNamespace={drillToNamespace}
+            drillToPod={drillToPod}
+          />
         )}
       </div>
     </div>

--- a/web/src/components/drilldown/views/DeploymentDrillDown.tsx
+++ b/web/src/components/drilldown/views/DeploymentDrillDown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useEffect, useRef, useCallback, type KeyboardEvent as ReactKeyboardEvent } from 'react'
 import { useLocalAgent } from '../../../hooks/useLocalAgent'
 import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
@@ -16,120 +15,9 @@ import { useTranslation } from 'react-i18next'
 import { copyToClipboard } from '../../../lib/clipboard'
 import { PageErrorBoundary } from '../../PageErrorBoundary'
 import { Button } from '../../ui/Button'
-
-/** Maximum replicas allowed via the UI scale widget. Kubernetes itself supports
- *  up to 2^31-1 but most real deployments won't exceed a few hundred. */
-const MAX_SCALE_REPLICAS = 100
-
-/** Pod status styling configuration */
-const POD_STATUS_CONFIG: Record<string, { bg: string; text: string }> = {
-  Running: { bg: 'bg-green-500/20', text: 'text-green-400' },
-  Pending: { bg: 'bg-yellow-500/20', text: 'text-yellow-400' },
-  Failed: { bg: 'bg-red-500/20', text: 'text-red-400' },
-  CrashLoopBackOff: { bg: 'bg-red-500/20', text: 'text-red-400' },
-  ImagePullBackOff: { bg: 'bg-red-500/20', text: 'text-red-400' },
-  Unknown: { bg: 'bg-red-500/20', text: 'text-red-400' },
-}
-
-/**
- * Classify a raw kubectl scale error into a stable i18n key. The caller
- * runs `t(...)` on the result. Returning a static key literal keeps the
- * keys compatible with i18next-typescript strict typing (no runtime
- * template literals inside t()).
- *
- * Issue 9284: previously we surfaced the full kubectl stderr, which exposed
- * internal cluster details (namespaces, group-version-kind, resource versions)
- * that aren't useful to end users.
- */
-type ScaleErrorKey =
-  | 'drilldown.scale.failedGeneric'
-  | 'drilldown.scale.failedForbidden'
-  | 'drilldown.scale.failedNotFound'
-  | 'drilldown.scale.failedInvalid'
-  | 'drilldown.scale.failedConflict'
-  | 'drilldown.scale.failedTimeout'
-
-function classifyScaleError(raw: string): ScaleErrorKey {
-  const lc = (raw || '').toLowerCase()
-  if (!raw) return 'drilldown.scale.failedGeneric'
-  if (lc.includes('forbidden') || lc.includes('cannot patch') || lc.includes('unauthorized')) {
-    return 'drilldown.scale.failedForbidden'
-  }
-  if (lc.includes('not found') || lc.includes('notfound')) {
-    return 'drilldown.scale.failedNotFound'
-  }
-  if (lc.includes('invalid') || lc.includes('must be') || lc.includes('out of range')) {
-    return 'drilldown.scale.failedInvalid'
-  }
-  if (lc.includes('conflict') || lc.includes('modified')) {
-    return 'drilldown.scale.failedConflict'
-  }
-  if (lc.includes('timeout') || lc.includes('timed out') || lc.includes('deadline')) {
-    return 'drilldown.scale.failedTimeout'
-  }
-  return 'drilldown.scale.failedGeneric'
-}
-
-interface Props {
-  data: Record<string, unknown>
-}
-
-type TabType = 'overview' | 'pods' | 'events' | 'describe' | 'yaml'
-
-/** Kubernetes set-based label selector expression */
-interface LabelSelectorRequirement {
-  key: string
-  operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'
-  values?: string[]
-}
-
-/**
- * Build a kubectl-compatible label selector string from matchLabels and matchExpressions.
- * Supports both equality-based (matchLabels) and set-based (matchExpressions) selectors.
- *
- * kubectl -l format:
- *   matchLabels:      "key=value"
- *   In:               "key in (val1,val2)"
- *   NotIn:            "key notin (val1,val2)"
- *   Exists:           "key"
- *   DoesNotExist:     "!key"
- */
-function buildLabelSelector(
-  matchLabels?: Record<string, unknown>,
-  matchExpressions?: LabelSelectorRequirement[],
-): string {
-  const parts: string[] = []
-
-  // Equality-based selectors from matchLabels
-  if (matchLabels) {
-    for (const [k, v] of Object.entries(matchLabels)) {
-      parts.push(`${k}=${v}`)
-    }
-  }
-
-  // Set-based selectors from matchExpressions
-  if (matchExpressions) {
-    for (const expr of matchExpressions) {
-      const values = (expr.values || []).join(',')
-      switch (expr.operator) {
-        case 'In':
-          parts.push(`${expr.key} in (${values})`)
-          break
-        case 'NotIn':
-          parts.push(`${expr.key} notin (${values})`)
-          break
-        case 'Exists':
-          parts.push(expr.key)
-          break
-        case 'DoesNotExist':
-          parts.push(`!${expr.key}`)
-          break
-      }
-    }
-  }
-
-  return parts.join(',')
-}
+import { MAX_SCALE_REPLICAS, POD_STATUS_CONFIG } from './deployment-drilldown/types'
+import { classifyScaleError, buildLabelSelector } from './deployment-drilldown/helpers'
+import type { TabType, Props } from './deployment-drilldown/types'
 
 function DeploymentDrillDownContent({ data }: Props) {
   const { t } = useTranslation()

--- a/web/src/components/drilldown/views/cluster-drilldown/ClusterResourceTree.tsx
+++ b/web/src/components/drilldown/views/cluster-drilldown/ClusterResourceTree.tsx
@@ -1,0 +1,433 @@
+import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, HardDrive, Search, AlertTriangle, XCircle } from 'lucide-react'
+import { StatusBadge } from '../../../ui/StatusBadge'
+import { StatusIndicator } from '../../../charts/StatusIndicator'
+import { NamespaceResources } from '../../../clusters/components'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../../../lib/cn'
+import type { NodeInfo, NamespaceStats, ClusterHealth, Service, PodIssue, Deployment, PVC } from '../../../../hooks/useMCP'
+import type { TreeLens } from './types'
+
+export interface ClusterResourceTreeProps {
+  effectiveClusterName: string
+  clusterDisplayName: string
+  health: ClusterHealth | null | undefined
+  filteredNodes: NodeInfo[]
+  filteredNamespaces: string[]
+  filteredNamespaceStats: NamespaceStats[]
+  unhealthyDeployments: Deployment[]
+  filteredServices: Service[]
+  filteredPVCs: PVC[]
+  namespaceResources: {
+    podIssueCounts: Record<string, number>
+    deploymentIssueCounts: Record<string, number>
+  }
+  issueCounts: {
+    nodes: number
+    deployments: number
+    pods: number
+    pvcs: number
+    total: number
+  }
+  hasVisibleResourceData: boolean
+  activeLens: TreeLens
+  setActiveLens: (lens: TreeLens) => void
+  searchFilter: string
+  setSearchFilter: (filter: string) => void
+  expandedSections: Set<string>
+  toggleSection: (section: string) => void
+  podIssues: PodIssue[]
+  drillToNode: (cluster: string, node: string, data?: Record<string, unknown>) => void
+  drillToNamespace: (cluster: string, namespace: string) => void
+  drillToPod: (cluster: string, namespace: string, pod: string, data?: Record<string, unknown>) => void
+}
+
+export function ClusterResourceTree({
+  effectiveClusterName,
+  clusterDisplayName,
+  health,
+  filteredNodes,
+  filteredNamespaces,
+  filteredNamespaceStats,
+  unhealthyDeployments,
+  filteredServices,
+  filteredPVCs,
+  namespaceResources,
+  issueCounts,
+  hasVisibleResourceData,
+  activeLens,
+  setActiveLens,
+  searchFilter,
+  setSearchFilter,
+  expandedSections,
+  toggleSection,
+  podIssues,
+  drillToNode,
+  drillToNamespace,
+  drillToPod,
+}: ClusterResourceTreeProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-4">
+      {/* Search and Filters */}
+      <div className="flex flex-col md:flex-row gap-3">
+        {/* Search */}
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
+          <input
+            type="text"
+            value={searchFilter}
+            onChange={(e) => setSearchFilter(e.target.value)}
+            placeholder={t('common.searchResources')}
+            className="w-full pl-10 pr-4 py-2 bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500/50"
+          />
+        </div>
+
+        {/* Lens/View Buttons */}
+        <div className="flex flex-wrap gap-2">
+          {[
+            { id: 'all' as TreeLens, label: 'All', icon: Layers },
+            { id: 'issues' as TreeLens, label: 'Issues', icon: AlertTriangle, count: issueCounts.total },
+            { id: 'nodes' as TreeLens, label: 'Nodes', icon: Server, count: filteredNodes.length },
+            { id: 'workloads' as TreeLens, label: 'Workloads', icon: Box, count: filteredNamespaceStats.length },
+            { id: 'storage' as TreeLens, label: 'Storage', icon: HardDrive, count: filteredPVCs.length },
+            { id: 'network' as TreeLens, label: 'Network', icon: Network, count: filteredServices.length },
+          ].map(lens => (
+            <button
+              key={lens.id}
+              onClick={() => setActiveLens(lens.id)}
+              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs rounded-lg border transition-colors ${
+                activeLens === lens.id
+                  ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
+                  : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              <lens.icon className="w-3.5 h-3.5" />
+              {lens.label}
+              {lens.count !== undefined && lens.count > 0 && (
+                <span className={cn(
+                  'ml-1 px-1.5 py-0.5 rounded-full text-2xs',
+                  lens.id === 'issues' ? 'bg-red-500/20 text-red-400' : 'bg-secondary text-muted-foreground'
+                )}>
+                  {lens.count}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Tree Content */}
+      <div className="bg-card/30 rounded-lg border border-border p-4">
+        <div className="relative">
+          {/* Cluster Header */}
+          <div
+            onClick={() => toggleSection('cluster')}
+            className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+          >
+            {expandedSections.has('cluster') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+            <Server className="w-4 h-4 text-cyan-400" />
+            <span className="font-medium text-foreground">{clusterDisplayName}</span>
+            <StatusIndicator status={
+              health?.reachable === false ? 'unreachable' :
+              (health?.nodeCount && health.nodeCount > 0)
+                ? (health.readyNodes === health.nodeCount ? 'healthy' : 'warning')
+                : (health?.healthy ? 'healthy' : 'error')
+            } />
+          </div>
+
+          {expandedSections.has('cluster') && (
+            <div className="ml-6 border-l-2 border-cyan-500/30 pl-4 mt-2 space-y-2">
+              {/* Nodes Branch */}
+              {(activeLens === 'all' || activeLens === 'nodes' || activeLens === 'issues') && filteredNodes.length > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('nodes')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('nodes') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <Server className="w-4 h-4 text-blue-400" />
+                    <span className="text-sm font-medium text-foreground">{t('common.nodes')}</span>
+                    <span className="text-xs text-muted-foreground">({filteredNodes.length})</span>
+                    {issueCounts.nodes > 0 && (
+                      <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
+                        {issueCounts.nodes} not ready
+                      </StatusBadge>
+                    )}
+                  </div>
+
+                  {expandedSections.has('nodes') && (
+                    <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
+                      {filteredNodes.slice(0, 20).map((node) => (
+                        <button
+                          key={node.name}
+                          onClick={() => drillToNode(effectiveClusterName, node.name, { status: node.status, roles: node.roles, unschedulable: node.unschedulable })}
+                          type="button"
+                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group w-full text-left bg-transparent border-none"
+                        >
+                          <div className={`w-2 h-2 rounded-full ${node.status === 'Ready' ? 'bg-green-400' : 'bg-red-400'}`} />
+                          <span className="text-sm text-foreground group-hover:text-primary transition-colors">{node.name}</span>
+                          <span className={`text-xs ${node.status === 'Ready' ? 'text-green-400' : 'text-red-400'}`}>
+                            {node.status}
+                          </span>
+                          {node.roles?.length > 0 && (
+                            <span className="text-xs text-muted-foreground">
+                              [{(node.roles || []).join(', ')}]
+                            </span>
+                          )}
+                          <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                        </button>
+                      ))}
+                      {filteredNodes.length > 20 && (
+                        <div className="text-xs text-muted-foreground p-2">
+                          +{filteredNodes.length - 20} more nodes...
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Namespaces Branch */}
+              {(activeLens === 'all' || activeLens === 'workloads') && filteredNamespaces.length > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('namespaces')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('namespaces') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <Database className="w-4 h-4 text-purple-400" />
+                    <span className="text-sm font-medium text-foreground">Namespaces</span>
+                    <span className="text-xs text-muted-foreground">({filteredNamespaces.length})</span>
+                  </div>
+
+                  {expandedSections.has('namespaces') && (
+                    <div className="ml-6 border-l-2 border-purple-500/30 pl-4 mt-1 space-y-1">
+                      {filteredNamespaceStats.slice(0, 15).map((namespaceStat, i) => {
+                        const ns = namespaceStat.name
+                        const nsKey = `ns-${ns}`
+                        const nsPodIssues = namespaceResources.podIssueCounts[ns] || 0
+                        const nsDeploymentIssues = namespaceResources.deploymentIssueCounts[ns] || 0
+                        const totalIssues = nsPodIssues + nsDeploymentIssues
+
+                        return (
+                          <div key={i}>
+                            <div
+                              onClick={() => toggleSection(nsKey)}
+                              className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                            >
+                              {expandedSections.has(nsKey) ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+                              <span className="text-sm text-foreground">{ns}</span>
+                              {namespaceStat.podCount > 0 && (
+                                <span className="text-xs text-muted-foreground">
+                                  {namespaceStat.runningPods}/{namespaceStat.podCount} pods
+                                </span>
+                              )}
+                              {namespaceStat.pendingPods > 0 && (
+                                <StatusBadge color="yellow" size="xs" rounded="full" className="ml-1">
+                                  {namespaceStat.pendingPods} pending
+                                </StatusBadge>
+                              )}
+                              {totalIssues > 0 && (
+                                <StatusBadge color="red" size="xs" rounded="full" className="ml-1">
+                                  {totalIssues}
+                                </StatusBadge>
+                              )}
+                            </div>
+
+                            {expandedSections.has(nsKey) && (
+                              <div className="ml-6 border-l-2 border-muted/30 pl-4 mt-1 space-y-2">
+                                <NamespaceResources clusterName={effectiveClusterName} namespace={ns} />
+                                <button
+                                  onClick={() => drillToNamespace(effectiveClusterName, ns)}
+                                  className="text-xs text-purple-400 hover:text-purple-300 p-1.5 transition-colors"
+                                >
+                                  View all in {ns} →
+                                </button>
+                              </div>
+                            )}
+                          </div>
+                        )
+                      })}
+                      {filteredNamespaces.length > 15 && (
+                        <div className="text-xs text-muted-foreground p-2">
+                          +{filteredNamespaces.length - 15} more namespaces...
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Deployments with Issues (when issues lens active) */}
+              {activeLens === 'issues' && issueCounts.deployments > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('deployment-issues')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('deployment-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <AlertTriangle className="w-4 h-4 text-orange-400" />
+                    <span className="text-sm font-medium text-foreground">Deployment Issues</span>
+                    <StatusBadge color="orange" size="xs" rounded="full">
+                      {issueCounts.deployments}
+                    </StatusBadge>
+                  </div>
+
+                  {expandedSections.has('deployment-issues') && (
+                    <div className="ml-6 border-l-2 border-orange-500/30 pl-4 mt-1 space-y-1">
+                      {unhealthyDeployments.map((dep, i) => (
+                        <div
+                          key={i}
+                          onClick={() => drillToNamespace(effectiveClusterName, dep.namespace)}
+                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                        >
+                          <XCircle className="w-3 h-3 text-orange-400" />
+                          <span className="text-sm text-foreground">{dep.name}</span>
+                          <span className="text-xs text-muted-foreground">{dep.namespace}</span>
+                          <span className="text-xs text-orange-400">{dep.readyReplicas}/{dep.replicas}</span>
+                          <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Pod Issues (when issues lens active) */}
+              {activeLens === 'issues' && issueCounts.pods > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('pod-issues')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('pod-issues') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <AlertTriangle className="w-4 h-4 text-red-400" />
+                    <span className="text-sm font-medium text-foreground">Pod Issues</span>
+                    <StatusBadge color="red" size="xs" rounded="full">
+                      {issueCounts.pods}
+                    </StatusBadge>
+                  </div>
+
+                  {expandedSections.has('pod-issues') && (
+                    <div className="ml-6 border-l-2 border-red-500/30 pl-4 mt-1 space-y-1">
+                      {podIssues.slice(0, 10).map((issue, i) => (
+                        <div
+                          key={i}
+                          onClick={() => drillToPod(effectiveClusterName, issue.namespace, issue.name, { ...issue })}
+                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                        >
+                          <XCircle className="w-3 h-3 text-red-400" />
+                          <span className="text-sm text-foreground">{issue.name}</span>
+                          <span className="text-xs text-muted-foreground">{issue.namespace}</span>
+                          <span className="text-xs text-red-400">{issue.status}</span>
+                          <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                        </div>
+                      ))}
+                      {podIssues.length > 10 && (
+                        <div className="text-xs text-muted-foreground p-2">
+                          +{podIssues.length - 10} more pod issues...
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Storage Resources */}
+              {(activeLens === 'storage' || (activeLens === 'all' && filteredPVCs.length > 0)) && filteredPVCs.length > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('storage')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('storage') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <HardDrive className="w-4 h-4 text-green-400" />
+                    <span className="text-sm font-medium text-foreground">{t('common.pvcs')}</span>
+                    <span className="text-xs text-muted-foreground">({filteredPVCs.length})</span>
+                    {issueCounts.pvcs > 0 && (
+                      <StatusBadge color="yellow" size="xs" rounded="full" className="ml-1">
+                        {issueCounts.pvcs} pending
+                      </StatusBadge>
+                    )}
+                  </div>
+
+                  {expandedSections.has('storage') && (
+                    <div className="ml-6 border-l-2 border-green-500/30 pl-4 mt-1 space-y-1">
+                      {filteredPVCs.slice(0, 10).map((pvc, i) => (
+                        <div
+                          key={i}
+                          onClick={() => drillToNamespace(effectiveClusterName, pvc.namespace)}
+                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                        >
+                          <div className={`w-2 h-2 rounded-full ${pvc.status === 'Bound' ? 'bg-green-400' : 'bg-yellow-400'}`} />
+                          <span className="text-sm text-foreground">{pvc.name}</span>
+                          <span className="text-xs text-muted-foreground">{pvc.namespace}</span>
+                          <span className={`text-xs ${pvc.status === 'Bound' ? 'text-green-400' : 'text-yellow-400'}`}>
+                            {pvc.status}
+                          </span>
+                          {pvc.capacity && <span className="text-xs text-muted-foreground">{pvc.capacity}</span>}
+                          <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                        </div>
+                      ))}
+                      {filteredPVCs.length > 10 && (
+                        <div className="text-xs text-muted-foreground p-2">
+                          +{filteredPVCs.length - 10} more PVCs...
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Network Resources */}
+              {activeLens === 'network' && filteredServices.length > 0 && (
+                <div>
+                  <div
+                    onClick={() => toggleSection('network')}
+                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer"
+                  >
+                    {expandedSections.has('network') ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
+                    <Network className="w-4 h-4 text-blue-400" />
+                    <span className="text-sm font-medium text-foreground">{t('common.services')}</span>
+                    <span className="text-xs text-muted-foreground">({filteredServices.length})</span>
+                  </div>
+
+                  {expandedSections.has('network') && (
+                    <div className="ml-6 border-l-2 border-blue-500/30 pl-4 mt-1 space-y-1">
+                      {filteredServices.slice(0, 15).map((svc, i) => (
+                        <div
+                          key={i}
+                          onClick={() => drillToNamespace(effectiveClusterName, svc.namespace)}
+                          className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+                        >
+                          <Network className="w-3 h-3 text-blue-400" />
+                          <span className="text-sm text-foreground">{svc.name}</span>
+                          <span className="text-xs text-muted-foreground">{svc.namespace}</span>
+                          <StatusBadge color="blue" size="xs">{svc.type}</StatusBadge>
+                          <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+                        </div>
+                      ))}
+                      {filteredServices.length > 15 && (
+                        <div className="text-xs text-muted-foreground p-2">
+                          +{filteredServices.length - 15} more services...
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+
+              {/* Empty state for filters */}
+              {!hasVisibleResourceData && (
+                <div className="text-center text-muted-foreground text-sm py-4">
+                  No resources match the current filter
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/cluster-drilldown/ClusterResourceTree.tsx
+++ b/web/src/components/drilldown/views/cluster-drilldown/ClusterResourceTree.tsx
@@ -2,6 +2,7 @@ import { ChevronRight, ChevronDown, Server, Box, Layers, Database, Network, Hard
 import { StatusBadge } from '../../../ui/StatusBadge'
 import { StatusIndicator } from '../../../charts/StatusIndicator'
 import { NamespaceResources } from '../../../clusters/components'
+import { Input } from '../../../ui/Input'
 import { useTranslation } from 'react-i18next'
 import { cn } from '../../../../lib/cn'
 import type { NodeInfo, NamespaceStats, ClusterHealth, Service, PodIssue, Deployment, PVC } from '../../../../hooks/useMCP'
@@ -74,12 +75,13 @@ export function ClusterResourceTree({
         {/* Search */}
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-          <input
+          <Input
             type="text"
             value={searchFilter}
             onChange={(e) => setSearchFilter(e.target.value)}
             placeholder={t('common.searchResources')}
-            className="w-full pl-10 pr-4 py-2 bg-secondary rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500/50"
+            className="pl-10"
+            leadingIcon={null}
           />
         </div>
 

--- a/web/src/components/drilldown/views/cluster-drilldown/index.ts
+++ b/web/src/components/drilldown/views/cluster-drilldown/index.ts
@@ -1,0 +1,3 @@
+export type { TreeLens, ClusterTab } from './types'
+export { ClusterResourceTree } from './ClusterResourceTree'
+export type { ClusterResourceTreeProps } from './ClusterResourceTree'

--- a/web/src/components/drilldown/views/cluster-drilldown/types.ts
+++ b/web/src/components/drilldown/views/cluster-drilldown/types.ts
@@ -1,0 +1,5 @@
+/** Lens/view filter options for the cluster resource tree */
+export type TreeLens = 'all' | 'issues' | 'nodes' | 'workloads' | 'storage' | 'network'
+
+/** Tab IDs for the ClusterDrillDown bottom section */
+export type ClusterTab = 'events' | 'resources'

--- a/web/src/components/drilldown/views/deployment-drilldown/helpers.ts
+++ b/web/src/components/drilldown/views/deployment-drilldown/helpers.ts
@@ -1,0 +1,91 @@
+/** Kubernetes set-based label selector expression */
+export interface LabelSelectorRequirement {
+  key: string
+  operator: 'In' | 'NotIn' | 'Exists' | 'DoesNotExist'
+  values?: string[]
+}
+
+/**
+ * Classify a raw kubectl scale error into a stable i18n key. The caller
+ * runs `t(...)` on the result. Returning a static key literal keeps the
+ * keys compatible with i18next-typescript strict typing (no runtime
+ * template literals inside t()).
+ *
+ * Issue 9284: previously we surfaced the full kubectl stderr, which exposed
+ * internal cluster details (namespaces, group-version-kind, resource versions)
+ * that aren't useful to end users.
+ */
+export type ScaleErrorKey =
+  | 'drilldown.scale.failedGeneric'
+  | 'drilldown.scale.failedForbidden'
+  | 'drilldown.scale.failedNotFound'
+  | 'drilldown.scale.failedInvalid'
+  | 'drilldown.scale.failedConflict'
+  | 'drilldown.scale.failedTimeout'
+
+export function classifyScaleError(raw: string): ScaleErrorKey {
+  const lc = (raw || '').toLowerCase()
+  if (!raw) return 'drilldown.scale.failedGeneric'
+  if (lc.includes('forbidden') || lc.includes('cannot patch') || lc.includes('unauthorized')) {
+    return 'drilldown.scale.failedForbidden'
+  }
+  if (lc.includes('not found') || lc.includes('notfound')) {
+    return 'drilldown.scale.failedNotFound'
+  }
+  if (lc.includes('invalid') || lc.includes('must be') || lc.includes('out of range')) {
+    return 'drilldown.scale.failedInvalid'
+  }
+  if (lc.includes('conflict') || lc.includes('modified')) {
+    return 'drilldown.scale.failedConflict'
+  }
+  if (lc.includes('timeout') || lc.includes('timed out') || lc.includes('deadline')) {
+    return 'drilldown.scale.failedTimeout'
+  }
+  return 'drilldown.scale.failedGeneric'
+}
+
+/**
+ * Build a kubectl-compatible label selector string from matchLabels and matchExpressions.
+ * Supports both equality-based (matchLabels) and set-based (matchExpressions) selectors.
+ *
+ * kubectl -l format:
+ *   matchLabels:      "key=value"
+ *   In:               "key in (val1,val2)"
+ *   NotIn:            "key notin (val1,val2)"
+ *   Exists:           "key"
+ *   DoesNotExist:     "!key"
+ */
+export function buildLabelSelector(
+  matchLabels?: Record<string, unknown>,
+  matchExpressions?: LabelSelectorRequirement[],
+): string {
+  const parts: string[] = []
+
+  if (matchLabels) {
+    for (const [k, v] of Object.entries(matchLabels)) {
+      parts.push(`${k}=${v}`)
+    }
+  }
+
+  if (matchExpressions) {
+    for (const expr of matchExpressions) {
+      const values = (expr.values || []).join(',')
+      switch (expr.operator) {
+        case 'In':
+          parts.push(`${expr.key} in (${values})`)
+          break
+        case 'NotIn':
+          parts.push(`${expr.key} notin (${values})`)
+          break
+        case 'Exists':
+          parts.push(expr.key)
+          break
+        case 'DoesNotExist':
+          parts.push(`!${expr.key}`)
+          break
+      }
+    }
+  }
+
+  return parts.join(',')
+}

--- a/web/src/components/drilldown/views/deployment-drilldown/index.ts
+++ b/web/src/components/drilldown/views/deployment-drilldown/index.ts
@@ -1,0 +1,4 @@
+export type { TabType, Props } from './types'
+export { MAX_SCALE_REPLICAS, POD_STATUS_CONFIG } from './types'
+export type { LabelSelectorRequirement, ScaleErrorKey } from './helpers'
+export { classifyScaleError, buildLabelSelector } from './helpers'

--- a/web/src/components/drilldown/views/deployment-drilldown/types.ts
+++ b/web/src/components/drilldown/views/deployment-drilldown/types.ts
@@ -1,0 +1,19 @@
+export type TabType = 'overview' | 'pods' | 'events' | 'describe' | 'yaml'
+
+export interface Props {
+  data: Record<string, unknown>
+}
+
+/** Maximum replicas allowed via the UI scale widget. Kubernetes itself supports
+ *  up to 2^31-1 but most real deployments won't exceed a few hundred. */
+export const MAX_SCALE_REPLICAS = 100
+
+/** Pod status styling configuration */
+export const POD_STATUS_CONFIG: Record<string, { bg: string; text: string }> = {
+  Running: { bg: 'bg-green-500/20', text: 'text-green-400' },
+  Pending: { bg: 'bg-yellow-500/20', text: 'text-yellow-400' },
+  Failed: { bg: 'bg-red-500/20', text: 'text-red-400' },
+  CrashLoopBackOff: { bg: 'bg-red-500/20', text: 'text-red-400' },
+  ImagePullBackOff: { bg: 'bg-red-500/20', text: 'text-red-400' },
+  Unknown: { bg: 'bg-red-500/20', text: 'text-red-400' },
+}


### PR DESCRIPTION
Fixes #21383

Refactors the two largest drill-down view files by extracting sub-components, helpers, and types into co-located files following the existing pod-drilldown/ pattern.

**ClusterDrillDown.tsx** (1003 to 661 lines, -34%): Extract ClusterResourceTree component to cluster-drilldown/ subdir; move TreeLens and ClusterTab types to cluster-drilldown/types.ts.

**DeploymentDrillDown.tsx** (901 to 789 lines, -12%): Extract buildLabelSelector and classifyScaleError to deployment-drilldown/helpers.ts; move TabType, Props, MAX_SCALE_REPLICAS, POD_STATUS_CONFIG to deployment-drilldown/types.ts.

Part of #21375.