### PR TITLE
[scanner] fix: stop backup cron cancelling primary GA4 monitor run

### DIFF
--- a/.github/workflows/ga4-error-monitor.yml
+++ b/.github/workflows/ga4-error-monitor.yml
@@ -40,7 +40,7 @@ env:
 permissions: read-all  # default read; writes scoped to job below
 concurrency:
   group: ga4-error-monitor
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   monitor:


### PR DESCRIPTION
Fixes #21475

## Root Cause

The `ga4-error-monitor` workflow has two cron triggers (`:42` and `:49`) intended as primary + backup for runner-starvation resilience. With `cancel-in-progress: true`, the `:49` backup cron always cancelled the still-running `:42` primary job. GitHub reports a cancelled job as a workflow `failure`, which caused the workflow-failure monitor to file issue #21475 on every cycle.

## Fix

Change `cancel-in-progress` from `true` to `false` so both the primary and backup runs can complete without interrupting each other. The existing issue-deduplication logic in the script already prevents duplicate GA4 issues from being created when runs overlap.

## Change

`.github/workflows/ga4-error-monitor.yml`:
```diff
 concurrency:
   group: ga4-error-monitor
-  cancel-in-progress: true
+  cancel-in-progress: false
```