### PR TITLE
🐛 [scanner] fix: resolve Coverage Suite test failure from run #4406

### DIFF
--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -28,7 +28,7 @@ vi.mock('../NamespaceCard', () => ({
   }) => (
     <div data-testid="namespace-card" onClick={onSelect}>
       <span>{namespace.name}</span>
-      {onDelete && <button onClick={(e) => { e.stopPropagation(); onDelete() }} title="Delete namespace">Delete Icon</button>}
+      {onDelete && <button onClick={(e) => { e.stopPropagation(); onDelete() }} title="Delete namespace" aria-label="Delete namespace">Delete Icon</button>}
     </div>
   ),
   NamespaceCardSkeleton: () => <div data-testid="namespace-skeleton">Loading...</div>,


### PR DESCRIPTION
Closing as duplicate of #21461, which fixes the same file with a cleaner approach (aria-label alone, no redundant title+text content). #21461 also closes #21462 via the CI re-run once merged.