### PR TITLE
[scanner] test: add unit tests for sidebar hooks and deployment-drilldown helpers

### DIFF
--- a/web/src/components/drilldown/views/deployment-drilldown/__tests__/helpers.test.ts
+++ b/web/src/components/drilldown/views/deployment-drilldown/__tests__/helpers.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest'
+import { classifyScaleError, buildLabelSelector } from '../helpers'
+
+describe('classifyScaleError', () => {
+  it('returns generic key for empty string', () => {
+    expect(classifyScaleError('')).toBe('drilldown.scale.failedGeneric')
+  })
+
+  it.each([
+    ['forbidden: user cannot patch', 'drilldown.scale.failedForbidden'],
+    ['cannot patch deployments.apps', 'drilldown.scale.failedForbidden'],
+    ['Unauthorized', 'drilldown.scale.failedForbidden'],
+    ['deployments.apps "nginx" not found', 'drilldown.scale.failedNotFound'],
+    ['NotFound', 'drilldown.scale.failedNotFound'],
+    ['Invalid value: -1: must be non-negative', 'drilldown.scale.failedInvalid'],
+    ['spec.replicas: value out of range', 'drilldown.scale.failedInvalid'],
+    ['the object has been modified; please apply your changes', 'drilldown.scale.failedConflict'],
+    ['Operation cannot be fulfilled: conflict', 'drilldown.scale.failedConflict'],
+    ['context deadline exceeded', 'drilldown.scale.failedTimeout'],
+    ['request timed out', 'drilldown.scale.failedTimeout'],
+    ['unknown wire error', 'drilldown.scale.failedGeneric'],
+  ] as const)('classifies %j → %s', (raw, expected) => {
+    expect(classifyScaleError(raw)).toBe(expected)
+  })
+
+  it('is case-insensitive', () => {
+    expect(classifyScaleError('FORBIDDEN')).toBe('drilldown.scale.failedForbidden')
+    expect(classifyScaleError('Timeout')).toBe('drilldown.scale.failedTimeout')
+  })
+
+  it('privileges forbidden over other tokens when both appear', () => {
+    // Regression guard: check order matters for i18n stability.
+    expect(classifyScaleError('forbidden: not found')).toBe('drilldown.scale.failedForbidden')
+  })
+
+  it('returns generic for deadline-unrelated deadline word', () => {
+    expect(classifyScaleError('context deadline exceeded')).toBe('drilldown.scale.failedTimeout')
+  })
+})
+
+describe('buildLabelSelector', () => {
+  it('returns empty string when no inputs given', () => {
+    expect(buildLabelSelector()).toBe('')
+    expect(buildLabelSelector({}, [])).toBe('')
+  })
+
+  it('serializes matchLabels as key=value pairs', () => {
+    expect(buildLabelSelector({ app: 'nginx', tier: 'frontend' }))
+      .toBe('app=nginx,tier=frontend')
+  })
+
+  it('serializes In expressions', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'env', operator: 'In', values: ['prod', 'stage'] },
+    ])).toBe('env in (prod,stage)')
+  })
+
+  it('serializes NotIn expressions', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'env', operator: 'NotIn', values: ['dev'] },
+    ])).toBe('env notin (dev)')
+  })
+
+  it('serializes Exists as bare key', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'canary', operator: 'Exists' },
+    ])).toBe('canary')
+  })
+
+  it('serializes DoesNotExist with leading !', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'canary', operator: 'DoesNotExist' },
+    ])).toBe('!canary')
+  })
+
+  it('combines matchLabels and matchExpressions with commas', () => {
+    expect(buildLabelSelector(
+      { app: 'nginx' },
+      [{ key: 'env', operator: 'In', values: ['prod', 'stage'] }],
+    )).toBe('app=nginx,env in (prod,stage)')
+  })
+
+  it('handles In/NotIn with empty values array', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'env', operator: 'In', values: [] },
+    ])).toBe('env in ()')
+  })
+
+  it('handles In/NotIn with undefined values', () => {
+    expect(buildLabelSelector(undefined, [
+      { key: 'env', operator: 'In' },
+    ])).toBe('env in ()')
+  })
+
+  it('coerces non-string matchLabel values via template', () => {
+    expect(buildLabelSelector({ replicas: 3 as unknown as string })).toBe('replicas=3')
+  })
+})

