### PR TITLE
🐛 [scanner] fix: repair registerHooks demo-hook tests after split refactor (fixes #21408)

### DIFF
--- a/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
@@ -136,7 +136,7 @@ vi.mock('../../../hooks/useMCS', () => ({
 const FAST_DELAY_MS = 10
 
 /** Speed up demo data timer for tests */
-vi.mock('../../constants/network', async (importOriginal) => {
+vi.mock('@/lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -148,7 +148,7 @@ vi.mock('../../../hooks/useMCS', () => ({
   useServiceImports: (...a: unknown[]) => mockUseServiceImports(...a),
 }))
 
-vi.mock('../../constants/network', async (importOriginal) => {
+vi.mock('@/lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,


### PR DESCRIPTION
Fixes #21408

## Problem

After PR #21404 split registerHooks.ts and moved useDemoDataHook to registerHooks/demoSupport.ts, 27 tests in registerHooks-coverage.test.ts and 1 in registerHooks-hooks.test.ts started failing. The failures covered demo hooks returning data when demo mode is ON.

## Root Cause

The relative mock path `../../constants/network` in tests no longer applies correctly to imports from the new demoSupport.ts module. Vitest resolves mock paths per-module, so after the refactor the SHORT_DELAY_MS mock wasn't being applied to the demoSupport module's import.

## Solution

Use the @ alias absolute path `@/lib/constants/network` to ensure the SHORT_DELAY_MS mock applies to all modules importing from constants/network, regardless of their relative location.

## Testing

CI will validate the tests now pass.