### PR TITLE
🐛 [scanner] fix: ReservationFormModal test i18n key assertions

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -24,8 +24,8 @@ vi.mock('../../../lib/modals', () => {
       </div>
     ) : null
   const BaseModal = Object.assign(BaseModalFn, {
-    Header: ({ children }: { children: React.ReactNode }) => (
-      <div data-testid="modal-header">{children}</div>
+    Header: ({ children, title }: { children?: React.ReactNode; title?: string }) => (
+      <div data-testid="modal-header">{title}{children}</div>
     ),
     Content: ({ children }: { children: React.ReactNode }) => (
       <div data-testid="modal-content">{children}</div>


### PR DESCRIPTION
Fixes #21440

## Root cause

The `BaseModal.Header` mock in the test file only rendered `children`, silently dropping the `title` prop:

```tsx
// Before (broken)
Header: ({ children }: { children: React.ReactNode }) => (
  <div data-testid="modal-header">{children}</div>
),
```

The real `ModalHeader` component renders `title` inside an `<h2>` element. The component passes the translation key as the `title` prop to `BaseModal.Header`:

```tsx
<BaseModal.Header
  title={editingReservation ? t('gpuReservations.form.editTitle') : t('gpuReservations.form.createTitle')}
```

Because the mock dropped `title`, `screen.getByText('gpuReservations.form.createTitle')` could never find the element in the DOM, causing both title-related tests to fail.

## Fix

Extend the mock to accept and render the `title` prop:

```tsx
// After (fixed)
Header: ({ children, title }: { children?: React.ReactNode; title?: string }) => (
  <div data-testid="modal-header">{title}{children}</div>
),
```

This aligns the mock with the real component's rendering behaviour and follows the established convention in this codebase where tests assert on i18n key strings (since the vitest jsdom setup mocks `t(key)` to return the key).