### PR TITLE
[scanner] fix: properly type Lucide icon component props

### DIFF
--- a/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
+++ b/web/src/components/cards/kagenti/KagentiLifecycleManager.tsx
@@ -54,7 +54,7 @@ function LifecycleSummaryBar({
   colorMap,
 }: {
   label: string
-  icon: typeof Bot
+  icon: React.ComponentType<{ className?: string }>
   states: readonly string[]
   counts: Record<string, number>
   colorMap: Record<string, { bg: string; text: string; border: string }>

--- a/web/src/components/layout/navbar/SearchResultsPanel.tsx
+++ b/web/src/components/layout/navbar/SearchResultsPanel.tsx
@@ -5,7 +5,7 @@ import { useSearchIndex, CATEGORY_ORDER, type SearchCategory, type SearchItem } 
 
 const RESULT_TYPE_CHIP_CLASS = 'inline-flex shrink-0 items-center rounded-full border border-border bg-secondary px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-foreground'
 
-const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: typeof Bot }> = {
+const CATEGORY_CONFIG: Record<SearchCategory, { label: string; icon: React.ComponentType<{ className?: string }> }> = {
   page: { label: 'Dashboards', icon: (props) => <div {...props}>📊</div> },
   card: { label: 'Cards', icon: (props) => <div {...props}>🎴</div> },
   stat: { label: 'Stats', icon: (props) => <div {...props}>📈</div> },


### PR DESCRIPTION
Fixes #21516

Resolves TypeScript build errors related to Lucide icon type incompatibilities. The issue was that using 'typeof Bot' and 'LucideIcon' type directly doesn't work when passing components as props. Found and applied the correct pattern for accepting icon components.

**Changes:**
- KagentiLifecycleManager.tsx: Changed `icon: typeof Bot` to `icon: React.ComponentType<{ className?: string }>`
- SearchResultsPanel.tsx: Changed `icon: typeof Bot` to `icon: React.ComponentType<{ className?: string }>`

This matches the established pattern used throughout the codebase in components like EPPHealth, EnterpriseComplianceCards, KagentStatusCard, etc.