### PR TITLE
[scanner] fix: resolve coverage suite failure

### DIFF
--- a/web/src/components/namespaces/__tests__/GrantAccessModal.test.tsx
+++ b/web/src/components/namespaces/__tests__/GrantAccessModal.test.tsx
@@ -180,8 +180,7 @@ describe('GrantAccessModal', () => {
       />
     )
 
-    const inputs = screen.getAllByRole('textbox')
-    const subjectInput = inputs[0]
+    const subjectInput = screen.getByPlaceholderText(/Select or type a user/i)
     const grantBtn = screen.getByRole('button', { name: /grant/i })
 
     await user.type(subjectInput, 'developer@example.com')


### PR DESCRIPTION
Fixes #21604

## Summary
- #21515 (Build and Deploy KC workflow failure) was already resolved and closed as completed prior to this PR — no code change needed here.
- #21604: the `GrantAccessModal successfully grants access with POST to kc-agent` test failed because the subject input gained an explicit `role="combobox"` for accessibility (#21598). `screen.getAllByRole('textbox')` no longer matches that input, so `inputs[0]` resolved to nothing and `user.type` threw.

## Fix
Switch the failing test to `screen.getByPlaceholderText(/Select or type a user/i)`, the same selector already used by the other tests in this file (`displays error when grant fails`, `shows discard confirmation...`, etc.).

## Verification
Ran the full test file locally with vitest — all 13 tests pass:
```
✓ src/components/namespaces/__tests__/GrantAccessModal.test.tsx (13 tests)
Test Files  1 passed (1)
Tests  13 passed (13)
```
