### PR TITLE
🐛 [scanner] fix: repair 27 registerHooks demo-hook test failures

### DIFF
--- a/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-coverage.test.ts
@@ -136,7 +136,7 @@ vi.mock('../../../hooks/useMCS', () => ({
 const FAST_DELAY_MS = 10
 
 /** Speed up demo data timer for tests */
-vi.mock('../../constants/network', async (importOriginal) => {
+vi.mock('@/lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,
@@ -167,7 +167,11 @@ function getHook(name: string): HookFn {
 
 beforeEach(() => {
   vi.clearAllMocks()
-  vi.useFakeTimers()
+  // Fake setTimeout/setInterval/Date but NOT queueMicrotask — Vitest 4 fakes
+  // queueMicrotask by default, which prevents the demo-mode-OFF isLoading
+  // transition from firing (useDemoDataHook uses queueMicrotask to clear
+  // isLoading when demo mode is off).
+  vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] })
   mockUseDemoMode.mockReturnValue({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() })
 })
 

--- a/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
+++ b/web/src/lib/unified/__tests__/registerHooks-hooks.test.ts
@@ -148,7 +148,7 @@ vi.mock('../../../hooks/useMCS', () => ({
   useServiceImports: (...a: unknown[]) => mockUseServiceImports(...a),
 }))
 
-vi.mock('../../constants/network', async (importOriginal) => {
+vi.mock('@/lib/constants/network', async (importOriginal) => {
   const actual = await importOriginal() as Record<string, unknown>
   return {
     ...actual,


### PR DESCRIPTION
Fixes #21418

Repairs demo-hook and lifecycle tests broken by the registerHooks split refactor (follow-up to #21410).

## Root cause

PR #21404 split `registerHooks.ts` and moved `useDemoDataHook` to `registerHooks/demoSupport.ts`. This introduced two issues:

**1. Broken `SHORT_DELAY_MS` mock (14 coverage + 1 hooks failures)**

The test files used `vi.mock('../../constants/network', ...)` (relative path). In Vitest 4.x, this mock is not applied to transitive imports from the deeper `registerHooks/demoSupport.ts` module, even though both paths resolve to the same absolute file. Using the `@` alias (`'@/lib/constants/network'`) makes Vitest resolve the mock unambiguously regardless of import depth.

Without this fix, `SHORT_DELAY_MS` remained 500ms in the hook, so tests that advance fake timers by 10–20ms never saw the timer fire.

**2. `queueMicrotask` faked by default in Vitest 4.x (12 coverage failures)**

Vitest 4.x fakes `queueMicrotask` by default when `vi.useFakeTimers()` is called without explicit `toFake` options. `useDemoDataHook` uses `queueMicrotask` to clear `isLoading` when demo mode is off, so the 12 demo-mode-OFF tests asserting `isLoading === false` were stuck in loading state.

Passing an explicit `toFake` list to `vi.useFakeTimers()` in the global `beforeEach` of the coverage test excludes `queueMicrotask`, letting it run as a real microtask.

## Changes

- `registerHooks-coverage.test.ts`: `@/lib/constants/network` alias + explicit `toFake` list
- `registerHooks-hooks.test.ts`: `@/lib/constants/network` alias only (inline fake timer tests are not affected by the global setup issue)