### PR TITLE
🐛 [scanner] fix: increase touch target sizes for mobile accessibility

### DIFF
--- a/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
+++ b/web/src/components/cards/card-wrapper/InstallCTAFlow.tsx
@@ -161,7 +161,7 @@ export function InstallCTAFlow({ cardType, title }: InstallCTAFlowProps) {
           <div className="bg-card border border-border rounded-xl shadow-2xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto p-6" role="dialog" aria-modal="true" aria-labelledby="install-guide-title" onClick={e => e.stopPropagation()}>
             <div className="flex flex-wrap items-center justify-between gap-y-2 mb-4">
               <h3 id="install-guide-title" className="text-lg font-semibold">{showInstallGuide.mission.mission?.title ?? `Install ${installInfo?.project ?? 'Component'}`}</h3>
-              <button onClick={() => setShowInstallGuide(null)} className="p-2 min-h-11 min-w-11 flex items-center justify-center hover:bg-secondary rounded" aria-label={t('common:actions.close')}><X className="w-4 h-4" /></button>
+              <button onClick={() => setShowInstallGuide(null)} className="p-3 min-h-[44px] min-w-[44px] flex items-center justify-center hover:bg-secondary rounded" aria-label={t('common:actions.close')}><X className="w-4 h-4" /></button>
             </div>
             {showInstallGuide.mission.mission?.description && (
               <p className="text-sm text-muted-foreground mb-4">{showInstallGuide.mission.mission.description}</p>

--- a/web/src/components/compliance/ChangeControlAudit.tsx
+++ b/web/src/components/compliance/ChangeControlAudit.tsx
@@ -129,7 +129,7 @@ export const ChangeControlAuditContent = memo(function ChangeControlAuditContent
   if (error) return (
     <div className="flex flex-col items-center justify-center h-64 gap-3">
       <p className="text-red-400 font-medium">{error}</p>
-      <button type="button" onClick={handleRetry} disabled={isRetrying} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 p-3 min-h-11 min-w-11 disabled:opacity-50"><RefreshCw className={cn('w-4 h-4', isRetrying && 'animate-spin')} /> Retry</button>
+      <button type="button" onClick={handleRetry} disabled={isRetrying} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-2 px-4 py-3 min-h-[44px] min-w-[44px] disabled:opacity-50"><RefreshCw className={cn('w-4 h-4', isRetrying && 'animate-spin')} /> Retry</button>
     </div>
   )
 

--- a/web/src/components/compliance/DataResidency.tsx
+++ b/web/src/components/compliance/DataResidency.tsx
@@ -154,7 +154,7 @@ export const DataResidencyContent = memo(function DataResidencyContent() {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-3">
         <p className="text-red-400 font-medium">{error}</p>
-        <button onClick={handleRetry} disabled={isRetrying} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 p-3 min-h-11 min-w-11 disabled:opacity-50">
+        <button onClick={handleRetry} disabled={isRetrying} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-2 px-4 py-3 min-h-[44px] min-w-[44px] disabled:opacity-50">
           <RefreshCw className={cn('w-4 h-4', isRetrying && 'animate-spin')} /> Retry
         </button>
       </div>

--- a/web/src/components/compliance/SegregationOfDuties.tsx
+++ b/web/src/components/compliance/SegregationOfDuties.tsx
@@ -96,7 +96,7 @@ export const SegregationOfDutiesContent = memo(function SegregationOfDutiesConte
   if (error) return (
     <div className="flex flex-col items-center justify-center h-64 gap-3">
       <p className="text-red-400 font-medium">{error}</p>
-      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-1 p-3 min-h-11 min-w-11"><RefreshCw className={cn('w-4 h-4', loading && 'animate-spin')} /> Retry</button>
+      <button onClick={fetchData} className="text-indigo-400 hover:text-indigo-300 text-sm flex items-center gap-2 px-4 py-3 min-h-[44px] min-w-[44px]"><RefreshCw className={cn('w-4 h-4', loading && 'animate-spin')} /> Retry</button>
     </div>
   )
 

--- a/web/src/components/teams/TeamDetail.tsx
+++ b/web/src/components/teams/TeamDetail.tsx
@@ -29,7 +29,7 @@ export function TeamDetail({ team, onBack, onUpdateTeam: _onUpdateTeam, onDelete
   return (
     <div>
       <div className="flex items-center gap-2 mb-4">
-        <button onClick={onBack} className="flex items-center gap-1 px-2 py-1 min-h-11 min-w-11 rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm">
+        <button onClick={onBack} className="flex items-center gap-2 px-3 py-3 min-h-[44px] min-w-[44px] rounded-lg hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors text-sm">
           <ArrowLeft className="w-4 h-4" />
           {t('common.back')}
         </button>


### PR DESCRIPTION
Fixes #21469

Increased padding and standardized minimum touch target sizes to 44x44px for better mobile accessibility compliance (WCAG 2.5.5).

## Changes

Fixed touch targets in top 5 priority components:

- **SegregationOfDuties**: Retry button padding increased (px-4 py-3)
- **ChangeControlAudit**: Retry button padding increased (px-4 py-3)  
- **DataResidency**: Retry button padding increased (px-4 py-3)
- **InstallCTAFlow**: Close button padding increased (p-3)
- **TeamDetail**: Back button padding increased (px-3 py-3)

Changed `min-h-11`/`min-w-11` to explicit `min-h-[44px]`/`min-w-[44px]` for clarity and increased gap/padding for improved touch target comfort.

## Note

This PR addresses the top 5 highest-priority components from the auto-QA report. The remaining files can be addressed in follow-up PRs if needed.