### PR TITLE
🐛 [scanner] fix: add BaseModal subcomponents to ReservationFormModal test mock

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -8,8 +8,8 @@ import type { GPUNode } from '../../../hooks/mcp/types.gpu'
 
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
-vi.mock('../../../lib/modals', () => ({
-  BaseModal: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
+vi.mock('../../../lib/modals', () => {
+  const BaseModal = ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
     <div
       data-testid="base-modal"
       onClick={onClose}
@@ -21,10 +21,22 @@ vi.mock('../../../lib/modals', () => ({
     >
       {children}
     </div>
-  ),
-  ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="confirm-dialog">{children}</div> : null,
-}))
+  )
+  BaseModal.Header = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="base-modal-header">{children}</div>
+  )
+  BaseModal.Content = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="base-modal-content">{children}</div>
+  )
+  BaseModal.Footer = ({ children }: { children?: React.ReactNode }) => (
+    <div data-testid="base-modal-footer">{children}</div>
+  )
+  return {
+    BaseModal,
+    ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+      open ? <div data-testid="confirm-dialog">{children}</div> : null,
+  }
+})
 
 vi.mock('../../../hooks/useMCP', () => ({
   useNamespaces: vi.fn(() => ({


### PR DESCRIPTION
Fixes #21462

The test mock for `BaseModal` only provided the top-level component, but the real `ReservationFormModal` uses `BaseModal.Header`, `BaseModal.Content`, and `BaseModal.Footer` subcomponents (compound component pattern). React evaluated these as `undefined`, producing:

```
Error: Element type is invalid: expected a string ... but got: undefined.
Check the render method of `ReservationFormModal`.
```

9 tests in `ReservationFormModal.test.tsx` failed for this reason, breaking the Coverage Suite on `main` and blocking every downstream PR from passing the Pre-Merge Build Gate.

Fix: attach `.Header`, `.Content`, `.Footer` to the mocked `BaseModal` function.