### PR TITLE
[scanner] fix: resolve test failures from Coverage Suite run #4397

### DIFF
--- a/web/src/components/gpu/__tests__/GPUReservationsTab.test.tsx
+++ b/web/src/components/gpu/__tests__/GPUReservationsTab.test.tsx
@@ -24,18 +24,21 @@ vi.mock('../../charts/Sparkline', () => ({
 function makeReservation(overrides: Partial<GPUReservation> = {}): GPUReservation {
   return {
     id: 'test-id',
-    user: 'test-user',
+    user_id: 'test-user-id',
+    user_name: 'test-user',
     cluster: 'test-cluster',
     namespace: 'default',
     title: 'Test Reservation',
-    gpuType: 'nvidia-a100',
-    count: 2,
+    description: '',
+    gpu_type: 'nvidia-a100',
+    gpu_count: 2,
     start_date: '2024-01-15T00:00:00Z',
     duration_hours: 24,
-    purpose: 'testing',
+    notes: '',
     status: 'active',
-    createdAt: '2024-01-15T00:00:00Z',
-    updatedAt: '2024-01-15T00:00:00Z',
+    quota_name: '',
+    quota_enforced: false,
+    created_at: '2024-01-15T00:00:00Z',
     ...overrides,
   }
 }
@@ -65,14 +68,14 @@ function renderTab(overrides: Partial<GPUReservationsTabProps> = {}) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('GPUReservationsTab', () => {
-  it('renders the "New Reservation" button', () => {
+  it('renders the "Create Reservation" button in empty state', () => {
     renderTab()
-    expect(screen.getByText('gpuReservations.newReservation')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.createReservation')).toBeTruthy()
   })
 
   it('shows empty state when no reservations are present', () => {
     renderTab({ filteredReservations: [] })
-    expect(screen.getByText('gpuReservations.noReservationsYet')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.overview.noReservationsYetShort')).toBeTruthy()
   })
 
   it('renders reservation cards when reservations are present', () => {
@@ -81,38 +84,44 @@ describe('GPUReservationsTab', () => {
     expect(screen.getAllByTestId('cluster-badge')).toHaveLength(2)
   })
 
-  it('calls onCreateReservation when the "New Reservation" button is clicked', () => {
+  it('calls onCreateReservation when the "Create Reservation" button is clicked', () => {
     const onCreateReservation = vi.fn()
     renderTab({ onCreateReservation })
-    fireEvent.click(screen.getByText('gpuReservations.newReservation'))
+    fireEvent.click(screen.getByText('gpuReservations.createReservation'))
     expect(onCreateReservation).toHaveBeenCalledTimes(1)
   })
 
   it('calls onSetSearchTerm when typing in the search field', () => {
     const onSetSearchTerm = vi.fn()
     renderTab({ onSetSearchTerm })
-    const searchInput = screen.getByPlaceholderText('gpuReservations.searchPlaceholder')
+    // The component renders t('gpuReservations.searchPlaceholder', 'Search reservations...')
+    // which resolves to the fallback string in the test i18n mock.
+    const searchInput = screen.getByPlaceholderText('Search reservations...')
     fireEvent.change(searchInput, { target: { value: 'test' } })
     expect(onSetSearchTerm).toHaveBeenCalledWith('test')
   })
 
-  it('calls onSetShowOnlyMine when the "My Reservations" filter is toggled', () => {
+  it('calls onSetShowOnlyMine(false) when the clear filter button is clicked', () => {
     const onSetShowOnlyMine = vi.fn()
-    renderTab({ onSetShowOnlyMine, user: { github_login: 'test-user' } })
-    fireEvent.click(screen.getByText('gpuReservations.myReservations'))
-    expect(onSetShowOnlyMine).toHaveBeenCalledWith(true)
+    // showOnlyMine=true causes the filter banner with a "Clear filter" button to appear
+    renderTab({ onSetShowOnlyMine, showOnlyMine: true, user: { github_login: 'test-user' } })
+    // The button label comes from t('common:common.clearFilter', 'Clear filter') → 'Clear filter'
+    fireEvent.click(screen.getByText('Clear filter'))
+    expect(onSetShowOnlyMine).toHaveBeenCalledWith(false)
   })
 
-  it('shows loading skeleton when reservationsLoading is true', () => {
-    renderTab({ reservationsLoading: true })
-    expect(screen.getByText('gpuReservations.loadingReservations')).toBeTruthy()
+  it('hides empty state when reservationsLoading is true', () => {
+    renderTab({ reservationsLoading: true, filteredReservations: [] })
+    // When loading, the empty-state block is suppressed (condition: length===0 && !reservationsLoading)
+    expect(screen.queryByText('gpuReservations.overview.noReservationsYetShort')).not.toBeInTheDocument()
   })
 
   it('calls onEditReservation when the edit button is clicked', () => {
     const onEditReservation = vi.fn()
     const reservation = makeReservation()
     renderTab({ filteredReservations: [reservation], onEditReservation })
-    const editButton = screen.getByLabelText('gpuReservations.editReservation')
+    // aria-label comes from t('gpuReservations.list.editReservation', { title }) → key string
+    const editButton = screen.getByLabelText('gpuReservations.list.editReservation')
     fireEvent.click(editButton)
     expect(onEditReservation).toHaveBeenCalledWith(reservation)
   })

--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -2,22 +2,56 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { ReservationFormModal } from '../ReservationFormModal'
-import type { ReservationFormModalProps } from '../ReservationFormModal'
+import type { GPUReservation } from '../../../hooks/useGPUReservations'
+import type { GPUClusterInfo } from '../ReservationFormModal'
+import type { GPUNode } from '../../../hooks/mcp/types.gpu'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
-vi.mock('../../../lib/modals', () => ({
-  BaseModal: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
-    <div data-testid="base-modal" onClick={onClose}>{children}</div>
-  ),
-  ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="confirm-dialog">{children}</div> : null,
-}))
+vi.mock('../../../lib/modals', () => {
+  const BaseModalFn = ({
+    isOpen,
+    children,
+    onClose,
+  }: {
+    isOpen: boolean
+    children: React.ReactNode
+    onClose: () => void
+  }) =>
+    isOpen ? (
+      <div data-testid="base-modal" onClick={onClose}>
+        {children}
+      </div>
+    ) : null
+  const BaseModal = Object.assign(BaseModalFn, {
+    Header: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="modal-header">{children}</div>
+    ),
+    Content: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="modal-content">{children}</div>
+    ),
+    Footer: ({ children }: { children: React.ReactNode }) => (
+      <div data-testid="modal-footer">{children}</div>
+    ),
+  })
+  return {
+    BaseModal,
+    ConfirmDialog: ({
+      open,
+      children,
+    }: {
+      open: boolean
+      children: React.ReactNode
+    }) => (open ? <div data-testid="confirm-dialog">{children}</div> : null),
+  }
+})
 
 vi.mock('../../../hooks/useMCP', () => ({
   useNamespaces: vi.fn(() => ({
-    namespaces: ['default', 'kube-system'],
-    loading: false,
+    namespaces: ['my-app', 'production'],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
   })),
   createOrUpdateResourceQuota: vi.fn(() => Promise.resolve()),
   deleteResourceQuota: vi.fn(() => Promise.resolve()),
@@ -29,15 +63,65 @@ vi.mock('../../../hooks/useMCP', () => ({
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function renderModal(overrides: Partial<ReservationFormModalProps> = {}) {
-  const defaults: ReservationFormModalProps = {
-    open: true,
+const defaultCluster: GPUClusterInfo = {
+  name: 'test-cluster',
+  totalGPUs: 8,
+  allocatedGPUs: 0,
+  availableGPUs: 8,
+  gpuTypes: ['nvidia-a100'],
+}
+
+const makeEditingReservation = (): GPUReservation => ({
+  id: 'test-id',
+  user_id: 'test-user-id',
+  user_name: 'test-user',
+  title: 'Test Reservation',
+  description: '',
+  cluster: 'test-cluster',
+  namespace: 'my-app',
+  gpu_count: 2,
+  gpu_type: 'nvidia-a100',
+  start_date: '2024-01-15T00:00:00Z',
+  duration_hours: 24,
+  notes: '',
+  status: 'active',
+  quota_name: '',
+  quota_enforced: false,
+  created_at: '2024-01-15T00:00:00Z',
+})
+
+const makeNode = (gpuType = 'nvidia-a100'): GPUNode => ({
+  name: 'node1',
+  cluster: 'test-cluster',
+  gpuType,
+  gpuCount: 4,
+  gpuAllocated: 0,
+})
+
+function renderModal(
+  overrides: Partial<{
+    isOpen: boolean
+    editingReservation: GPUReservation | null
+    gpuClusters: GPUClusterInfo[]
+    allNodes: GPUNode[]
+    onClose: () => void
+    onSave: (input: unknown) => Promise<void>
+    onActivate: (id: string) => Promise<void>
+    onSaved: () => void
+    onError: (msg: string) => void
+  }> = {},
+) {
+  const defaults = {
+    isOpen: true,
     editingReservation: null,
-    currentCluster: 'test-cluster',
-    nodes: [],
+    gpuClusters: [defaultCluster],
+    allNodes: [makeNode()],
+    user: null,
     onClose: vi.fn(),
-    onCreate: vi.fn(() => Promise.resolve()),
-    onUpdate: vi.fn(() => Promise.resolve()),
+    onSave: vi.fn(() => Promise.resolve()),
+    onActivate: vi.fn(() => Promise.resolve()),
+    onSaved: vi.fn(),
+    onError: vi.fn(),
   }
   return render(<ReservationFormModal {...defaults} {...overrides} />)
 }
@@ -45,82 +129,62 @@ function renderModal(overrides: Partial<ReservationFormModalProps> = {}) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('ReservationFormModal', () => {
-  it('does not render when open is false', () => {
-    renderModal({ open: false })
+  it('does not render when isOpen is false', () => {
+    renderModal({ isOpen: false })
     expect(screen.queryByTestId('base-modal')).not.toBeInTheDocument()
   })
 
-  it('renders the modal when open is true', () => {
+  it('renders the modal when isOpen is true', () => {
     renderModal()
     expect(screen.getByTestId('base-modal')).toBeInTheDocument()
   })
 
   it('shows "Create Reservation" title when editingReservation is null', () => {
     renderModal()
-    expect(screen.getByText('gpuReservations.createReservation')).toBeTruthy()
+    // t('gpuReservations.form.createTitle') returns the key in test env
+    expect(screen.getByText('gpuReservations.form.createTitle')).toBeTruthy()
   })
 
   it('shows "Edit Reservation" title when editingReservation is provided', () => {
-    const editingReservation = {
-      id: 'test-id',
-      user: 'test-user',
-      cluster: 'test-cluster',
-      namespace: 'default',
-      title: 'Test',
-      gpuType: 'nvidia-a100',
-      count: 2,
-      start_date: '2024-01-15T00:00:00Z',
-      duration_hours: 24,
-      purpose: 'testing',
-      status: 'active' as const,
-      createdAt: '2024-01-15T00:00:00Z',
-      updatedAt: '2024-01-15T00:00:00Z',
-    }
-    renderModal({ editingReservation })
-    expect(screen.getByText('gpuReservations.editReservation')).toBeTruthy()
+    renderModal({ editingReservation: makeEditingReservation() })
+    // t('gpuReservations.form.editTitle') returns the key in test env
+    expect(screen.getByText('gpuReservations.form.editTitle')).toBeTruthy()
   })
 
-  it('calls onClose when the close button is clicked', () => {
+  it('calls onClose when the modal backdrop is clicked', () => {
     const onClose = vi.fn()
     renderModal({ onClose })
     fireEvent.click(screen.getByTestId('base-modal'))
     expect(onClose).toHaveBeenCalledTimes(1)
   })
 
-  it('shows GPU type selector with available options', () => {
-    const nodes = [
-      { name: 'node1', gpuType: 'nvidia-a100', gpuCount: 4, allocatableGPU: 4, requestedGPU: 0, status: 'Ready' },
-      { name: 'node2', gpuType: 'nvidia-h100', gpuCount: 8, allocatableGPU: 8, requestedGPU: 0, status: 'Ready' },
-    ]
-    renderModal({ nodes })
-    expect(screen.getByLabelText('gpuReservations.form.gpuType')).toBeTruthy()
+  it('shows GPU type label in the form', () => {
+    const allNodes = [makeNode('nvidia-a100'), makeNode('nvidia-h100')]
+    renderModal({
+      editingReservation: makeEditingReservation(),
+      allNodes,
+    })
+    // t('gpuReservations.form.fields.gpuTypeLabel') returns the key
+    expect(screen.getByText('gpuReservations.form.fields.gpuTypeLabel')).toBeTruthy()
   })
 
-  it('validates required fields and shows error messages', () => {
+  it('shows a validation error when submitting with no cluster selected', () => {
     renderModal()
-    const submitButton = screen.getByText('gpuReservations.form.submit')
+    // Click the create/save button — t('gpuReservations.form.buttons.create') → key
+    const submitButton = screen.getByText('gpuReservations.form.buttons.create')
     fireEvent.click(submitButton)
-    expect(screen.getByText('gpuReservations.form.titleRequired')).toBeTruthy()
+    // Validation: cluster is required first
+    expect(screen.getByText('gpuReservations.form.errors.selectCluster')).toBeTruthy()
   })
 
-  it('calls onCreate with form data when submitting a new reservation', async () => {
-    const onCreate = vi.fn(() => Promise.resolve())
-    renderModal({ onCreate })
-    
-    fireEvent.change(screen.getByLabelText('gpuReservations.form.title'), { target: { value: 'Test Reservation' } })
-    fireEvent.change(screen.getByLabelText('gpuReservations.form.namespace'), { target: { value: 'default' } })
-    
-    const submitButton = screen.getByText('gpuReservations.form.submit')
-    fireEvent.click(submitButton)
-    
-    // onCreate should eventually be called after validation passes
-    expect(onCreate).toHaveBeenCalled()
-  })
-
-  it('displays namespace dropdown with available namespaces', () => {
+  it('shows cancel and save buttons', () => {
     renderModal()
-    expect(screen.getByLabelText('gpuReservations.form.namespace')).toBeTruthy()
-    expect(screen.getByText('default')).toBeTruthy()
-    expect(screen.getByText('kube-system')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.form.buttons.cancel')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.form.buttons.create')).toBeTruthy()
+  })
+
+  it('shows namespace label in the form', () => {
+    renderModal({ editingReservation: makeEditingReservation() })
+    expect(screen.getByText('gpuReservations.form.fields.namespaceLabel')).toBeTruthy()
   })
 })

--- a/web/src/components/stellar/__tests__/RecommendedTasksPanel.test.tsx
+++ b/web/src/components/stellar/__tests__/RecommendedTasksPanel.test.tsx
@@ -2,17 +2,13 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { RecommendedTasksPanel } from '../RecommendedTasksPanel'
-import type { RecommendedTasksPanelProps } from '../RecommendedTasksPanel'
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function renderPanel(overrides: Partial<RecommendedTasksPanelProps> = {}) {
-  const defaults: RecommendedTasksPanelProps = {
-    recommendations: [],
-    onSchedule: vi.fn(),
-    onDismiss: vi.fn(),
-  }
-  return render(<RecommendedTasksPanel {...defaults} {...overrides} />)
+function renderPanel(
+  createTask: (...args: unknown[]) => Promise<unknown> = vi.fn(() => Promise.resolve()),
+) {
+  return render(<RecommendedTasksPanel createTask={createTask} />)
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -20,170 +16,64 @@ function renderPanel(overrides: Partial<RecommendedTasksPanelProps> = {}) {
 describe('RecommendedTasksPanel', () => {
   it('renders the panel title', () => {
     renderPanel()
-    expect(screen.getByText('stellar.recommendedTasks.title')).toBeTruthy()
+    // t('stellar.recommendedTasks.stellarSuggests') returns the key in test env
+    expect(screen.getByText('stellar.recommendedTasks.stellarSuggests')).toBeTruthy()
   })
 
-  it('shows empty state when no recommendations are provided', () => {
-    renderPanel({ recommendations: [] })
-    expect(screen.getByText('stellar.recommendedTasks.noTasksAvailable')).toBeTruthy()
+  it('renders recommendation cards from the built-in list', () => {
+    renderPanel()
+    // The component renders RECOMMENDATIONS (8 items) from its hardcoded constant.
+    // At least the first item's title key should appear.
+    expect(screen.getByText('stellar.recommendedTasks.items.auditRbac.title')).toBeTruthy()
   })
 
-  it('renders recommendation cards when recommendations are provided', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-      {
-        id: 'rec-2',
-        category: 'observability' as const,
-        icon: 'BarChart3',
-        titleKey: 'stellar.recommendedTasks.task.setupMetrics',
-        blurbKey: 'stellar.recommendedTasks.task.setupMetricsBlurb',
-        priority: 3,
-        estimatedMinutes: 45,
-      },
-    ]
-    renderPanel({ recommendations })
-    expect(screen.getByText('stellar.recommendedTasks.task.enableRBAC')).toBeTruthy()
-    expect(screen.getByText('stellar.recommendedTasks.task.setupMetrics')).toBeTruthy()
+  it('shows category label for security recommendations', () => {
+    renderPanel()
+    // t('stellar.recommendedTasks.categories.security') returns the key
+    expect(screen.getAllByText('stellar.recommendedTasks.categories.security').length).toBeGreaterThan(0)
   })
 
-  it('groups recommendations by priority', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.highPriority',
-        blurbKey: 'stellar.recommendedTasks.task.highPriorityBlurb',
-        priority: 1,
-        estimatedMinutes: 30,
-      },
-      {
-        id: 'rec-2',
-        category: 'best-practices' as const,
-        icon: 'FileText',
-        titleKey: 'stellar.recommendedTasks.task.lowPriority',
-        blurbKey: 'stellar.recommendedTasks.task.lowPriorityBlurb',
-        priority: 5,
-        estimatedMinutes: 45,
-      },
-    ]
-    renderPanel({ recommendations })
-    expect(screen.getByText('stellar.recommendedTasks.priority.critical')).toBeTruthy()
-    expect(screen.getByText('stellar.recommendedTasks.priority.low')).toBeTruthy()
+  it('expands a recommendation when its title is clicked', () => {
+    renderPanel()
+    const title = screen.getByText('stellar.recommendedTasks.items.auditRbac.title')
+    fireEvent.click(title)
+    // After expanding, the blurb text should appear
+    expect(screen.getByText('stellar.recommendedTasks.items.auditRbac.blurb')).toBeTruthy()
   })
 
-  it('calls onSchedule when a recommendation is scheduled', () => {
-    const onSchedule = vi.fn()
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations, onSchedule })
-    const scheduleButton = screen.getByText('stellar.recommendedTasks.schedule.doNow')
-    fireEvent.click(scheduleButton)
-    expect(onSchedule).toHaveBeenCalledWith('rec-1', expect.any(Number))
-  })
-
-  it('calls onDismiss when a recommendation is dismissed', () => {
-    const onDismiss = vi.fn()
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations, onDismiss })
-    const dismissButton = screen.getByLabelText('stellar.recommendedTasks.dismiss')
-    fireEvent.click(dismissButton)
-    expect(onDismiss).toHaveBeenCalledWith('rec-1')
-  })
-
-  it('shows estimated time for each recommendation', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations })
-    expect(screen.getByText('stellar.recommendedTasks.estimatedTime')).toBeTruthy()
-  })
-
-  it('displays category badges for recommendations', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations })
-    expect(screen.getByText('stellar.recommendedTasks.category.security')).toBeTruthy()
-  })
-
-  it('expands recommendation details when clicked', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations })
-    const card = screen.getByText('stellar.recommendedTasks.task.enableRBAC')
-    fireEvent.click(card)
-    expect(screen.getByText('stellar.recommendedTasks.task.enableRBACBlurb')).toBeTruthy()
-  })
-
-  it('shows schedule options when scheduling a task', () => {
-    const recommendations = [
-      {
-        id: 'rec-1',
-        category: 'security' as const,
-        icon: 'Shield',
-        titleKey: 'stellar.recommendedTasks.task.enableRBAC',
-        blurbKey: 'stellar.recommendedTasks.task.enableRBACBlurb',
-        priority: 2,
-        estimatedMinutes: 30,
-      },
-    ]
-    renderPanel({ recommendations })
-    const scheduleButton = screen.getByText('stellar.recommendedTasks.schedule.doNow')
-    fireEvent.click(scheduleButton)
+  it('shows schedule buttons when a recommendation is expanded', () => {
+    renderPanel()
+    fireEvent.click(screen.getByText('stellar.recommendedTasks.items.auditRbac.title'))
+    // t('stellar.recommendedTasks.schedule.doNow') returns the key
+    expect(screen.getByText('stellar.recommendedTasks.schedule.doNow')).toBeTruthy()
     expect(screen.getByText('stellar.recommendedTasks.schedule.inOneHour')).toBeTruthy()
     expect(screen.getByText('stellar.recommendedTasks.schedule.tomorrow')).toBeTruthy()
+  })
+
+  it('calls createTask when a schedule button is clicked', async () => {
+    const createTask = vi.fn(() => Promise.resolve())
+    renderPanel(createTask)
+    fireEvent.click(screen.getByText('stellar.recommendedTasks.items.auditRbac.title'))
+    fireEvent.click(screen.getByText('stellar.recommendedTasks.schedule.doNow'))
+    expect(createTask).toHaveBeenCalledTimes(1)
+  })
+
+  it('collapses and re-expands the panel when the header is clicked', () => {
+    renderPanel()
+    const header = screen.getByText('stellar.recommendedTasks.stellarSuggests')
+    // Initially expanded — recommendations visible
+    expect(screen.getByText('stellar.recommendedTasks.items.auditRbac.title')).toBeTruthy()
+    // Collapse
+    fireEvent.click(header)
+    expect(screen.queryByText('stellar.recommendedTasks.items.auditRbac.title')).not.toBeInTheDocument()
+    // Re-expand
+    fireEvent.click(header)
+    expect(screen.getByText('stellar.recommendedTasks.items.auditRbac.title')).toBeTruthy()
+  })
+
+  it('shows the count of remaining recommendations in the badge', () => {
+    renderPanel()
+    // The badge shows total RECOMMENDATIONS.length (8) initially
+    expect(screen.getByText('8')).toBeTruthy()
   })
 })

--- a/web/src/components/stellar/watchDetail/__tests__/WatchDetailContent.test.tsx
+++ b/web/src/components/stellar/watchDetail/__tests__/WatchDetailContent.test.tsx
@@ -1,12 +1,12 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
-import { WatchDetailContent } from '../watchDetail/WatchDetailContent'
-import type { StellarWatch, StellarNotification } from '../../../types/stellar'
+import { WatchDetailContent } from '../WatchDetailContent'
+import type { StellarWatch, StellarNotification } from '../../../../types/stellar'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
-vi.mock('../watchDetail/WatchDetailPrimitives', () => ({
+vi.mock('../WatchDetailPrimitives', () => ({
   Section: ({ title, children }: { title: string; children: React.ReactNode }) => (
     <div data-testid="section" data-title={title}>{children}</div>
   ),
@@ -16,8 +16,19 @@ vi.mock('../watchDetail/WatchDetailPrimitives', () => ({
   Stat: ({ label, value }: { label: string; value: string }) => (
     <div data-testid="stat" data-label={label}>{value}</div>
   ),
-  Recommendation: ({ title, onClick }: { title: string; onClick: () => void }) => (
-    <button data-testid="recommendation" onClick={onClick}>{title}</button>
+  Recommendation: ({
+    label,
+    onExecute,
+  }: {
+    label: string
+    rationale: string
+    confidence: number
+    color: string
+    onExecute: () => void
+  }) => (
+    <button data-testid="recommendation" onClick={onExecute}>
+      {label}
+    </button>
   ),
 }))
 
@@ -31,10 +42,11 @@ function makeWatch(overrides: Partial<StellarWatch> = {}): StellarWatch {
     resourceKind: 'Pod',
     resourceName: 'test-pod',
     reason: 'CrashLoopBackOff detected',
-    createdAt: '2024-01-15T00:00:00Z',
+    status: 'active',
     lastUpdate: 'Pod is crashing',
     lastChecked: '2024-01-15T12:00:00Z',
-    active: true,
+    createdAt: '2024-01-15T00:00:00Z',
+    updatedAt: '2024-01-15T00:00:00Z',
     ...overrides,
   }
 }
@@ -42,15 +54,14 @@ function makeWatch(overrides: Partial<StellarWatch> = {}): StellarWatch {
 function makeNotification(overrides: Partial<StellarNotification> = {}): StellarNotification {
   return {
     id: 'notif-1',
+    type: 'event',
+    severity: 'warning',
+    title: 'Pod crashed',
+    body: 'Pod crashed unexpectedly',
     cluster: 'test-cluster',
     namespace: 'default',
-    resourceKind: 'Pod',
-    resourceName: 'test-pod',
-    severity: 'warning',
-    message: 'Pod crashed',
+    read: false,
     createdAt: '2024-01-15T00:00:00Z',
-    dismissed: false,
-    snoozedUntil: null,
     ...overrides,
   }
 }
@@ -163,8 +174,8 @@ describe('WatchDetailContent', () => {
   it('displays event timeline when related events are provided', () => {
     const watch = makeWatch()
     const events = [
-      makeNotification(),
-      makeNotification({ id: 'notif-2', severity: 'critical' }),
+      makeNotification({ title: 'Pod crashed' }),
+      makeNotification({ id: 'notif-2', severity: 'critical', title: 'Critical failure' }),
     ]
     render(
       <WatchDetailContent
@@ -185,16 +196,18 @@ describe('WatchDetailContent', () => {
         onClose={vi.fn()}
       />
     )
+    // The component renders ev.title in the event timeline
     expect(screen.getByText('Pod crashed')).toBeTruthy()
   })
 
-  it('shows attempt summary when provided', () => {
+  it('shows attempt summary section headers when provided', () => {
     const watch = makeWatch()
     const attemptSummary = {
-      totalAttempts: 3,
-      successCount: 1,
-      failureCount: 2,
-      lastAttemptStatus: 'failed',
+      total: 3,
+      resolved: 1,
+      escalated: 1,
+      paused: 1,
+      recent: [],
     }
     render(
       <WatchDetailContent
@@ -215,6 +228,6 @@ describe('WatchDetailContent', () => {
         onClose={vi.fn()}
       />
     )
-    expect(screen.getByTestId('section-header')).toBeTruthy()
+    expect(screen.getAllByTestId('section-header').length).toBeGreaterThan(0)
   })
 })


### PR DESCRIPTION
Fixes #21437

## Summary

Resolves 27 test failures across 4 test files by aligning test interfaces with actual component implementations. The tests were auto-generated with incorrect type assumptions and mismatched component APIs.

### Changes

**`GPUReservationsTab.test.tsx`**
- Fixed `makeReservation()` field names to match the actual `GPUReservation` type (`gpu_count`, `gpu_type`, `user_name`, `user_id`, `created_at` instead of wrong camelCase variants)
- Updated assertions to use correct i18n keys: `gpuReservations.createReservation`, `gpuReservations.overview.noReservationsYetShort`, `gpuReservations.list.editReservation`
- Fixed placeholder text to match the fallback string from `t(key, fallback)` calls
- Rewrote "My Reservations" test to test the actual clear-filter behavior (component exposes a clear button, not a toggle)
- Rewrote loading state test to check suppression of empty state

**`ReservationFormModal.test.tsx`**
- Rewrote to match actual component API (`isOpen` not `open`; `gpuClusters/allNodes/onSave/onActivate/onSaved/onError` instead of simplified props)
- Added `BaseModal.Header/.Content/.Footer` sub-component mocks
- Fixed `useNamespaces` mock shape (`isLoading` not `loading`)
- Used non-system namespaces (system namespaces are filtered by the component)
- Updated assertions to use correct i18n keys (`gpuReservations.form.createTitle`, `gpuReservations.form.buttons.*`, etc.)

**`RecommendedTasksPanel.test.tsx`**
- Rewrote to test actual component API (`createTask` prop + hardcoded `RECOMMENDATIONS` constant) instead of a hypothetical `recommendations/onSchedule/onDismiss` interface
- Tests now cover: panel render, recommendation list, expand/collapse, schedule buttons, `createTask` callback

**`WatchDetailContent.test.tsx`** (was "failed to load")
- Fixed `StellarWatch` type: replaced `active: boolean` with `status: 'active'`, added required `updatedAt`
- Fixed `StellarNotification` type: replaced `message/dismissed/snoozedUntil/resourceKind/resourceName` with correct fields (`title`, `body`, `read`, `type`)
- Fixed `Recommendation` mock to use `label`/`onExecute` props (not `title`/`onClick`)
- Fixed event timeline assertion to check `ev.title` (component renders `ev.title`, not `ev.message`)
- Fixed import paths for the file's location within `watchDetail/__tests__/`