### PR TITLE
🌱 [scanner] fix: extract hardcoded thresholds to named constants

### DIFF
--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -26,6 +26,7 @@ function authHeaders(): Record<string, string> {
 }
 
 const DEMO_REPORTS = generateBenchmarkReports()
+const HTTP_SERVICE_UNAVAILABLE = 503
 
 // ---------------------------------------------------------------------------
 // Module-level SSE singleton — shared across all card hook instances
@@ -221,7 +222,7 @@ export function useCachedBenchmarkReports() {
         headers: authHeaders(),
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
-      if (res.status === 503) throw new Error('BENCHMARK_UNAVAILABLE')
+      if (res.status === HTTP_SERVICE_UNAVAILABLE) throw new Error('BENCHMARK_UNAVAILABLE')
       if (!res.ok) throw new Error(`Benchmark API error: ${res.status}`)
       const data = await res.json()
       return (data.reports ?? []) as BenchmarkReport[]

--- a/web/src/hooks/useCardGridNavigation.ts
+++ b/web/src/hooks/useCardGridNavigation.ts
@@ -18,6 +18,8 @@ interface UseCardGridNavigationOptions {
   gridColumns?: number
 }
 
+const DEFAULT_GRID_COLUMNS = 12
+
 function computeGridLayout(cards: CardLike[], gridColumns: number): GridPosition[] {
   const layout: GridPosition[] = []
   let row = 0
@@ -38,7 +40,7 @@ function computeGridLayout(cards: CardLike[], gridColumns: number): GridPosition
 export function useCardGridNavigation({
   cards,
   onExpandCard,
-  gridColumns = 12 }: UseCardGridNavigationOptions) {
+  gridColumns = DEFAULT_GRID_COLUMNS }: UseCardGridNavigationOptions) {
   const cardRefMap = useRef<Map<string, HTMLElement>>(new Map())
 
   const layout = computeGridLayout(cards, gridColumns)

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -4,6 +4,8 @@ import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
 import { logger } from '@/lib/logger'
 
+const HTTP_NO_CONTENT = 204
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -328,7 +330,7 @@ function useConsoleCR<T extends { metadata: { name: string } }>(
       const response = await agentFetch(agentWriteURL('', { name }), {
         method: 'DELETE',
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-      if (response.ok || response.status === 204) {
+      if (response.ok || response.status === HTTP_NO_CONTENT) {
         // Optimistic update
         setItems(prev => prev.filter(i => i.metadata.name !== name))
         return true

--- a/web/src/hooks/useContextualNudges.ts
+++ b/web/src/hooks/useContextualNudges.ts
@@ -25,6 +25,8 @@ export type NudgeType = 'customize' | 'drag-hint' | 'pwa-install'
 const CUSTOMIZE_NUDGE_VISIT_THRESHOLD = 3
 /** Number of sessions before showing the PWA install nudge */
 const PWA_NUDGE_SESSION_THRESHOLD = 3
+/** Duration the drag-hint shimmy animation plays before auto-hiding */
+const SHIMMY_DURATION_MS = 2000
 
 interface NudgeState {
   /** Which nudge (if any) should currently be shown */
@@ -82,7 +84,6 @@ export function useContextualNudges(hasCustomizedDashboard: boolean): NudgeState
       setShowDragHint(true)
       safeSetItem(STORAGE_KEY_DRAG_HINT_SHOWN, 'true')
       // Auto-hide shimmy after animation completes
-      const SHIMMY_DURATION_MS = 2000
       const timer = setTimeout(() => setShowDragHint(false), SHIMMY_DURATION_MS)
       return () => clearTimeout(timer)
     }

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -80,7 +80,7 @@ const SETTINGS_KEY = 'kubestellar-token-settings'
 const CATEGORY_KEY = 'kubestellar-token-categories'
 const PERIOD_KEY = 'kubestellar-token-period'
 const SETTINGS_CHANGED_EVENT = 'kubestellar-token-settings-changed'
-const POLL_INTERVAL = 30000 // Poll every 30 seconds
+const POLL_INTERVAL_MS = 30_000 // Poll every 30 seconds
 const LOCAL_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' })
 
 const DEFAULT_SETTINGS = {
@@ -661,7 +661,7 @@ function startPolling() {
   fetchTokenUsage()
 
   // Poll at interval — store the ID so we can clean up when all subscribers leave
-  pollIntervalId = setInterval(fetchTokenUsage, POLL_INTERVAL)
+  pollIntervalId = setInterval(fetchTokenUsage, POLL_INTERVAL_MS)
 }
 
 // Stop singleton polling when no subscribers remain (prevents memory leaks)


### PR DESCRIPTION
Fixes #21442

Extracts magic numbers and hardcoded thresholds to named constants across 5 hook files:

- **useCardGridNavigation**: `12` → `DEFAULT_GRID_COLUMNS`
- **useContextualNudges**: hoists inline `SHIMMY_DURATION_MS = 2000` to module top
- **useBenchmarkData**: `503` → `HTTP_SERVICE_UNAVAILABLE`
- **useConsoleCRs**: `204` → `HTTP_NO_CONTENT`
- **useTokenUsage**: renames `POLL_INTERVAL` → `POLL_INTERVAL_MS` for consistency with codebase `_MS` suffix convention

All constants follow the existing pattern: module-top `const` declarations with descriptive names.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>