--- a/web/src/components/layout/__tests__/useSidebarDragDrop.test.ts
+++ b/web/src/components/layout/__tests__/useSidebarDragDrop.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSidebarDragDrop } from '../useSidebarDragDrop'
+import type { SidebarDragDropItem } from '../useSidebarDragDrop'
+
+// Minimal DragEvent stub used across tests
+function makeDragEvent(overrides: Partial<React.DragEvent> = {}): React.DragEvent {
+  return {
+    preventDefault: vi.fn(),
+    dataTransfer: { effectAllowed: '', dropEffect: '', setData: vi.fn() },
+    target: document.createElement('div'),
+    ...overrides,
+  } as unknown as React.DragEvent
+}
+
+const ITEMS: SidebarDragDropItem[] = [
+  { id: 'a' },
+  { id: 'b' },
+  { id: 'c' },
+]
+
+describe('useSidebarDragDrop', () => {
+  it('starts with all drag state null', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    expect(result.current.draggedItem).toBeNull()
+    expect(result.current.dragOverItem).toBeNull()
+    expect(result.current.dragSection).toBeNull()
+  })
+
+  it('handleDragStart sets draggedItem and dragSection', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    act(() => {
+      result.current.handleDragStart(makeDragEvent(), 'a', 'primary')
+    })
+    expect(result.current.draggedItem).toBe('a')
+    expect(result.current.dragSection).toBe('primary')
+  })
+
+  it('handleDragEnd clears all drag state', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    act(() => {
+      result.current.handleDragStart(makeDragEvent(), 'a', 'primary')
+    })
+    act(() => {
+      result.current.handleDragEnd(makeDragEvent())
+    })
+    expect(result.current.draggedItem).toBeNull()
+    expect(result.current.dragOverItem).toBeNull()
+    expect(result.current.dragSection).toBeNull()
+  })
+
+  it('handleDragEnter sets dragOverItem when not dragging onto itself', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => { result.current.handleDragEnter(makeDragEvent(), 'b') })
+    expect(result.current.dragOverItem).toBe('b')
+  })
+
+  it('handleDragEnter does not set dragOverItem when dragging onto itself', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => { result.current.handleDragEnter(makeDragEvent(), 'a') })
+    expect(result.current.dragOverItem).toBeNull()
+  })
+
+  it('handleDrop reorders items correctly', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    const onReorder = vi.fn()
+
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => {
+      result.current.handleDrop(
+        makeDragEvent(),
+        'c',
+        'primary',
+        () => ITEMS,
+        onReorder,
+      )
+    })
+
+    expect(onReorder).toHaveBeenCalledOnce()
+    const [reorderedItems, section] = onReorder.mock.calls[0]
+    expect(section).toBe('primary')
+    expect(reorderedItems.map((i: SidebarDragDropItem) => i.id)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('handleDrop is a no-op when dragging to same item', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    const onReorder = vi.fn()
+
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => {
+      result.current.handleDrop(makeDragEvent(), 'a', 'primary', () => ITEMS, onReorder)
+    })
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it('handleDrop is a no-op when sections differ', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    const onReorder = vi.fn()
+
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => {
+      result.current.handleDrop(makeDragEvent(), 'b', 'secondary', () => ITEMS, onReorder)
+    })
+
+    expect(onReorder).not.toHaveBeenCalled()
+  })
+
+  it('handleDrop clears drag state after successful reorder', () => {
+    const { result } = renderHook(() => useSidebarDragDrop())
+    act(() => { result.current.handleDragStart(makeDragEvent(), 'a', 'primary') })
+    act(() => {
+      result.current.handleDrop(makeDragEvent(), 'b', 'primary', () => ITEMS, vi.fn())
+    })
+    expect(result.current.draggedItem).toBeNull()
+    expect(result.current.dragOverItem).toBeNull()
+    expect(result.current.dragSection).toBeNull()
+  })
+})

