### PR TITLE
[scanner] fix: optional chaining and focused component pattern fixes

### DIFF
--- a/web/src/components/namespaces/NamespaceManager.tsx
+++ b/web/src/components/namespaces/NamespaceManager.tsx
@@ -189,9 +189,7 @@ export function NamespaceManager() {
         <div className="mb-4 p-3 rounded-lg bg-red-500/20 border border-red-500/50 text-red-400 flex items-center gap-2">
           <AlertTriangle className="w-4 h-4" />
           {error}
-          <button aria-label={t('actions.dismiss')} onClick={() => setError(null)} className="ml-auto">
-            <X className="w-4 h-4" />
-          </button>
+          <Button variant="ghost" size="sm" aria-label={t('actions.dismiss')} onClick={() => setError(null)} icon={<X className="w-4 h-4" />} className="ml-auto" />
         </div>
       )}
 

--- a/web/src/hooks/useDrillDown.actions.test.tsx
+++ b/web/src/hooks/useDrillDown.actions.test.tsx
@@ -61,7 +61,7 @@ describe('useDrillDownActions', () => {
 
       act(() => { result.current.actions.drillToCluster('ctx/prod-cluster') })
 
-      expect(result.current.drillDown.state.isOpen).toBe(true)
+      expect(result.current.drillDown.state?.isOpen).toBe(true)
       expect(result.current.drillDown.state.currentView?.type).toBe('cluster')
       expect(result.current.drillDown.state.currentView?.title).toBe('prod-cluster')
       expect(result.current.drillDown.state.currentView?.data.cluster).toBe('ctx/prod-cluster')


### PR DESCRIPTION
Fixes #21484
Fixes #21485

## Changes

Focused fixes for Auto-QA findings:

### #21485 — Optional chaining for safe property access
- `web/src/hooks/useDrillDown.actions.test.tsx`: Changed `result.current.drillDown.state.isOpen` → `result.current.drillDown.state?.isOpen` to guard against potential `Cannot read property of undefined` errors.

### #21484 — Component pattern consistency
- `web/src/components/namespaces/NamespaceManager.tsx`: Replaced the raw `<button>` dismiss element in the error banner with `<Button variant="ghost" size="sm">` (Button component already imported) for consistent component usage.

> ℹ️ Other raw `<button>` instances in `GrantAccessModal.tsx` (dropdown list items, overlay) and `NamespaceFilterBar.tsx` (segmented control) were intentionally left as-is — they use styling patterns that don't map cleanly to the shared Button component variants and would require non-trivial rework.