### PR TITLE
🐛 [scanner] fix: resolve failing tests in Coverage Suite #4390

### DIFF
--- a/web/src/components/clusters/__tests__/ClusterDetailModal.test.tsx
+++ b/web/src/components/clusters/__tests__/ClusterDetailModal.test.tsx
@@ -52,6 +52,7 @@ vi.mock('../../../hooks/useMCP', () => ({
 vi.mock('../utils', () => ({
   isClusterUnreachable: () => false,
   isClusterHealthy: () => true,
+  getProviderInfo: () => ({ color: 'text-blue-400', bgColor: 'bg-blue-500/20' }),
 }))
 
 vi.mock('../../../hooks/useDrillDown', () => ({

--- a/web/src/lib/unified/registerHooks/demoSupport.ts
+++ b/web/src/lib/unified/registerHooks/demoSupport.ts
@@ -39,10 +39,10 @@ export {
 
 export function useDemoDataHook<T>(demoData: T[]) {
   const { isDemoMode: demoMode } = useDemoMode()
-  // Lazy-initialise so demo-OFF mode starts with isLoading=false immediately —
-  // no async microtask required, which keeps synchronous act() wrappers happy
-  // in tests and avoids a visible loading flash in the UI for non-demo users.
-  const [isLoading, setIsLoading] = useState(() => !!demoMode)
+  // Initialise directly from demoMode so demo-OFF mode starts with isLoading=false
+  // immediately — no async microtask required, which keeps synchronous act() wrappers
+  // happy in tests and avoids a visible loading flash in the UI for non-demo users.
+  const [isLoading, setIsLoading] = useState(demoMode)
 
   useEffect(() => {
     if (!demoMode) {

--- a/web/src/lib/unified/registerHooks/demoSupport.ts
+++ b/web/src/lib/unified/registerHooks/demoSupport.ts
@@ -4,7 +4,7 @@
 
 import { useEffect, useState } from 'react'
 import { useDemoMode } from '../../../hooks/useDemoMode'
-import { SHORT_DELAY_MS } from '../../constants/network'
+import { SHORT_DELAY_MS } from '@/lib/constants/network'
 import { MS_PER_SECOND, MS_PER_MINUTE, MS_PER_HOUR, MS_PER_DAY } from '../../constants/time'
 
 const THIRTY_SECONDS_MS = 30 * MS_PER_SECOND
@@ -39,14 +39,17 @@ export {
 
 export function useDemoDataHook<T>(demoData: T[]) {
   const { isDemoMode: demoMode } = useDemoMode()
-  const [isLoading, setIsLoading] = useState(true)
+  // Lazy-initialise so demo-OFF mode starts with isLoading=false immediately —
+  // no async microtask required, which keeps synchronous act() wrappers happy
+  // in tests and avoids a visible loading flash in the UI for non-demo users.
+  const [isLoading, setIsLoading] = useState(() => !!demoMode)
 
   useEffect(() => {
     if (!demoMode) {
-      queueMicrotask(() => setIsLoading(false))
+      setIsLoading(false)
       return
     }
-    queueMicrotask(() => setIsLoading(true))
+    setIsLoading(true)
     const timer = setTimeout(() => setIsLoading(false), SHORT_DELAY_MS)
     return () => clearTimeout(timer)
   }, [demoMode])


### PR DESCRIPTION
Fixes #21424

## Summary

Two root causes addressed for the 29 failing tests in Coverage Suite run #4390:

### 1. `demoSupport.ts` — replace `queueMicrotask` with lazy `useState` init

`useDemoDataHook` initialised `isLoading=true` unconditionally and used `queueMicrotask` to clear it when demo mode is OFF. Synchronous `act()` wrappers in Vitest do not flush externally-queued microtasks, so 12 demo-mode-OFF tests and the transition test all saw `isLoading===true` and failed.

- **Fix**: lazy-initialise `useState(() => !!demoMode)` so demo-OFF mode starts with `isLoading=false` immediately — no async work required. Replace `queueMicrotask` calls with direct `setIsLoading()` calls that React's scheduler flushes inside synchronous `act()`.
- Also switch the `SHORT_DELAY_MS` import to the `@/` alias so `vi.mock("@/lib/constants/network")` is applied unambiguously to this transitive import in Vitest 4, fixing the 13 demo-mode-ON timer tests (Batch 4/5/6) where the unmocked 500 ms delay meant timers never fired within 11 ms advances.

### 2. `ClusterDetailModal.test.tsx` — add `getProviderInfo` to utils mock

PR #21406 moved `getProviderInfo` from `ClusterDetailModal.tsx` into `utils.ts` and updated the import. The test's `vi.mock("../utils")` factory was not updated, so `getProviderInfo` was `undefined` at render time, throwing a `TypeError` that prevented the component from mounting and caused both ClusterDetailModal header tests to fail.

- **Fix**: add `getProviderInfo: () => ({ color, bgColor })` to the mock.
