### PR TITLE
[quality] test: 24 unit tests for matchInstallIntent (Refs #21526)

### DIFF
--- a/web/src/lib/missions/__tests__/intentMatcher.test.ts
+++ b/web/src/lib/missions/__tests__/intentMatcher.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from 'vitest'
+import { matchInstallIntent } from '../intentMatcher'
+import type { MissionExport } from '../types'
+
+function mission(overrides: Partial<MissionExport> = {}): MissionExport {
+  return {
+    version: 'kc-mission-v1',
+    title: 'Example',
+    description: '',
+    type: 'deploy',
+    tags: [],
+    steps: [{ title: 'Step 1', description: '' }],
+    ...overrides,
+  }
+}
+
+const opa = mission({
+  name: 'install-open-policy-agent-opa',
+  title: 'Install Open Policy Agent',
+  cncfProject: 'opa',
+  tags: ['policy', 'admission'],
+})
+
+const cilium = mission({
+  name: 'install-cilium',
+  title: 'Install Cilium CNI',
+  cncfProject: 'cilium',
+  tags: ['cni', 'networking'],
+})
+
+const argo = mission({
+  name: 'install-argo-cd',
+  title: 'Install Argo CD',
+  cncfProject: 'argo-cd',
+  tags: ['gitops'],
+})
+
+const installers = [opa, cilium, argo]
+
+describe('matchInstallIntent — no intent detected', () => {
+  it('returns null for empty prompt', () => {
+    expect(matchInstallIntent('', installers)).toBeNull()
+  })
+
+  it('returns null for prompt without install verb', () => {
+    expect(matchInstallIntent('what is cilium?', installers)).toBeNull()
+  })
+
+  it('returns null when install verb has no target', () => {
+    expect(matchInstallIntent('install', installers)).toBeNull()
+    expect(matchInstallIntent('please install', installers)).toBeNull()
+  })
+
+  it('returns null when target slugifies to empty (only punctuation)', () => {
+    expect(matchInstallIntent('install ???', installers)).toBeNull()
+  })
+})
+
+describe('matchInstallIntent — verb variants', () => {
+  it.each([
+    ['install cilium'],
+    ['set up cilium'],
+    ['deploy cilium'],
+    ['provision cilium'],
+    ['add cilium'],
+  ])('recognizes verb in %s', (prompt) => {
+    expect(matchInstallIntent(prompt, installers)).toBe(cilium)
+  })
+
+  it('is case-insensitive on the verb', () => {
+    expect(matchInstallIntent('INSTALL cilium', installers)).toBe(cilium)
+    expect(matchInstallIntent('Deploy Cilium', installers)).toBe(cilium)
+  })
+
+  it('accepts a "please" politeness prefix before the verb', () => {
+    expect(matchInstallIntent('please install cilium', installers)).toBe(cilium)
+  })
+})
+
+describe('matchInstallIntent — target normalization', () => {
+  it('strips trailing punctuation from the target', () => {
+    expect(matchInstallIntent('install cilium?', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium!!!', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium.', installers)).toBe(cilium)
+  })
+
+  it('strips a trailing "please"', () => {
+    expect(matchInstallIntent('install cilium please', installers)).toBe(cilium)
+  })
+
+  it('strips leading article the/a/an', () => {
+    expect(matchInstallIntent('install the cilium', installers)).toBe(cilium)
+    expect(matchInstallIntent('install a cilium', installers)).toBe(cilium)
+    expect(matchInstallIntent('install an argo cd', installers)).toBe(argo)
+  })
+
+  it('splits on trailing context words (on/in/to/for/with/using/via)', () => {
+    expect(matchInstallIntent('install cilium on my cluster', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium in kind', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium to prod', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium for testing', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium with helm', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium using helm', installers)).toBe(cilium)
+    expect(matchInstallIntent('install cilium via helm', installers)).toBe(cilium)
+  })
+
+  it('slugifies multi-word targets to install-<hyphen-joined>', () => {
+    expect(matchInstallIntent('install argo cd', installers)).toBe(argo)
+    expect(matchInstallIntent('install Argo CD please', installers)).toBe(argo)
+  })
+})
+
+describe('matchInstallIntent — candidate resolution order', () => {
+  it('prefers exact install-<slug> name match', () => {
+    // "install open policy agent opa" → slug "open-policy-agent-opa"
+    // → prefixed "install-open-policy-agent-opa" matches opa.name exactly.
+    expect(matchInstallIntent('install open policy agent opa', installers)).toBe(opa)
+  })
+
+  it('falls back to cncfProject exact-slug match when no name match', () => {
+    // slug "opa": no installer has name "install-opa" in this list,
+    // but the first installer has cncfProject === "opa".
+    const noNameMatch = [
+      mission({ name: 'install-something-else', title: 'Other', cncfProject: 'opa' }),
+    ]
+    expect(matchInstallIntent('install opa', noNameMatch)).toBe(noNameMatch[0])
+  })
+
+  it('falls back to title substring match after cncfProject fails', () => {
+    const list = [
+      mission({ name: 'install-foo', title: 'Install Bar Baz', cncfProject: 'foo' }),
+    ]
+    // slug "baz" is not "install-foo" (name) or "foo" (cncfProject),
+    // but title slug "install-bar-baz" contains "baz".
+    expect(matchInstallIntent('install baz', list)).toBe(list[0])
+  })
+
+  it('falls back to token match (candidate term contains query slug)', () => {
+    const list = [
+      mission({
+        name: 'install-something',
+        title: 'Something',
+        cncfProject: 'something',
+        tags: ['observability-stack'],
+      }),
+    ]
+    // slug "observability" → tag term "observability-stack" contains it
+    expect(matchInstallIntent('install observability', list)).toBe(list[0])
+  })
+
+  it('falls back to token match (query slug contains candidate term)', () => {
+    const list = [
+      mission({
+        name: 'install-something',
+        title: 'Something',
+        cncfProject: 'something',
+        tags: ['obs'],
+      }),
+    ]
+    // slug "observability" contains tag term "obs"
+    expect(matchInstallIntent('install observability', list)).toBe(list[0])
+  })
+
+  it('returns null when nothing matches at any tier', () => {
+    expect(matchInstallIntent('install nonexistent-project', installers)).toBeNull()
+  })
+})
+
+describe('matchInstallIntent — degenerate inputs', () => {
+  it('handles empty installers array', () => {
+    expect(matchInstallIntent('install cilium', [])).toBeNull()
+  })
+
+  it('handles nullish installers via the `|| []` fallback', () => {
+    // Bypass the type signature — the runtime guard exists specifically
+    // for this case (callers may pass `undefined` before the KB has loaded).
+    expect(matchInstallIntent('install cilium', undefined as unknown as MissionExport[])).toBeNull()
+    expect(matchInstallIntent('install cilium', null as unknown as MissionExport[])).toBeNull()
+  })
+
+  it('tolerates missions with missing optional fields (no crash)', () => {
+    const sparse = mission({
+      name: undefined,
+      title: '',
+      cncfProject: undefined,
+      tags: undefined,
+    })
+    // Sparse installer produces only empty search terms — falls through to null.
+    expect(matchInstallIntent('install cilium', [sparse])).toBeNull()
+  })
+
+  it('returns null when the target has no matching candidate', () => {
+    // "install the" extracts slug "the" (the leading-article regex only
+    // strips "the " with trailing whitespace, so a bare "the" survives).
+    // None of the installers match "the" at any tier → null.
+    expect(matchInstallIntent('install the', installers)).toBeNull()
+  })
+})
+
+describe('matchInstallIntent — verb boundary', () => {
+  it('does not treat "uninstall" or "reinstall" as install verbs', () => {
+    // The regex prefix `(?:^|\b)` requires the verb to start at a word
+    // boundary. In "uninstall"/"reinstall" the 'i' of install has no
+    // preceding boundary (u/r and i are both word chars), so no match.
+    expect(matchInstallIntent('uninstall cilium', installers)).toBeNull()
+    expect(matchInstallIntent('reinstall cilium', installers)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds **24 unit tests** for `matchInstallIntent` in `web/src/lib/missions/intentMatcher.ts` — a previously **zero-coverage** pure function that maps natural-language install prompts (e.g. "install cilium via helm") to a matching `MissionExport` from the console-kb installer list.

### Test file: `web/src/lib/missions/__tests__/intentMatcher.test.ts`

### Coverage

| Group | Tests | What's verified |
|---|---|---|
| **No intent detected** | 4 | empty prompt / no install verb / verb-with-no-target / target that slugifies to empty (`install ???`) — all return `null`. |
| **Verb variants** | 5+2 | `install`, `set up`, `deploy`, `provision`, `add` are each recognized. Verb is case-insensitive; `please <verb>` politeness prefix is stripped. |
| **Target normalization** | 5 | Trailing punctuation (`?`, `!`, `.`), trailing `please`, leading article (`the`/`a`/`an` + whitespace), trailing context words (`on`/`in`/`to`/`for`/`with`/`using`/`via`), and multi-word → hyphen slug conversion. |
| **Candidate resolution order** | 6 | Exact `install-<slug>` name match wins; falls back to `cncfProject` exact match, then `title` substring match, then bidirectional token match; returns `null` when nothing matches. |
| **Degenerate inputs** | 4 | Empty installers array, `undefined`/`null` installers (the `\|\| []` runtime fallback for uninitialised KB), sparse mission with all optional fields omitted, and the "slug survives but no match" path (`install the`). |
| **Verb boundary** | 1 (2 asserts) | `uninstall cilium` and `reinstall cilium` correctly return `null` — the regex prefix `(?:^\|\b)` prevents matching `install` when it's a suffix of a larger word. |

All assertions were verified against the actual regex/slug behavior of the source file (executed the regexes with sample inputs in Node before committing) — no `expect`s guess at behavior; the two initially-wrong expectations (`install the` and `uninstall cilium`) were corrected after empirical verification.

### Relationship to #21526

Fresh coverage that isn't in the tracking issue's checklist but fits the same pattern used by #21590 and #21591: pick a pure, exported, previously-untested function from `web/src/lib/missions/` and lock in its behavior with a focused vitest file.

Test file follows the existing convention in `web/src/lib/missions/__tests__/` (see `matcher.test.ts`, `composer.test.ts`, `fileParser.test.ts`).

Refs #21526

---
*Filed by quality agent (ACMM L4/L6 — full mode)*