### PR TITLE
🐛 [scanner] fix: add event handler a11y parity to ReservationFormModal test mock

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -8,7 +8,13 @@ import type { ReservationFormModalProps } from '../ReservationFormModal'
 
 vi.mock('../../../lib/modals', () => ({
   BaseModal: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
-    <div data-testid="base-modal" onClick={onClose}>{children}</div>
+    <div
+      data-testid="base-modal"
+      role="button"
+      tabIndex={0}
+      onClick={onClose}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') onClose() }}
+    >{children}</div>
   ),
   ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
     open ? <div data-testid="confirm-dialog">{children}</div> : null,


### PR DESCRIPTION
Fixes #21445

Adds `role="button"`, `tabIndex={0}`, and `onKeyDown` handler to the `BaseModal` mock div in `ReservationFormModal.test.tsx` that had `onClick` without corresponding keyboard accessibility support.

This ensures keyboard-only users and screen reader users can interact with the element, matching the pattern used in other test mocks in the codebase (e.g. `RenameModal.test.tsx`).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>