### PR TITLE
🐛 [scanner] fix: honor isOpen and title prop in ReservationFormModal test mock

### DIFF
--- a/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.test.tsx
@@ -9,21 +9,35 @@ import type { GPUNode } from '../../../hooks/mcp/types.gpu'
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 vi.mock('../../../lib/modals', () => {
-  const BaseModal = ({ children, onClose }: { children: React.ReactNode; onClose: () => void }) => (
-    <div
-      data-testid="base-modal"
-      onClick={onClose}
-      role="button"
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') onClose()
-      }}
-    >
+  const BaseModal = ({
+    isOpen,
+    children,
+    onClose,
+  }: {
+    isOpen?: boolean
+    children: React.ReactNode
+    onClose: () => void
+  }) => {
+    if (isOpen === false) return null
+    return (
+      <div
+        data-testid="base-modal"
+        onClick={onClose}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') onClose()
+        }}
+      >
+        {children}
+      </div>
+    )
+  }
+  BaseModal.Header = ({ title, children }: { title?: React.ReactNode; children?: React.ReactNode }) => (
+    <div data-testid="base-modal-header">
+      {title}
       {children}
     </div>
-  )
-  BaseModal.Header = ({ children }: { children?: React.ReactNode }) => (
-    <div data-testid="base-modal-header">{children}</div>
   )
   BaseModal.Content = ({ children }: { children?: React.ReactNode }) => (
     <div data-testid="base-modal-content">{children}</div>
@@ -33,8 +47,8 @@ vi.mock('../../../lib/modals', () => {
   )
   return {
     BaseModal,
-    ConfirmDialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
-      open ? <div data-testid="confirm-dialog">{children}</div> : null,
+    ConfirmDialog: ({ isOpen, children }: { isOpen?: boolean; children?: React.ReactNode }) =>
+      isOpen ? <div data-testid="confirm-dialog">{children}</div> : null,
   }
 })
 


### PR DESCRIPTION
Restores build-gate on `main`. PR #21464 added the `BaseModal` subcomponents to the test mock, but 3 tests still fail on every PR because:

1. The `BaseModal` mock does not honor the `isOpen` prop, so it renders even when `isOpen` is `false`.
2. `BaseModal.Header` receives its title via a `title` prop, but the mock only rendered `children`.

This PR:

- Makes the `BaseModal` mock return `null` when `isOpen === false`.
- Renders both the `title` prop and `children` in the `BaseModal.Header` mock.
- Aligns the `ConfirmDialog` mock with the `isOpen` prop actually used by `ReservationFormModal` (was previously `open`, which never rendered).

Fixes the following failures observed on #21460 and #21461 (and every open PR):

```
FAIL  src/components/gpu/__tests__/ReservationFormModal.test.tsx > ReservationFormModal > does not render when isOpen is false
FAIL  src/components/gpu/__tests__/ReservationFormModal.test.tsx > ReservationFormModal > shows "Create Reservation" title when editingReservation is null
FAIL  src/components/gpu/__tests__/ReservationFormModal.test.tsx > ReservationFormModal > shows "Edit Reservation" title when editingReservation is provided
```

Test-only change; no runtime code touched.