### PR TITLE
[scanner] fix: extract hardcoded strings to i18n

### DIFF
--- a/web/src/components/cards/ActiveAlerts.test.tsx
+++ b/web/src/components/cards/ActiveAlerts.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event'
 import { ActiveAlerts } from './ActiveAlerts'
 import type { Alert } from '../../types/alerts'
 import type { GroupedAlert } from '../../lib/alerts/groupAlertsForDisplay'
+import { useTranslation } from 'react-i18next'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -137,11 +138,14 @@ vi.mock('../ui/Pagination', () => ({
     currentPage: number
     totalPages: number
     onPageChange: (p: number) => void
-  }) => (
-    <div data-testid="pagination" data-page={currentPage} data-total={totalPages}>
-      <button onClick={() => onPageChange(currentPage + 1)}>Next</button>
-    </div>
-  ),
+  }) => {
+    const { t } = useTranslation()
+    return (
+      <div data-testid="pagination" data-page={currentPage} data-total={totalPages}>
+        <button onClick={() => onPageChange(currentPage + 1)}>{t('actions.next')}</button>
+      </div>
+    )
+  },
 }))
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/cards/AppStatus.test.tsx
+++ b/web/src/components/cards/AppStatus.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AppStatus } from './AppStatus'
 import type { Deployment } from '../../hooks/mcp/types'
+import { useTranslation } from 'react-i18next'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -70,12 +71,14 @@ vi.mock('../../lib/cards/CardComponents', () => ({
     currentPage: number
     totalPages: number
     onPageChange: (p: number) => void
-  }) =>
-    needsPagination ? (
+  }) => {
+    const { t } = useTranslation()
+    return needsPagination ? (
       <div data-testid="pagination" data-page={currentPage} data-total={totalPages}>
-        <button onClick={() => onPageChange(currentPage + 1)}>Next</button>
+        <button onClick={() => onPageChange(currentPage + 1)}>{t('actions.next')}</button>
       </div>
-    ) : null,
+    ) : null
+  },
   CardAIActions: ({ resource }: { resource: { name: string } }) => (
     <div data-testid={`ai-actions-${resource.name}`} />
   ),

--- a/web/src/components/cards/CrossClusterPolicyComparison.test.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.test.tsx
@@ -12,6 +12,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { useTranslation } from 'react-i18next'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -65,12 +66,14 @@ vi.mock('../ui/Button', () => ({
 }))
 
 vi.mock('./kyverno/KyvernoDetailModal', () => ({
-  KyvernoDetailModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
-    isOpen ? (
+  KyvernoDetailModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) => {
+    const { t } = useTranslation()
+    return isOpen ? (
       <div data-testid="kyverno-modal">
-        <button onClick={onClose}>Close</button>
+        <button onClick={onClose}>{t('actions.close')}</button>
       </div>
-    ) : null,
+    ) : null
+  },
 }))
 
 // ---------------------------------------------------------------------------
@@ -238,7 +241,7 @@ describe('CrossClusterPolicyComparison', () => {
       render(<CrossClusterPolicyComparison />)
       const policyRow = screen.getByRole('button', { name: /View policy details: ClusterPolicy\/require-labels/i })
       await userEvent.click(policyRow)
-      await userEvent.click(screen.getByText('Close'))
+      await userEvent.click(screen.getByText('actions.close'))
       expect(screen.queryByTestId('kyverno-modal')).not.toBeInTheDocument()
     })
   })

--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { NamespaceClusterGroup } from '../NamespaceClusterGroup'
 import type { NamespaceDetails } from '../types'
+import { useTranslation } from 'react-i18next'
 
 /**
  * NamespaceClusterGroup Component Tests
@@ -25,13 +26,16 @@ vi.mock('../NamespaceCard', () => ({
     namespace: NamespaceDetails
     onSelect: () => void
     onDelete?: () => void
-  }) => (
-    <div data-testid="namespace-card">
-      <span>{namespace.name}</span>
-      <button onClick={onSelect}>Select</button>
-      {onDelete && <button onClick={onDelete}>Delete</button>}
-    </div>
-  ),
+  }) => {
+    const { t } = useTranslation()
+    return (
+      <div data-testid="namespace-card">
+        <span>{namespace.name}</span>
+        <button onClick={onSelect}>{t('common.select')}</button>
+        {onDelete && <button onClick={onDelete}>{t('actions.delete')}</button>}
+      </div>
+    )
+  },
   NamespaceCardSkeleton: () => <div data-testid="namespace-skeleton">Loading...</div>,
 }))
 

--- a/web/src/pages/TeamManagement.test.tsx
+++ b/web/src/pages/TeamManagement.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { act, fireEvent, render, screen } from '@testing-library/react'
+import { useTranslation } from 'react-i18next'
 
 const useTeamsMock = vi.hoisted(() => ({
   teams: [{ id: 'team-1', name: 'Alpha Team', description: 'First team', memberCount: 3, createdBy: '1', createdAt: '', updatedAt: '' }],
@@ -46,12 +47,15 @@ vi.mock('@/components/teams/TeamList', () => ({
 }))
 
 vi.mock('@/components/teams/TeamDetail', () => ({
-  TeamDetail: ({ team, onBack }: { team: { name: string }; onBack: () => void }) => (
-    <div data-testid="team-detail">
-      <span>{team.name}</span>
-      <button onClick={onBack}>Back</button>
-    </div>
-  ),
+  TeamDetail: ({ team, onBack }: { team: { name: string }; onBack: () => void }) => {
+    const { t } = useTranslation()
+    return (
+      <div data-testid="team-detail">
+        <span>{team.name}</span>
+        <button onClick={onBack}>{t('common.back')}</button>
+      </div>
+    )
+  },
 }))
 
 import { TeamManagementPage } from './TeamManagement'
@@ -95,7 +99,7 @@ describe('TeamManagementPage', () => {
     expect(screen.getByTestId('team-detail')).toBeInTheDocument()
 
     await act(async () => {
-      fireEvent.click(screen.getByText('Back'))
+      fireEvent.click(screen.getByText('common.back'))
     })
     expect(screen.getByTestId('team-list')).toBeInTheDocument()
     expect(screen.queryByTestId('team-detail')).not.toBeInTheDocument()


### PR DESCRIPTION
Fixes #21428

Extracts hardcoded button label strings from test mock components to use `t()` from react-i18next, consistent with the behaviour of the production components they mock.

## Changes

| File | String(s) fixed | Key used |
|------|----------------|---------|
| `pages/TeamManagement.test.tsx` | `Back` | `t('common.back')` |
| `components/cards/CrossClusterPolicyComparison.test.tsx` | `Close` | `t('actions.close')` |
| `components/cards/ActiveAlerts.test.tsx` | `Next` | `t('actions.next')` |
| `components/cards/AppStatus.test.tsx` | `Next` | `t('actions.next')` |
| `components/namespaces/__tests__/NamespaceClusterGroup.test.tsx` | `Select`, `Delete` | `t('common.select')`, `t('actions.delete')` |

All translation keys already exist in `web/src/locales/en/common.json`. Test assertions that previously matched English text (`getByText('Back')`, `getByText('Close')`) are updated to match the key string returned by the test i18n mock.

## Notes

- The global vitest i18n mock (`src/test/setup.ts`) returns the key itself for unknown strings, so `t('common.back')` renders as `common.back` in tests. Assertions are updated accordingly.
- 10 remaining flagged files (AlertRules, GitOpsDrift, DynamicCard, RecentEvents, WatchesPanel, AppStatus pagination, CreateDashboardModal, TeamDetail tests) are left as follow-up to keep this PR under 50 lines.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>