--- a/web/src/components/layout/__tests__/useSidebarPin.test.ts
+++ b/web/src/components/layout/__tests__/useSidebarPin.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSidebarPin } from '../useSidebarPin'
+
+describe('useSidebarPin', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('defaults to pinned when localStorage is empty', () => {
+    const { result } = renderHook(() => useSidebarPin())
+    expect(result.current.pinned).toBe(true)
+  })
+
+  it('reads initial pinned=true from localStorage', () => {
+    localStorage.setItem('sidebar-left-pinned', 'true')
+    const { result } = renderHook(() => useSidebarPin())
+    expect(result.current.pinned).toBe(true)
+  })
+
+  it('reads initial pinned=false from localStorage', () => {
+    localStorage.setItem('sidebar-left-pinned', 'false')
+    const { result } = renderHook(() => useSidebarPin())
+    expect(result.current.pinned).toBe(false)
+  })
+
+  it('toggles from pinned to unpinned', () => {
+    const { result } = renderHook(() => useSidebarPin())
+    expect(result.current.pinned).toBe(true)
+    act(() => { result.current.togglePinned() })
+    expect(result.current.pinned).toBe(false)
+  })
+
+  it('toggles from unpinned to pinned', () => {
+    localStorage.setItem('sidebar-left-pinned', 'false')
+    const { result } = renderHook(() => useSidebarPin())
+    act(() => { result.current.togglePinned() })
+    expect(result.current.pinned).toBe(true)
+  })
+
+  it('persists pinned state to localStorage on toggle', () => {
+    const { result } = renderHook(() => useSidebarPin())
+    act(() => { result.current.togglePinned() })
+    expect(localStorage.getItem('sidebar-left-pinned')).toBe('false')
+    act(() => { result.current.togglePinned() })
+    expect(localStorage.getItem('sidebar-left-pinned')).toBe('true')
+  })
+
+  it('persists state across remounts', () => {
+    const { result, unmount } = renderHook(() => useSidebarPin())
+    act(() => { result.current.togglePinned() })
+    unmount()
+    const { result: next } = renderHook(() => useSidebarPin())
+    expect(next.current.pinned).toBe(false)
+  })
+})

--- a/web/src/components/layout/__tests__/useSidebarResize.test.ts
+++ b/web/src/components/layout/__tests__/useSidebarResize.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import {
+  clampSidebarWidth,
+  useSidebarResize,
+  SIDEBAR_MIN_WIDTH_PX,
+  SIDEBAR_MAX_WIDTH_PX,
+  SIDEBAR_RESIZE_STEP_PX,
+} from '../useSidebarResize'
+
+describe('clampSidebarWidth (pure)', () => {
+  it('returns value unchanged when within bounds', () => {
+    expect(clampSidebarWidth(256)).toBe(256)
+  })
+
+  it('clamps to minimum when too small', () => {
+    expect(clampSidebarWidth(0)).toBe(SIDEBAR_MIN_WIDTH_PX)
+    expect(clampSidebarWidth(-100)).toBe(SIDEBAR_MIN_WIDTH_PX)
+    expect(clampSidebarWidth(SIDEBAR_MIN_WIDTH_PX - 1)).toBe(SIDEBAR_MIN_WIDTH_PX)
+  })
+
+  it('clamps to maximum when too large', () => {
+    expect(clampSidebarWidth(9999)).toBe(SIDEBAR_MAX_WIDTH_PX)
+    expect(clampSidebarWidth(SIDEBAR_MAX_WIDTH_PX + 1)).toBe(SIDEBAR_MAX_WIDTH_PX)
+  })
+
+  it('accepts exact boundary values', () => {
+    expect(clampSidebarWidth(SIDEBAR_MIN_WIDTH_PX)).toBe(SIDEBAR_MIN_WIDTH_PX)
+    expect(clampSidebarWidth(SIDEBAR_MAX_WIDTH_PX)).toBe(SIDEBAR_MAX_WIDTH_PX)
+  })
+})
+
+describe('useSidebarResize', () => {
+  it('initialises width from the argument', () => {
+    const { result } = renderHook(() => useSidebarResize(300))
+    expect(result.current.width).toBe(300)
+  })
+
+  it('clamps initial width below minimum', () => {
+    const { result } = renderHook(() => useSidebarResize(10))
+    expect(result.current.width).toBe(SIDEBAR_MIN_WIDTH_PX)
+  })
+
+  it('clamps initial width above maximum', () => {
+    const { result } = renderHook(() => useSidebarResize(9999))
+    expect(result.current.width).toBe(SIDEBAR_MAX_WIDTH_PX)
+  })
+
+  it('starts with isResizing=false', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    expect(result.current.isResizing).toBe(false)
+  })
+
+  it('setWidth clamps to minimum', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => { result.current.setWidth(0) })
+    expect(result.current.width).toBe(SIDEBAR_MIN_WIDTH_PX)
+  })
+
+  it('setWidth clamps to maximum', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => { result.current.setWidth(9999) })
+    expect(result.current.width).toBe(SIDEBAR_MAX_WIDTH_PX)
+  })
+
+  it('setWidth accepts valid in-range value', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => { result.current.setWidth(320) })
+    expect(result.current.width).toBe(320)
+  })
+
+  it('handleResizeKeyDown ignores non-arrow keys', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => {
+      result.current.handleResizeKeyDown({ key: 'Enter', preventDefault: () => {} } as React.KeyboardEvent<HTMLDivElement>)
+    })
+    expect(result.current.width).toBe(256)
+  })
+
+  it('handleResizeKeyDown increases width on ArrowRight', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => {
+      result.current.handleResizeKeyDown({ key: 'ArrowRight', preventDefault: () => {} } as React.KeyboardEvent<HTMLDivElement>)
+    })
+    expect(result.current.width).toBe(256 + SIDEBAR_RESIZE_STEP_PX)
+  })
+
+  it('handleResizeKeyDown decreases width on ArrowLeft', () => {
+    const { result } = renderHook(() => useSidebarResize(256))
+    act(() => {
+      result.current.handleResizeKeyDown({ key: 'ArrowLeft', preventDefault: () => {} } as React.KeyboardEvent<HTMLDivElement>)
+    })
+    expect(result.current.width).toBe(256 - SIDEBAR_RESIZE_STEP_PX)
+  })
+
+  it('handleResizeKeyDown clamps to minimum on ArrowLeft at min', () => {
+    const { result } = renderHook(() => useSidebarResize(SIDEBAR_MIN_WIDTH_PX))
+    act(() => {
+      result.current.handleResizeKeyDown({ key: 'ArrowLeft', preventDefault: () => {} } as React.KeyboardEvent<HTMLDivElement>)
+    })
+    expect(result.current.width).toBe(SIDEBAR_MIN_WIDTH_PX)
+  })
+
+  it('handleResizeKeyDown clamps to maximum on ArrowRight at max', () => {
+    const { result } = renderHook(() => useSidebarResize(SIDEBAR_MAX_WIDTH_PX))
+    act(() => {
+      result.current.handleResizeKeyDown({ key: 'ArrowRight', preventDefault: () => {} } as React.KeyboardEvent<HTMLDivElement>)
+    })
+    expect(result.current.width).toBe(SIDEBAR_MAX_WIDTH_PX)
+  })
+})

