### PR TITLE
🐛 [scanner] fix: address 4 test failures from Coverage Suite #4407

### DIFF
--- a/web/src/components/namespaces/NamespaceCard.tsx
+++ b/web/src/components/namespaces/NamespaceCard.tsx
@@ -61,6 +61,7 @@ export function NamespaceCard({ namespace, isSelected, onSelect, onDelete, isSys
           disabled={isDeleting}
           className="p-2 rounded text-muted-foreground hover:text-red-400 hover:bg-red-500/10 transition-colors opacity-0 group-hover:opacity-100 disabled:opacity-50 disabled:cursor-not-allowed"
           title="Delete namespace"
+          aria-label="Delete namespace"
         >
           {isDeleting
             ? <Loader2 className="w-4 h-4 animate-spin" />


### PR DESCRIPTION
Fixes #21467

Adds `aria-label="Delete namespace"` to the NamespaceCard delete button so the accessibility-oriented test can locate it. The other 3 test failures from Coverage Suite #4407 were addressed by #21468.