### PR TITLE
🐛 [scanner] fix: resolve test failures from Coverage Suite run #4398

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -57,7 +57,7 @@ describe('ReservationFormModal', () => {
 
   it('shows "Create Reservation" title when editingReservation is null', () => {
     renderModal()
-    expect(screen.getByText('gpuReservations.createReservation')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.form.createTitle')).toBeTruthy()
   })
 
   it('shows "Edit Reservation" title when editingReservation is provided', () => {
@@ -77,7 +77,7 @@ describe('ReservationFormModal', () => {
       updatedAt: '2024-01-15T00:00:00Z',
     }
     renderModal({ editingReservation })
-    expect(screen.getByText('gpuReservations.editReservation')).toBeTruthy()
+    expect(screen.getByText('gpuReservations.form.editTitle')).toBeTruthy()
   })
 
   it('calls onClose when the close button is clicked', () => {


### PR DESCRIPTION
Fixes #21440

Update `ReservationFormModal` tests to match actual translation keys used by the component:
- `gpuReservations.createReservation` → `gpuReservations.form.createTitle`
- `gpuReservations.editReservation` → `gpuReservations.form.editTitle`

The component renders `t('gpuReservations.form.createTitle')` and `t('gpuReservations.form.editTitle')` for the modal title, but tests expected the shorter top-level keys. Since vitest mocks `t()` to return the key itself, the assertions failed.