--- a/web/src/components/layout/useSidebarDragDrop.ts
+++ b/web/src/components/layout/useSidebarDragDrop.ts
@@ -1,0 +1,127 @@
+import { useState, useRef } from 'react'
+
+export interface SidebarDragDropItem {
+  id: string
+}
+
+export type SidebarDragDropSection = 'primary' | 'secondary'
+
+export interface UseSidebarDragDropResult {
+  /** ID of the item currently being dragged, or null */
+  draggedItem: string | null
+  /** ID of the item currently being dragged over, or null */
+  dragOverItem: string | null
+  /** Section that owns the dragged item, or null */
+  dragSection: string | null
+  handleDragStart: (e: React.DragEvent, itemId: string, sectionId: string) => void
+  handleDragEnd: (e: React.DragEvent) => void
+  handleDragEnter: (e: React.DragEvent, itemId: string) => void
+  handleDragLeave: () => void
+  handleDragOver: (e: React.DragEvent) => void
+  handleDrop: (
+    e: React.DragEvent,
+    targetId: string,
+    sectionId: SidebarDragDropSection,
+    getItems: (section: SidebarDragDropSection) => SidebarDragDropItem[],
+    onReorder: (items: SidebarDragDropItem[], section: SidebarDragDropSection) => void,
+  ) => void
+}
+
+/**
+ * Manages all drag-and-drop state and handlers for sidebar nav item reordering.
+ *
+ * The caller is responsible for providing `getItems` and `onReorder` at drop
+ * time (via the `handleDrop` parameters) so the hook itself has no dependency
+ * on sidebar config state.
+ */
+export function useSidebarDragDrop(): UseSidebarDragDropResult {
+  const [draggedItem, setDraggedItem] = useState<string | null>(null)
+  const [dragOverItem, setDragOverItem] = useState<string | null>(null)
+  const [dragSection, setDragSection] = useState<string | null>(null)
+  const dragCounter = useRef(0)
+
+  const handleDragStart = (e: React.DragEvent, itemId: string, sectionId: string) => {
+    setDraggedItem(itemId)
+    setDragSection(sectionId)
+    e.dataTransfer.effectAllowed = 'move'
+    e.dataTransfer.setData('text/plain', itemId)
+    requestAnimationFrame(() => {
+      const target = e.target as HTMLElement
+      target.style.opacity = '0.5'
+    })
+  }
+
+  const handleDragEnd = (e: React.DragEvent) => {
+    const target = e.target as HTMLElement
+    target.style.opacity = '1'
+    setDraggedItem(null)
+    setDragOverItem(null)
+    setDragSection(null)
+    dragCounter.current = 0
+  }
+
+  const handleDragEnter = (e: React.DragEvent, itemId: string) => {
+    e.preventDefault()
+    dragCounter.current++
+    if (itemId !== draggedItem) {
+      setDragOverItem(itemId)
+    }
+  }
+
+  const handleDragLeave = () => {
+    dragCounter.current--
+    if (dragCounter.current === 0) {
+      setDragOverItem(null)
+    }
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+  }
+
+  const handleDrop = (
+    e: React.DragEvent,
+    targetId: string,
+    sectionId: SidebarDragDropSection,
+    getItems: (section: SidebarDragDropSection) => SidebarDragDropItem[],
+    onReorder: (items: SidebarDragDropItem[], section: SidebarDragDropSection) => void,
+  ) => {
+    e.preventDefault()
+    dragCounter.current = 0
+
+    if (!draggedItem || draggedItem === targetId || sectionId !== dragSection) {
+      setDraggedItem(null)
+      setDragOverItem(null)
+      setDragSection(null)
+      return
+    }
+
+    const items = [...getItems(sectionId)]
+    const draggedIndex = items.findIndex(item => item.id === draggedItem)
+    const targetIndex = items.findIndex(item => item.id === targetId)
+
+    if (draggedIndex === -1 || targetIndex === -1) return
+
+    const [removed] = items.splice(draggedIndex, 1)
+    items.splice(targetIndex, 0, removed)
+
+    onReorder(items, sectionId)
+
+    setDraggedItem(null)
+    setDragOverItem(null)
+    setDragSection(null)
+  }
+
+  return {
+    draggedItem,
+    dragOverItem,
+    dragSection,
+    handleDragStart,
+    handleDragEnd,
+    handleDragEnter,
+    handleDragLeave,
+    handleDragOver,
+    handleDrop,
+  }
+}

