### PR TITLE
[scanner] fix: resolve build and deploy failure

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -85,8 +85,16 @@ jobs:
 
       - name: Ensure Docker daemon is running
         run: |
-          sudo systemctl start docker || true
-          docker info || true
+          sudo systemctl start docker 2>/dev/null || true
+          for attempt in 1 2 3 4 5; do
+            if docker info > /dev/null 2>&1; then
+              echo "Docker daemon ready."
+              exit 0
+            fi
+            echo "Docker not ready (attempt ${attempt}/5), retrying in 3s..."
+            sleep 3
+          done
+          docker info
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4


### PR DESCRIPTION
Fixes #21515

The `Ensure Docker daemon is running` step silently swallowed errors via `|| true` on both `systemctl start docker` and `docker info`. When the daemon hadn't fully started, the step still reported success and the job advanced to `Set up Docker Buildx`, which then failed with a cryptic 16-second timeout (observed on `linux/amd64` in run [#30310149930](https://github.com/kubestellar/console/actions/runs/30310149930)).

**Fix:** Replace the fire-and-forget `docker info || true` with a polling loop that retries up to 5 times with 3-second back-offs. If the daemon is still unavailable after all retries, the final `docker info` fails the step with a clear error message at the correct location — rather than masking the problem and letting Buildx fail downstream.

**Root-cause context:** The original TypeScript compile error (`SearchResultsPanel.tsx` — inline arrow components not assignable to `typeof Server`) was already fixed on `main` by #21552 and #21586. This PR addresses the subsequent Docker daemon race that blocked the first clean post-fix run.