### PR TITLE
[scanner] fix: patch brace-expansion vulnerability

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -5206,16 +5206,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {

--- a/web/package.json
+++ b/web/package.json
@@ -167,6 +167,7 @@
     "form-data": ">=4.0.6",
     "@opentelemetry/core": ">=2.8.0",
     "@babel/core": "^7.29.6",
-    "react-router": "^8.3.0"
+    "react-router": "^8.3.0",
+    "brace-expansion": ">=5.0.8"
   }
 }


### PR DESCRIPTION
Fixes #21480

Add `brace-expansion>=5.0.8` to npm overrides to address GHSA-mh99-v99m-4gvg (CVE-2026-14257). Regenerated `package-lock.json` resolves to 5.0.8.