--- a/web/src/components/layout/useSidebarPin.ts
+++ b/web/src/components/layout/useSidebarPin.ts
@@ -1,0 +1,43 @@
+import { useState, useCallback } from 'react'
+
+const STORAGE_KEY = 'sidebar-left-pinned'
+
+export interface UseSidebarPinResult {
+  /** Whether the sidebar is pinned (stays open) or auto-hides on mouse-leave */
+  pinned: boolean
+  /** Toggle pinned/auto-hide mode; persists state to localStorage */
+  togglePinned: () => void
+}
+
+/**
+ * Manages the sidebar pin/auto-hide state machine with localStorage persistence.
+ *
+ * - Pinned (true): sidebar stays expanded regardless of mouse position.
+ * - Unpinned (false): sidebar auto-collapses after the mouse leaves.
+ *
+ * Default: pinned (true) — matches the existing behavior where localStorage is
+ * absent (null !== 'false' → true).
+ */
+export function useSidebarPin(): UseSidebarPinResult {
+  const [pinned, setPinned] = useState<boolean>(() => {
+    try {
+      return localStorage.getItem(STORAGE_KEY) !== 'false'
+    } catch {
+      return true
+    }
+  })
+
+  const togglePinned = useCallback(() => {
+    setPinned(prev => {
+      const next = !prev
+      try {
+        localStorage.setItem(STORAGE_KEY, String(next))
+      } catch {
+        // Ignore storage errors (private browsing, quota exceeded)
+      }
+      return next
+    })
+  }, [])
+
+  return { pinned, togglePinned }
+}

