### PR TITLE
🌱 [quality] test: add unit tests for 3 untested Netlify proxy functions

### DIFF
--- a/web/e2e/compliance/card-loading-compliance.spec.ts
+++ b/web/e2e/compliance/card-loading-compliance.spec.ts
@@ -928,7 +928,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     }
   })
 
-  test('setup — mocks + warmup + manifest', async ({ page }, testInfo) => {
+  test('setup — mocks + warmup + manifest', async ({ page: _page }, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
 
     await setupAuth(sharedPage)
@@ -965,7 +965,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   // beyond the actual manifest size short-circuit (Playwright requires test
   // declarations at load time, so we can't size this dynamically).
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`cold — batch ${batchIdx + 1}`, async ({ page }, testInfo) => {
+    test(`cold — batch ${batchIdx + 1}`, async ({ page: _page }, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -978,7 +978,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('navigate away — between cold and warm phases', async ({ page }, testInfo) => {
+  test('navigate away — between cold and warm phases', async ({ page: _page }, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
     console.log('[Compliance] Phase 3: Navigate away')
@@ -987,7 +987,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
   })
 
   for (let batchIdx = 0; batchIdx < MAX_EXPECTED_BATCHES; batchIdx++) {
-    test(`warm — batch ${batchIdx + 1}`, async ({ page }, testInfo) => {
+    test(`warm — batch ${batchIdx + 1}`, async ({ page: _page }, testInfo) => {
       testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
       if (!complianceState.setupDone) {
         test.skip(true, 'setup did not complete')
@@ -1004,7 +1004,7 @@ test.describe('card loading compliance (per-batch split — Issue 9088)', () => 
     })
   }
 
-  test('aggregate report + cross-batch assertions', async ({ page }, testInfo) => {
+  test('aggregate report + cross-batch assertions', async ({ page: _page }, testInfo) => {
     testInfo.setTimeout(IS_CI ? PER_BATCH_TIMEOUT_MS * CI_TIMEOUT_MULTIPLIER : PER_BATCH_TIMEOUT_MS)
     if (!complianceState.setupDone) test.skip(true, 'setup did not complete')
 

--- a/web/netlify/functions/__tests__/gtag-proxy.test.ts
+++ b/web/netlify/functions/__tests__/gtag-proxy.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment node
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the GA4 gtag.js Netlify proxy.
+ *
+ * Verifies query-string forwarding, size caps (both content-length header
+ * and actual body length), upstream failure handling, and success headers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "../gtag-proxy.mts";
+
+const GTAG_BASE_URL = "https://www.googletagmanager.com/gtag/js";
+const MAX_RESPONSE_BYTES = 512_000;
+
+const mockFetch = vi.fn<typeof globalThis.fetch>();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function textResponse(body: string, init?: ResponseInit): Response {
+  return new Response(body, init);
+}
+
+describe("gtag-proxy", () => {
+  it("forwards query string to Google Tag Manager", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("gtag_body", { status: 200 }));
+    await handler(new Request("https://console.kubestellar.io/api/gtag?id=G-ABC123"));
+    expect(mockFetch).toHaveBeenCalledWith(
+      `${GTAG_BASE_URL}?id=G-ABC123`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+
+  it("passes an empty query string when none is present", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("gtag_body", { status: 200 }));
+    await handler(new Request("https://console.kubestellar.io/api/gtag"));
+    expect(mockFetch).toHaveBeenCalledWith(
+      GTAG_BASE_URL,
+      expect.any(Object),
+    );
+  });
+
+  it("forwards user-agent header from the incoming request", async () => {
+    mockFetch.mockResolvedValueOnce(textResponse("gtag_body", { status: 200 }));
+    await handler(
+      new Request("https://console.kubestellar.io/api/gtag", {
+        headers: { "user-agent": "Mozilla/5.0 test" },
+      }),
+    );
+    const call = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((call?.headers as Record<string, string>)["User-Agent"]).toBe("Mozilla/5.0 test");
+  });
+
+  it("forwards upstream non-200 status with empty body", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 429 }));
+    const res = await handler(new Request("https://console.kubestellar.io/api/gtag"));
+    expect(res.status).toBe(429);
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 502 when content-length header exceeds the cap", async () => {
+    mockFetch.mockResolvedValueOnce(
+      textResponse("small body", {
+        status: 200,
+        headers: { "content-length": String(MAX_RESPONSE_BYTES + 1) },
+      }),
+    );
+    const res = await handler(new Request("https://console.kubestellar.io/api/gtag"));
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("Upstream response too large");
+  });
+
+  it("returns 502 when the body itself exceeds the cap (no content-length header)", async () => {
+    const oversized = "x".repeat(MAX_RESPONSE_BYTES + 1);
+    mockFetch.mockResolvedValueOnce(textResponse(oversized, { status: 200 }));
+    const res = await handler(new Request("https://console.kubestellar.io/api/gtag"));
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("Upstream response too large");
+  });
+
+  it("returns 502 when fetch throws", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network boom"));
+    const res = await handler(new Request("https://console.kubestellar.io/api/gtag"));
+    expect(res.status).toBe(502);
+  });
+
+  it("happy path returns js content-type, cache header, and nosniff", async () => {
+    const body = "console.log('ok')";
+    mockFetch.mockResolvedValueOnce(textResponse(body, { status: 200 }));
+    const res = await handler(new Request("https://console.kubestellar.io/api/gtag?id=G-X"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/javascript; charset=utf-8");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await res.text()).toBe(body);
+  });
+});

--- a/web/netlify/functions/__tests__/umami-script.test.ts
+++ b/web/netlify/functions/__tests__/umami-script.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment node
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the Umami tracking-script Netlify proxy.
+ *
+ * Covers upstream success, upstream non-200 forwarding, oversized response
+ * → 413, generic fetch errors → 502, and correct response headers.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "../umami-script.mts";
+
+const UMAMI_URL = "https://analytics.kubestellar.io/ksc";
+const MAX_SCRIPT_BYTES = 1_048_576;
+
+const mockFetch = vi.fn<typeof globalThis.fetch>();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("umami-script", () => {
+  it("forwards user-agent header to upstream", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("script body", { status: 200 }));
+    await handler(
+      new Request("https://console.kubestellar.io/api/ksc", {
+        headers: { "user-agent": "CustomAgent/1.0" },
+      }),
+    );
+    expect(mockFetch).toHaveBeenCalledWith(
+      UMAMI_URL,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    const opts = mockFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    expect((opts?.headers as Record<string, string>)["User-Agent"]).toBe("CustomAgent/1.0");
+  });
+
+  it("forwards upstream non-OK status with empty body", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+    const res = await handler(new Request("https://console.kubestellar.io/api/ksc"));
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("");
+  });
+
+  it("returns 413 when upstream response exceeds the size cap", async () => {
+    const oversized = new Response("tiny actual body", {
+      status: 200,
+      headers: { "content-length": String(MAX_SCRIPT_BYTES + 1) },
+    });
+    mockFetch.mockResolvedValueOnce(oversized);
+    const res = await handler(new Request("https://console.kubestellar.io/api/ksc"));
+    expect(res.status).toBe(413);
+  });
+
+  it("returns 502 when fetch throws a non-size error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network boom"));
+    const res = await handler(new Request("https://console.kubestellar.io/api/ksc"));
+    expect(res.status).toBe(502);
+  });
+
+  it("happy path returns script with cache and nosniff headers", async () => {
+    const body = "(function(){/* umami */})()";
+    mockFetch.mockResolvedValueOnce(new Response(body, { status: 200 }));
+    const res = await handler(new Request("https://console.kubestellar.io/api/ksc"));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("application/javascript; charset=utf-8");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=3600");
+    expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+    expect(await res.text()).toBe(body);
+  });
+});

--- a/web/netlify/functions/__tests__/youtube-thumbnail.test.ts
+++ b/web/netlify/functions/__tests__/youtube-thumbnail.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+/**
+ * @vitest-environment node
+ *
+ * Unit tests for the YouTube thumbnail Netlify proxy.
+ *
+ * Mocks global fetch so every branch (input validation, upstream 404,
+ * placeholder-heuristic 404, size cap, network error, happy path) is
+ * exercised without touching img.youtube.com.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import handler from "../youtube-thumbnail.mts";
+
+const VALID_ID = "dQw4w9WgXcQ";
+const BASE = "https://console.kubestellar.io/api/youtube/thumbnail/";
+const DEFAULT_THUMBNAIL_MAX_BYTES = 1200;
+const MAX_THUMBNAIL_BYTES = 2_097_152;
+
+const mockFetch = vi.fn<typeof globalThis.fetch>();
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", mockFetch);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function makeReq(id: string): Request {
+  return new Request(`${BASE}${id}`);
+}
+
+function bufferResponse(bytes: number, status = 200): Response {
+  return new Response(new Uint8Array(bytes), { status });
+}
+
+describe("youtube-thumbnail — input validation", () => {
+  it.each([
+    ["empty id", ""],
+    ["too short (10 chars)", "aaaaaaaaaa"],
+    ["too long (12 chars)", "aaaaaaaaaaaa"],
+    ["invalid char '!'", "abcdefghij!"],
+    ["invalid char space", "abcdefghi j"],
+  ])("returns 400 for %s", async (_label, id) => {
+    const res = await handler(makeReq(id));
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("invalid video id");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts hyphen and underscore in id", async () => {
+    mockFetch.mockResolvedValueOnce(bufferResponse(DEFAULT_THUMBNAIL_MAX_BYTES + 100));
+    const res = await handler(makeReq("aa_-bb_-cc0"));
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("youtube-thumbnail — upstream results", () => {
+  it("forwards 404 when upstream returns non-OK", async () => {
+    mockFetch.mockResolvedValueOnce(new Response(null, { status: 404 }));
+    const res = await handler(makeReq(VALID_ID));
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("thumbnail not found");
+  });
+
+  it("returns 404 for the default placeholder (body below threshold)", async () => {
+    mockFetch.mockResolvedValueOnce(bufferResponse(DEFAULT_THUMBNAIL_MAX_BYTES - 1));
+    const res = await handler(makeReq(VALID_ID));
+    expect(res.status).toBe(404);
+    expect(await res.text()).toBe("video not found");
+  });
+
+  it("returns 413 when upstream body exceeds the size cap", async () => {
+    const oversized = new Response(new Uint8Array(64), {
+      status: 200,
+      // content-length header alone triggers the too-large guard in readCappedBuffer
+      headers: { "content-length": String(MAX_THUMBNAIL_BYTES + 1) },
+    });
+    mockFetch.mockResolvedValueOnce(oversized);
+    const res = await handler(makeReq(VALID_ID));
+    expect(res.status).toBe(413);
+    expect(await res.text()).toBe("thumbnail too large");
+  });
+
+  it("returns 502 when fetch throws a non-size error", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network boom"));
+    const res = await handler(makeReq(VALID_ID));
+    expect(res.status).toBe(502);
+    expect(await res.text()).toBe("failed to fetch thumbnail");
+  });
+
+  it("happy path returns image/jpeg with long cache header", async () => {
+    const size = DEFAULT_THUMBNAIL_MAX_BYTES + 500;
+    mockFetch.mockResolvedValueOnce(bufferResponse(size));
+    const res = await handler(makeReq(VALID_ID));
+    expect(res.status).toBe(200);
+    expect(res.headers.get("Content-Type")).toBe("image/jpeg");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=86400");
+    const body = new Uint8Array(await res.arrayBuffer());
+    expect(body.byteLength).toBe(size);
+    expect(mockFetch).toHaveBeenCalledWith(
+      `https://img.youtube.com/vi/${VALID_ID}/mqdefault.jpg`,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+  });
+});


### PR DESCRIPTION
Fixes #21431

## Test Improvement

Adds unit-test coverage for **3 previously untested Netlify Functions** in `web/netlify/functions/`:

| File | Tests | What's covered |
|---|---|---|
| `youtube-thumbnail.test.ts` | 9 | 5 input-validation cases (empty / too short / too long / invalid char / space), hyphen+underscore ID accepted, upstream 404, placeholder-heuristic 404 (body < 1200 bytes), size cap → 413, network error → 502, happy path returns `image/jpeg` with 24 h cache. |
| `gtag-proxy.test.ts` | 8 | Query string forwarded to `googletagmanager.com`, empty query works, `user-agent` header forwarded, upstream non-200 forwarded, `content-length` header > 512 KB → 502, actual body length > 512 KB → 502, fetch throw → 502, happy path returns `application/javascript` + `nosniff`. |
| `umami-script.test.ts` | 5 | `user-agent` forwarded, upstream non-200 forwarded, oversized upstream → 413 via `isResponseTooLargeError`, generic error → 502, happy path returns script with `Cache-Control: public, max-age=3600` + `nosniff`. |

### Approach

Follows the established pattern from `fetch-with-timeout.test.ts`:
- `// @vitest-environment node` header (matches identity/health tests)
- `vi.stubGlobal("fetch", mockFetch)` in `beforeEach`, `vi.restoreAllMocks()` in `afterEach`
- Real `Response` objects for upstream fixtures so `readCappedBuffer` / `resp.text()` exercise the same code paths as production

### Why these files?

All three are exposed on the production site (console.kubestellar.io) and touch security-adjacent concerns (input validation on video IDs, response-size caps to prevent memory exhaustion, `X-Content-Type-Options: nosniff`). Before this PR a regression in any of these branches would ship unnoticed.

---
*Filed by quality agent (ACMM L4/L6 — full mode)*