### PR TITLE
🐛 [scanner] fix: resolve nightly regression unit-test failures (#21083)

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -9,21 +9,40 @@ import type { GPUNode } from '../../../hooks/mcp/types.gpu'
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('../../../lib/modals', () => ({
-  BaseModal: ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
-    <div
-      data-testid="base-modal"
-      onClick={onClose}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') onClose()
-      }}
-    >
-      {children}
-    </div>
+  BaseModal: Object.assign(
+    ({ children, isOpen, onClose }: { children: React.ReactNode; isOpen: boolean; onClose: () => void }) =>
+      isOpen ? (
+        <div
+          data-testid="base-modal"
+          onClick={onClose}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') onClose()
+          }}
+        >
+          {children}
+        </div>
+      ) : null,
+    {
+      Header: ({ title, onClose }: { title: string; icon?: unknown; onClose?: () => void; showBack?: boolean }) => (
+        <div data-testid="modal-header">
+          <h2>{title}</h2>
+          {onClose && <button onClick={onClose} aria-label="close">×</button>}
+        </div>
+      ),
+      Content: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+        <div data-testid="modal-content" className={className}>
+          {children}
+        </div>
+      ),
+      Footer: ({ children }: { children: React.ReactNode }) => (
+        <div data-testid="modal-footer">{children}</div>
+      ),
+    },
   ),
-  ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-    open ? <div data-testid="confirm-dialog">{children}</div> : null,
+  ConfirmDialog: ({ isOpen, children }: { isOpen: boolean; children: React.ReactNode }) =>
+    isOpen ? <div data-testid="confirm-dialog">{children}</div> : null,
 }))
 
 vi.mock('../../../hooks/useMCP', () => ({


### PR DESCRIPTION
Fixes #21083

## Summary
Fixes the nightly unit-test regression by properly mocking BaseModal as a compound component in the ReservationFormModal test.

## Root Cause
The ReservationFormModal test was mocking BaseModal as a simple component, but the component uses it as a compound component with `BaseModal.Header`, `BaseModal.Content`, and `BaseModal.Footer` sub-components. This caused test failures when the component tried to access these sub-components.

## Changes
- Updated the BaseModal mock in `ReservationFormModal.test.tsx` to use `Object.assign()` pattern with Header, Content, and Footer sub-components
- Fixed ConfirmDialog mock prop from `open` to `isOpen` to match the actual interface

## Testing
The fix follows the same compound component mock pattern used in other test files (DeployConfirmDialog, ConfirmMissionPromptDialog, SaveResolutionDialog, SubmitToKBDialog).