### PR TITLE
[scanner] fix: add stale-data freshness indicators to key cards

### DIFF
--- a/web/src/components/cards/EtcdStatus.tsx
+++ b/web/src/components/cards/EtcdStatus.tsx
@@ -78,7 +78,7 @@ function isManagedCluster(allPods: PodInfo[], cluster: string): boolean {
 export function EtcdStatus() {
   const { t } = useTranslation('cards')
   // Fetch from all namespaces so we catch etcd pods outside kube-system
-  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures } = useCachedPods()
+  const { pods, isLoading, isRefreshing, isDemoFallback, isFailed, consecutiveFailures, lastRefresh } = useCachedPods()
   const hasData = pods.length > 0
   const { showSkeleton } = useCardLoadingState({
     isLoading: isLoading && !hasData,
@@ -86,7 +86,9 @@ export function EtcdStatus() {
     hasAnyData: hasData,
     isDemoData: isDemoFallback,
     isFailed,
-    consecutiveFailures })
+    consecutiveFailures,
+    lastRefresh,
+  })
 
   const etcdPods = pods.filter(isEtcdPod)
 

--- a/web/src/components/cards/KagentAgentListCard.tsx
+++ b/web/src/components/cards/KagentAgentListCard.tsx
@@ -77,6 +77,7 @@ export function KagentAgentListCard({ config }: KagentAgentListCardProps) {
     isRefreshing,
     isDemoFallback,
     consecutiveFailures,
+    lastRefresh,
   } = useCachedKagentStatus()
 
   const hasAnyData = data.totalAgents > 0
@@ -87,6 +88,7 @@ export function KagentAgentListCard({ config }: KagentAgentListCardProps) {
     isFailed: consecutiveFailures >= FAILURE_THRESHOLD,
     consecutiveFailures,
     isDemoData: isDemoFallback,
+    lastRefresh,
   })
 
   // Filter clusters if config specifies one

--- a/web/src/components/cards/PodIssues.tsx
+++ b/web/src/components/cards/PodIssues.tsx
@@ -43,6 +43,7 @@ export function PodIssues() {
     isDemoFallback,
     isFailed,
     consecutiveFailures,
+    lastRefresh,
     error
   } = useCachedPodIssues()
 
@@ -57,6 +58,7 @@ export function PodIssues() {
     hasAnyData: hasData,
     isFailed,
     consecutiveFailures,
+    lastRefresh,
   })
   const { drillToPod } = useDrillDownActions()
 


### PR DESCRIPTION
Fixes #21490

## Summary

Passes `lastRefresh` from cached data hooks into `useCardLoadingState` for three key production cards that were missing freshness indicators:

- **EtcdStatus**: `useCachedPods` already returned `lastRefresh`; now forwarded to `useCardLoadingState`
- **KagentAgentListCard**: `useCachedKagentStatus` already returned `lastRefresh`; now forwarded
- **PodIssues**: `useCachedPodIssues` already returned `lastRefresh`; now forwarded

`useCardLoadingState` converts the epoch-ms timestamp to a `Date`, reports it via `useReportCardDataState`, and the `CardWrapper` header renders "Updated X ago" — consistent with the existing pattern used by `AppStatus`, `ChartVersions`, `ClusterHealth`, and others.

## Changes

3 files, 8 lines changed (purely additive — no logic altered).

## Risk

Low. No data-fetching logic changed. The `lastRefresh` value already existed in each hook return; it was simply not forwarded. `useCardLoadingState` already handles `lastRefresh` gracefully (null-safe).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>