### PR TITLE
🌱 [scanner] refactor: split oversized ClusterDetailModal (partial #21375)

### DIFF
--- a/web/src/components/clusters/ClusterAIActions.tsx
+++ b/web/src/components/clusters/ClusterAIActions.tsx
@@ -1,0 +1,62 @@
+import { Bot, Stethoscope, Wrench, Wand2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
+import { Button } from '../ui/Button'
+
+interface ClusterAIActionsProps {
+  isUnreachable: boolean
+  podIssuesCount: number
+  deploymentIssuesCount: number
+  onDiagnose: () => void
+  onRepair: () => void
+  onAsk: () => void
+}
+
+export function ClusterAIActions({ isUnreachable, podIssuesCount, deploymentIssuesCount, onDiagnose, onRepair, onAsk }: ClusterAIActionsProps) {
+  const { t } = useTranslation()
+  const totalIssues = podIssuesCount + deploymentIssuesCount
+
+  return (
+    <div className="mb-6 p-4 rounded-lg bg-linear-to-r from-purple-500/10 to-blue-500/10 border border-purple-500/20">
+      <div className="flex items-center gap-2 mb-3">
+        <Bot className="w-5 h-5 text-purple-400" />
+        <span className="text-sm font-medium text-foreground">{t('clusterDetail.aiAssistant')}</span>
+      </div>
+      <div className="flex flex-wrap gap-2">
+        <button
+          onClick={onDiagnose}
+          disabled={isUnreachable}
+          className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title={t('clusterDetail.diagnoseTitle')}
+        >
+          <Stethoscope className="w-3.5 h-3.5" />
+          {t('clusterDetail.diagnose')}
+        </button>
+        <button
+          onClick={onRepair}
+          disabled={isUnreachable || totalIssues === 0}
+          className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-400 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          title={totalIssues === 0 ? t('clusterDetail.noIssuesToRepair') : t('clusterDetail.repairTitle')}
+        >
+          <Wrench className="w-3.5 h-3.5" />
+          {t('clusterDetail.repair')}
+          {totalIssues > 0 && (
+            <StatusBadge color="red" size="xs">
+              {totalIssues}
+            </StatusBadge>
+          )}
+        </button>
+        <Button
+          variant="accent"
+          size="sm"
+          onClick={onAsk}
+          disabled={isUnreachable}
+          icon={<Wand2 className="w-3.5 h-3.5" />}
+          title={t('clusterDetail.askTitle')}
+        >
+          {t('clusterDetail.ask')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useRef, useEffect } from 'react'
-import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronRight, ChevronDown, Layers, Server, Network, HardDrive, Box, FolderOpen, Loader2, Cpu, MemoryStick, Database, Wand2, Stethoscope, Wrench, Bot, ExternalLink } from 'lucide-react'
+import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronDown, Layers, Server, Network, HardDrive, FolderOpen, Loader2, Cpu, MemoryStick, Database, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
-import { isClusterUnreachable, isClusterHealthy } from './utils'
+import { isClusterUnreachable, isClusterHealthy, getProviderInfo, type ClusterDetailCloudProvider } from './utils'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useMissions } from '../../hooks/useMissions'
 import { emitClusterAction } from '../../lib/analytics'
@@ -20,32 +20,13 @@ import { sanitizeUrl } from '../../lib/utils/sanitizeUrl'
 import { ClusterStatusDetails } from './ClusterStatusDetails'
 import { formatMemoryPromptStat } from '../../lib/formatStats'
 import { buildDiagnosePrompt, buildRepairPrompt } from './diagnosePrompt'
-
-// Cloud provider types
-type CloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
+import { ClusterAIActions } from './ClusterAIActions'
+import { ClusterIssuesList } from './ClusterIssuesList'
 
 // Maximum time to wait for initial data before forcing modal to show content (10 seconds)
 // Prevents indefinite loading when cluster is slow or unreachable
 const MAX_INITIAL_LOADING_MS = 10_000
 const MAX_HEADER_ALIASES = 2
-
-function getProviderInfo(provider: CloudProvider): { color: string; bgColor: string } {
-  switch (provider) {
-    case 'eks': return { color: 'text-orange-400', bgColor: 'bg-orange-500/20' }
-    case 'gke': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
-    case 'aks': return { color: 'text-cyan-400', bgColor: 'bg-cyan-500/20' }
-    case 'openshift': return { color: 'text-red-400', bgColor: 'bg-red-500/20' }
-    case 'oci': return { color: 'text-red-500', bgColor: 'bg-red-500/20' }
-    case 'alibaba': return { color: 'text-orange-300', bgColor: 'bg-orange-500/20' }
-    case 'digitalocean': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
-    case 'rancher': return { color: 'text-green-400', bgColor: 'bg-green-500/20' }
-    case 'coreweave': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
-    case 'kind': return { color: 'text-blue-300', bgColor: 'bg-blue-500/20' }
-    case 'minikube': return { color: 'text-purple-400', bgColor: 'bg-purple-500/20' }
-    case 'k3s': return { color: 'text-green-300', bgColor: 'bg-green-500/20' }
-    default: return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
-  }
-}
 
 interface ClusterDetailModalProps {
   clusterName: string
@@ -278,7 +259,7 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
                 detectCloudProviderShared(clusterName, serverUrl, clusterInfo?.namespaces, clusterUser)
               // Get console URL based on detected provider
               const consoleUrl = getConsoleUrl(detectedProvider, clusterName, serverUrl)
-              const providerInfo = getProviderInfo(detectedProvider === 'kubernetes' ? 'unknown' : detectedProvider as CloudProvider)
+              const providerInfo = getProviderInfo(detectedProvider === 'kubernetes' ? 'unknown' : detectedProvider as ClusterDetailCloudProvider)
               const providerLabel = getProviderLabel(detectedProvider)
               return (
                 <>
@@ -378,58 +359,25 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
         )}
 
         {/* AI Actions */}
-        <div className="mb-6 p-4 rounded-lg bg-linear-to-r from-purple-500/10 to-blue-500/10 border border-purple-500/20">
-          <div className="flex items-center gap-2 mb-3">
-            <Bot className="w-5 h-5 text-purple-400" />
-            <span className="text-sm font-medium text-foreground">{t('clusterDetail.aiAssistant')}</span>
-          </div>
-          <div className="flex flex-wrap gap-2">
-            <button
-              onClick={handleDiagnose}
-              disabled={isUnreachable}
-              className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg bg-blue-500/20 hover:bg-blue-500/30 text-blue-400 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              title={t('clusterDetail.diagnoseTitle')}
-            >
-              <Stethoscope className="w-3.5 h-3.5" />
-              {t('clusterDetail.diagnose')}
-            </button>
-            <button
-              onClick={handleRepair}
-              disabled={isUnreachable || (podIssues.length === 0 && clusterDeploymentIssues.length === 0)}
-              className="flex items-center gap-1.5 px-2 py-1.5 rounded-lg bg-red-500/20 hover:bg-red-500/30 text-red-400 text-xs font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-              title={podIssues.length === 0 && clusterDeploymentIssues.length === 0 ? t('clusterDetail.noIssuesToRepair') : t('clusterDetail.repairTitle')}
-            >
-              <Wrench className="w-3.5 h-3.5" />
-              {t('clusterDetail.repair')}
-              {(podIssues.length > 0 || clusterDeploymentIssues.length > 0) && (
-                <StatusBadge color="red" size="xs">
-                  {podIssues.length + clusterDeploymentIssues.length}
-                </StatusBadge>
-              )}
-            </button>
-            <Button
-              variant="accent"
-              size="sm"
-              onClick={() => {
-                emitClusterAction('ask', clusterName)
-                onClose() // Close modal so mission sidebar is visible
-                startMission({
-                  title: `Ask about ${clusterName.split('/').pop()}`,
-                  description: 'Custom question about the cluster',
-                  type: 'custom',
-                  cluster: clusterName,
-                  initialPrompt: `I have a question about Kubernetes cluster "${clusterName}". The cluster currently has ${health?.nodeCount || 0} nodes, ${health?.podCount || 0} pods, ${health?.cpuCores || 0} CPU cores, and ${promptMemorySummary} memory. How can I help you?`,
-                  context: { clusterName, health }
-                })
-              }}
-              disabled={isUnreachable}
-              icon={<Wand2 className="w-3.5 h-3.5" />}
-              title={t('clusterDetail.askTitle')}
-            >
-              {t('clusterDetail.ask')}
-            </Button>
-          </div>
-        </div>
+        <ClusterAIActions
+          isUnreachable={isUnreachable}
+          podIssuesCount={podIssues.length}
+          deploymentIssuesCount={clusterDeploymentIssues.length}
+          onDiagnose={handleDiagnose}
+          onRepair={handleRepair}
+          onAsk={() => {
+            emitClusterAction('ask', clusterName)
+            onClose()
+            startMission({
+              title: `Ask about ${clusterName.split('/').pop()}`,
+              description: 'Custom question about the cluster',
+              type: 'custom',
+              cluster: clusterName,
+              initialPrompt: `I have a question about Kubernetes cluster "${clusterName}". The cluster currently has ${health?.nodeCount || 0} nodes, ${health?.podCount || 0} pods, ${health?.cpuCores || 0} CPU cores, and ${promptMemorySummary} memory. How can I help you?`,
+              context: { clusterName, health }
+            })
+          }}
+        />
 
         {/* Stats - Interactive Cards */}
         <div className="grid grid-cols-3 gap-4 mb-6">
@@ -691,76 +639,14 @@ export function ClusterDetailModal({ clusterName, clusterUser, onClose, onRename
         )}
 
         {/* Issues Section */}
-        {(podIssues.length > 0 || clusterDeploymentIssues.length > 0) && (
-          <div className="mb-6">
-            <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
-              <AlertTriangle className="w-4 h-4 text-red-400" />
-              {t('clusterDetail.issuesCount', { count: podIssues.length + clusterDeploymentIssues.length })}
-            </h3>
-            <div className="space-y-2">
-              {podIssues.slice(0, 5).map((issue, i) => (
-                <div
-                  key={`pod-${i}`}
-                  onClick={() => {
-                    drillToPod(clusterName, issue.namespace, issue.name, {
-                      status: issue.status,
-                      restarts: issue.restarts,
-                      issues: issue.issues,
-                      reason: issue.reason })
-                    onClose()
-                  }}
-                  className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 flex-1 min-w-0">
-                      <StatusBadge color="blue" size="xs" icon={<Box className="w-3 h-3" />} className="shrink-0">{t('clusterDetail.pod')}</StatusBadge>
-                      <span className="font-medium text-foreground truncate">{issue.name}</span>
-                      <span className="text-xs text-muted-foreground shrink-0">({issue.namespace})</span>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0 ml-2">
-                      <StatusBadge color="red" size="xs">{issue.status}</StatusBadge>
-                      <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                    </div>
-                  </div>
-                  {issue.restarts > 0 && (
-                    <div className="mt-1 text-xs text-muted-foreground pl-14">{t('clusterDetail.restarts', { count: issue.restarts })}</div>
-                  )}
-                </div>
-              ))}
-              {clusterDeploymentIssues.slice(0, 3).map((issue, i) => (
-                <div
-                  key={`dep-${i}`}
-                  onClick={() => {
-                    drillToDeployment(clusterName, issue.namespace, issue.name, {
-                      replicas: issue.replicas,
-                      readyReplicas: issue.readyReplicas,
-                      reason: issue.reason,
-                      message: issue.message })
-                    onClose()
-                  }}
-                  className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2 flex-1 min-w-0">
-                      <StatusBadge color="purple" size="xs" icon={<Layers className="w-3 h-3" />} className="shrink-0">{t('clusterDetail.deploy')}</StatusBadge>
-                      <span className="font-medium text-foreground truncate">{issue.name}</span>
-                      <span className="text-xs text-muted-foreground shrink-0">({issue.namespace})</span>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0 ml-2">
-                      <StatusBadge color="red" size="xs">
-                        {issue.readyReplicas}/{issue.replicas} ready
-                      </StatusBadge>
-                      <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                    </div>
-                  </div>
-                  {issue.message && (
-                    <div className="mt-1 text-xs text-red-400 pl-16 truncate">{issue.message}</div>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
-        )}
+        <ClusterIssuesList
+          podIssues={podIssues}
+          deploymentIssues={clusterDeploymentIssues}
+          clusterName={clusterName}
+          onDrillToPod={drillToPod}
+          onDrillToDeployment={drillToDeployment}
+          onClose={onClose}
+        />
 
         {/* GPU Section */}
         {stableClusterGPUs.length > 0 && (

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useRef, useEffect } from 'react'
-import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronDown, Layers, Server, Network, HardDrive, FolderOpen, Loader2, Cpu, MemoryStick, Database, ExternalLink } from 'lucide-react'
+import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronDown, ChevronRight, Layers, Server, Network, HardDrive, FolderOpen, Loader2, Cpu, MemoryStick, Database, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
 import { useClusterHealth, usePodIssues, useDeploymentIssues, useGPUNodes, useNodes, useNamespaceStats, useDeployments, useClusters } from '../../hooks/useMCP'
 import { isClusterUnreachable, isClusterHealthy, getProviderInfo, type ClusterDetailCloudProvider } from './utils'

--- a/web/src/components/clusters/ClusterDetailModal.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useRef, useEffect } from 'react'
 import { X, CheckCircle, AlertTriangle, WifiOff, Pencil, Trash2, ChevronDown, ChevronRight, Layers, Server, Network, HardDrive, FolderOpen, Loader2, Cpu, MemoryStick, Database, ExternalLink } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'

--- a/web/src/components/clusters/ClusterIssuesList.tsx
+++ b/web/src/components/clusters/ClusterIssuesList.tsx
@@ -1,0 +1,90 @@
+import { AlertTriangle, ChevronRight, Box, Layers } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../ui/StatusBadge'
+import type { PodIssue, DeploymentIssue } from '../../hooks/mcp/types.workloads'
+
+interface ClusterIssuesListProps {
+  podIssues: PodIssue[]
+  deploymentIssues: DeploymentIssue[]
+  clusterName: string
+  onDrillToPod: (cluster: string, namespace: string, name: string, data?: Record<string, unknown>) => void
+  onDrillToDeployment: (cluster: string, namespace: string, name: string, data?: Record<string, unknown>) => void
+  onClose: () => void
+}
+
+export function ClusterIssuesList({ podIssues, deploymentIssues, clusterName, onDrillToPod, onDrillToDeployment, onClose }: ClusterIssuesListProps) {
+  const { t } = useTranslation()
+  const totalCount = podIssues.length + deploymentIssues.length
+  if (totalCount === 0) return null
+
+  return (
+    <div className="mb-6">
+      <h3 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
+        <AlertTriangle className="w-4 h-4 text-red-400" />
+        {t('clusterDetail.issuesCount', { count: totalCount })}
+      </h3>
+      <div className="space-y-2">
+        {podIssues.slice(0, 5).map((issue, i) => (
+          <div
+            key={`pod-${i}`}
+            onClick={() => {
+              onDrillToPod(clusterName, issue.namespace, issue.name, {
+                status: issue.status,
+                restarts: issue.restarts,
+                issues: issue.issues,
+                reason: issue.reason })
+              onClose()
+            }}
+            className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                <StatusBadge color="blue" size="xs" icon={<Box className="w-3 h-3" />} className="shrink-0">{t('clusterDetail.pod')}</StatusBadge>
+                <span className="font-medium text-foreground truncate">{issue.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0">({issue.namespace})</span>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-2">
+                <StatusBadge color="red" size="xs">{issue.status}</StatusBadge>
+                <ChevronRight className="w-4 h-4 text-muted-foreground" />
+              </div>
+            </div>
+            {issue.restarts > 0 && (
+              <div className="mt-1 text-xs text-muted-foreground pl-14">{t('clusterDetail.restarts', { count: issue.restarts })}</div>
+            )}
+          </div>
+        ))}
+        {deploymentIssues.slice(0, 3).map((issue, i) => (
+          <div
+            key={`dep-${i}`}
+            onClick={() => {
+              onDrillToDeployment(clusterName, issue.namespace, issue.name, {
+                replicas: issue.replicas,
+                readyReplicas: issue.readyReplicas,
+                reason: issue.reason,
+                message: issue.message })
+              onClose()
+            }}
+            className="p-3 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2 flex-1 min-w-0">
+                <StatusBadge color="purple" size="xs" icon={<Layers className="w-3 h-3" />} className="shrink-0">{t('clusterDetail.deploy')}</StatusBadge>
+                <span className="font-medium text-foreground truncate">{issue.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0">({issue.namespace})</span>
+              </div>
+              <div className="flex items-center gap-2 shrink-0 ml-2">
+                <StatusBadge color="red" size="xs">
+                  {issue.readyReplicas}/{issue.replicas} ready
+                </StatusBadge>
+                <ChevronRight className="w-4 h-4 text-muted-foreground" />
+              </div>
+            </div>
+            {issue.message && (
+              <div className="mt-1 text-xs text-red-400 pl-16 truncate">{issue.message}</div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/clusters/utils.ts
+++ b/web/src/components/clusters/utils.ts
@@ -208,3 +208,24 @@ export function loadClusterCards(): ClusterCard[] {
 export function saveClusterCards(cards: ClusterCard[]): void {
   safeSetItem(CLUSTERS_CARDS_KEY, JSON.stringify(cards))
 }
+
+// Cloud provider display type (excludes 'kubernetes' which maps to 'unknown' at call sites)
+export type ClusterDetailCloudProvider = 'eks' | 'gke' | 'aks' | 'openshift' | 'oci' | 'alibaba' | 'digitalocean' | 'rancher' | 'coreweave' | 'kind' | 'minikube' | 'k3s' | 'unknown'
+
+export function getProviderInfo(provider: ClusterDetailCloudProvider): { color: string; bgColor: string } {
+  switch (provider) {
+    case 'eks': return { color: 'text-orange-400', bgColor: 'bg-orange-500/20' }
+    case 'gke': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
+    case 'aks': return { color: 'text-cyan-400', bgColor: 'bg-cyan-500/20' }
+    case 'openshift': return { color: 'text-red-400', bgColor: 'bg-red-500/20' }
+    case 'oci': return { color: 'text-red-500', bgColor: 'bg-red-500/20' }
+    case 'alibaba': return { color: 'text-orange-300', bgColor: 'bg-orange-500/20' }
+    case 'digitalocean': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
+    case 'rancher': return { color: 'text-green-400', bgColor: 'bg-green-500/20' }
+    case 'coreweave': return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
+    case 'kind': return { color: 'text-blue-300', bgColor: 'bg-blue-500/20' }
+    case 'minikube': return { color: 'text-purple-400', bgColor: 'bg-purple-500/20' }
+    case 'k3s': return { color: 'text-green-300', bgColor: 'bg-green-500/20' }
+    default: return { color: 'text-blue-400', bgColor: 'bg-blue-500/20' }
+  }
+}


### PR DESCRIPTION
Fixes #21375

Partial refactor of `ClusterDetailModal.tsx` (943 → 829 LOC) by extracting two sub-components and moving a utility function:

### Changes
- **`ClusterAIActions.tsx`** (new) — extracted the AI assistant panel (Diagnose / Repair / Ask buttons) from `ClusterDetailModal`
- **`ClusterIssuesList.tsx`** (new) — extracted the pod/deployment issues list section
- **`utils.ts`** — moved `getProviderInfo()` helper and `ClusterDetailCloudProvider` type from `ClusterDetailModal` into the shared cluster utilities module
- **`ClusterDetailModal.tsx`** — updated to import and use the new components; removed extracted code

This is a focused, surgical PR addressing the largest easily-splittable file from the auto-QA report. Further files in the 500–930 LOC range can be addressed in follow-up PRs.