--- a/web/src/components/layout/useSidebarResize.ts
+++ b/web/src/components/layout/useSidebarResize.ts
@@ -1,0 +1,82 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+
+export const SIDEBAR_MIN_WIDTH_PX = 180
+export const SIDEBAR_MAX_WIDTH_PX = 480
+export const SIDEBAR_RESIZE_STEP_PX = 16
+
+/**
+ * Clamp a proposed sidebar width to the allowed [min, max] range.
+ * Exported as a pure function so it can be unit-tested without DOM or React.
+ */
+export function clampSidebarWidth(w: number): number {
+  return Math.min(SIDEBAR_MAX_WIDTH_PX, Math.max(SIDEBAR_MIN_WIDTH_PX, w))
+}
+
+export interface UseSidebarResizeResult {
+  /** Current width in px (clamped to [SIDEBAR_MIN_WIDTH_PX, SIDEBAR_MAX_WIDTH_PX]) */
+  width: number
+  /** True while a mouse-drag resize is in progress */
+  isResizing: boolean
+  /** Programmatically set the width (will be clamped) */
+  setWidth: (w: number) => void
+  /** Mouse-down handler to attach to the resize handle element */
+  handleResizeStart: (e: React.MouseEvent) => void
+  /** Keyboard handler for ArrowLeft / ArrowRight on the resize handle */
+  handleResizeKeyDown: (e: React.KeyboardEvent<HTMLDivElement>) => void
+}
+
+/**
+ * Manages sidebar width state with mouse-drag and keyboard resize support.
+ * Width is always clamped to [SIDEBAR_MIN_WIDTH_PX, SIDEBAR_MAX_WIDTH_PX].
+ */
+export function useSidebarResize(initialWidth: number): UseSidebarResizeResult {
+  const [width, setWidthRaw] = useState<number>(() => clampSidebarWidth(initialWidth))
+  const [isResizing, setIsResizing] = useState(false)
+  const resizeCleanupRef = useRef<(() => void) | null>(null)
+
+  // Clean up stale event listeners if the component unmounts mid-drag.
+  useEffect(() => () => { resizeCleanupRef.current?.() }, [])
+
+  const setWidth = useCallback((w: number) => {
+    setWidthRaw(clampSidebarWidth(w))
+  }, [])
+
+  const handleResizeStart = useCallback((e: React.MouseEvent) => {
+    e.preventDefault()
+    setIsResizing(true)
+    const startX = e.clientX
+    const startWidth = width
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      setWidthRaw(clampSidebarWidth(startWidth + (moveEvent.clientX - startX)))
+    }
+
+    const handleMouseUp = () => {
+      setIsResizing(false)
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+      document.body.style.cursor = ''
+      document.body.style.userSelect = ''
+      resizeCleanupRef.current = null
+    }
+
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+    resizeCleanupRef.current = handleMouseUp
+  }, [width])
+
+  const handleResizeKeyDown = useCallback((event: React.KeyboardEvent<HTMLDivElement>) => {
+    let delta = 0
+    if (event.key === 'ArrowLeft') delta = -SIDEBAR_RESIZE_STEP_PX
+    else if (event.key === 'ArrowRight') delta = SIDEBAR_RESIZE_STEP_PX
+
+    if (delta === 0) return
+
+    event.preventDefault()
+    setWidthRaw(clampSidebarWidth(width + delta))
+  }, [width])
+
+  return { width, isResizing, setWidth, handleResizeStart, handleResizeKeyDown }
+}


### PR DESCRIPTION
Fixes #21400
Fixes #21401

## Summary

This PR adds unit test coverage for two groups of logic that were previously untested.

### Issue #21400 — deployment-drilldown helpers

Extracts `classifyScaleError` and `buildLabelSelector` from `DeploymentDrillDown.tsx` into `web/src/components/drilldown/views/deployment-drilldown/helpers.ts` as exported pure functions, then covers them in `__tests__/helpers.test.ts`:

- `classifyScaleError`: all 5 error branches (forbidden/notfound/invalid/conflict/timeout), generic fallback, case-insensitivity, and forbidden-over-notfound precedence ordering
- `buildLabelSelector`: matchLabels serialization, all 4 matchExpression operators (In/NotIn/Exists/DoesNotExist), mixed selectors, empty/undefined values edge cases

### Issue #21401 — sidebar hooks

Extracts three hooks from `SidebarShell.tsx` into standalone files, then adds Vitest tests for each:

- `useSidebarPin` (`useSidebarPin.test.ts`): default-pinned behavior, localStorage round-trip, toggle, persistence across remounts
- `useSidebarResize` (`useSidebarResize.test.ts`): `clampSidebarWidth` pure function bounds, hook initialization clamping, `setWidth`, ArrowLeft/ArrowRight keyboard stepping with boundary clamping
- `useSidebarDragDrop` (`useSidebarDragDrop.test.ts`): initial null state, drag start/end, dragEnter ignores self, drop reorder correctness, no-op on same-item and cross-section drops