### PR TITLE
🐛 Fix Ref type incompatibility in KagentiLifecycleManager

### DIFF
--- a/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
+++ b/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import {
   Activity, ArrowRight, Bot, Hammer,
   Server,
+  type LucideIcon,
 } from 'lucide-react'
 import { useKagentiAgents, useKagentiBuilds } from '../../../hooks/useMCP'
 import { useCardLoadingState } from '../CardDataContext'
@@ -54,7 +55,7 @@ function LifecycleSummaryBar({
   colorMap,
 }: {
   label: string
-  icon: typeof Bot
+  icon: LucideIcon
   states: readonly string[]
   counts: Record<string, number>
   colorMap: Record<string, { bg: string; text: string; border: string }>


### PR DESCRIPTION
Fix the TypeScript build error: 'Ref<SVGSVGElement>' is not assignable to 'Ref<HTMLDivElement>'.

Replace incorrect 'typeof Bot' type annotation with 'LucideIcon' type. The 'typeof Bot' syntax doesn't properly express that the icon prop should accept any LucideIcon component. Using the explicit 'LucideIcon' type from lucide-react resolves the type checking error while maintaining correct component typing.