### PR TITLE
🐛 [scanner] fix: coverage suite test failure

### DIFF
--- a/web/src/pages/WhiteLabel.test.tsx
+++ b/web/src/pages/WhiteLabel.test.tsx
@@ -45,7 +45,7 @@ function getCopyButtonForStep(stepTitle: string) {
     throw new Error(`Missing card for step: ${stepTitle}`)
   }
 
-  return within(card as HTMLElement).getByRole('button', { name: 'Copy commands' })
+  return within(card as HTMLElement).getByRole('button', { name: 'whiteLabel.copyCommands' })
 }
 
 describe('WhiteLabel', () => {


### PR DESCRIPTION
Fixes #21397

## Root Cause

PR #21387 changed `WhiteLabel.tsx`'s copy button from:
```tsx
aria-label="Copy commands"
```
to:
```tsx
aria-label={t('whiteLabel.copyCommands')}
```

The global `react-i18next` mock in `src/test/setup.ts` returns the translation key as-is (e.g. `t('whiteLabel.copyCommands')` → `'whiteLabel.copyCommands'`). The test helper `getCopyButtonForStep` still looked for `{ name: 'Copy commands' }`, so `getByRole` couldn't find the button and the test threw.

## Fix

Update `getCopyButtonForStep` in `WhiteLabel.test.tsx` to look for the key that the test mock actually returns (`'whiteLabel.copyCommands'`), matching the component's current aria-label in the test environment.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>