### PR TITLE
[scanner] fix: replace hardcoded colors and add dark-mode support

### DIFF
--- a/web/src/components/cards/GPUUsageTrend.tsx
+++ b/web/src/components/cards/GPUUsageTrend.tsx
@@ -22,6 +22,7 @@ import {
   CHART_AXIS_FONT_SIZE,
   CHART_BODY_FONT_SIZE,
   CHART_TEXT_MUTED } from '../../lib/constants'
+import { getChartColor, getChartColorRgba } from '../../lib/chartColors'
 import { MS_PER_MINUTE, MS_PER_HOUR } from '../../lib/constants/time'
 
 /**
@@ -370,11 +371,11 @@ const GPUUsageTrend = memo(function GPUUsageTrend() {
         stack: 'total',
         step: 'end' as const,
         data: history.map(d => d.allocated),
-        lineStyle: { color: '#9333ea', width: 2 },
-        itemStyle: { color: '#9333ea' },
+        lineStyle: { color: getChartColor(1), width: 2 },
+        itemStyle: { color: getChartColor(1) },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(147,51,234,0.6)' }, { offset: 1, color: 'rgba(147,51,234,0.1)' }] },
+            colorStops: [{ offset: 0, color: getChartColorRgba(1, 0.6) }, { offset: 1, color: getChartColorRgba(1, 0.1) }] },
         },
         showSymbol: false,
       },
@@ -384,11 +385,11 @@ const GPUUsageTrend = memo(function GPUUsageTrend() {
         stack: 'total',
         step: 'end' as const,
         data: history.map(d => d.free),
-        lineStyle: { color: '#22c55e', width: 2 },
-        itemStyle: { color: '#22c55e' },
+        lineStyle: { color: getChartColor(3), width: 2 },
+        itemStyle: { color: getChartColor(3) },
         areaStyle: {
           color: { type: 'linear', x: 0, y: 0, x2: 0, y2: 1,
-            colorStops: [{ offset: 0, color: 'rgba(34,197,94,0.6)' }, { offset: 1, color: 'rgba(34,197,94,0.1)' }] },
+            colorStops: [{ offset: 0, color: getChartColorRgba(3, 0.6) }, { offset: 1, color: getChartColorRgba(3, 0.1) }] },
         },
         showSymbol: false,
       },

--- a/web/src/components/cards/ResourceTrend.tsx
+++ b/web/src/components/cards/ResourceTrend.tsx
@@ -18,6 +18,7 @@ import {
   CHART_AXIS_FONT_SIZE,
   CHART_BODY_FONT_SIZE,
   CHART_TEXT_MUTED } from '../../lib/constants'
+import { getChartColor } from '../../lib/chartColors'
 import { useDemoMode } from '../../hooks/useDemoMode'
 
 interface ResourcePoint {
@@ -202,18 +203,18 @@ export const ResourceTrend = memo(function ResourceTrend() {
     switch (view) {
       case 'compute':
         return [
-          { dataKey: 'cpuCores', color: '#3b82f6', name: 'CPU Cores' },
-          { dataKey: 'memoryGB', color: '#22c55e', name: 'Memory (GB)' },
+          { dataKey: 'cpuCores', color: getChartColor(2), name: 'CPU Cores' },
+          { dataKey: 'memoryGB', color: getChartColor(3), name: 'Memory (GB)' },
         ]
       case 'workloads':
         return [
-          { dataKey: 'pods', color: '#9333ea', name: 'Pods' },
-          { dataKey: 'nodes', color: '#f59e0b', name: 'Nodes' },
+          { dataKey: 'pods', color: getChartColor(1), name: 'Pods' },
+          { dataKey: 'nodes', color: getChartColor(4), name: 'Nodes' },
         ]
       default:
         return [
-          { dataKey: 'cpuCores', color: '#3b82f6', name: 'CPU' },
-          { dataKey: 'pods', color: '#9333ea', name: 'Pods' },
+          { dataKey: 'cpuCores', color: getChartColor(2), name: 'CPU' },
+          { dataKey: 'pods', color: getChartColor(1), name: 'Pods' },
         ]
     }
   }, [view])

--- a/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
+++ b/web/src/components/cards/insights/ResourceImbalanceDetector.tsx
@@ -9,6 +9,7 @@ import { StatusBadge } from '../../ui/StatusBadge'
 import { CardControlsRow } from '../../../lib/cards/CardComponents'
 import { useInsightSort, INSIGHT_SORT_OPTIONS, type InsightSortField } from './insightSortUtils'
 import { CHART_GRID_STROKE, CHART_TOOLTIP_CONTENT_STYLE, CHART_TOOLTIP_FONT_SIZE_COMPACT, CHART_TICK_COLOR, CHART_HEIGHT_LG, CHART_TOOLTIP_TEXT_COLOR, CHART_AXIS_FONT_SIZE } from '../../../lib/constants/ui'
+import { getChartColor } from '../../../lib/chartColors'
 
 const GRID_LEFT_PX = 105
 const GRID_RIGHT_PX = 20
@@ -55,7 +56,7 @@ export function ResourceImbalanceDetector() {
         name: name.length > CHART_LABEL_MAX_LEN ? name.slice(0, CHART_LABEL_TRUNCATE_LEN) + '...' : name,
         fullName: name,
         value,
-        fill: value > OVERLOADED_THRESHOLD_PCT ? '#ef4444' : value < UNDERLOADED_THRESHOLD_PCT ? '#3b82f6' : '#22c55e' }))
+        fill: value > OVERLOADED_THRESHOLD_PCT ? getChartColor(5) : value < UNDERLOADED_THRESHOLD_PCT ? getChartColor(2) : getChartColor(3) }))
       .sort((a, b) => b.value - a.value)
   }, [imbalanceInsights, selectedClusters])
 
@@ -102,8 +103,8 @@ export function ResourceImbalanceDetector() {
           symbol: 'none',
           data: [{
             xAxis: avgValue,
-            label: { formatter: `Avg ${avgValue}%`, position: 'start', color: '#fbbf24', fontSize: CHART_AXIS_FONT_SIZE },
-            lineStyle: { color: '#fbbf24', type: 'dashed' },
+            label: { formatter: `Avg ${avgValue}%`, position: 'start', color: getChartColor(4), fontSize: CHART_AXIS_FONT_SIZE },
+            lineStyle: { color: getChartColor(4), type: 'dashed' },
           }],
         },
       }],

--- a/web/src/components/mission-control/BlueprintInfoPanels.tsx
+++ b/web/src/components/mission-control/BlueprintInfoPanels.tsx
@@ -30,7 +30,7 @@ import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 // ---------------------------------------------------------------------------
 
 export const STATUS_COLORS: Record<string, string> = {
-  pending: 'text-slate-500 dark:text-slate-400',
+  pending: 'text-muted-foreground',
   running: 'text-amber-600 dark:text-amber-400',
   completed: 'text-green-600 dark:text-green-400',
   failed: 'text-red-600 dark:text-red-400',
@@ -58,15 +58,15 @@ export function GaugeRow({ label, value, max, unit }: {
     : max != null ? `— / ${max}${unit ?? ''}` : 'N/A'
   const barColorClass = pctVal != null
     ? pctVal >= 80 ? 'bg-red-500' : pctVal >= 50 ? 'bg-amber-500' : 'bg-green-500'
-    : 'bg-slate-700 dark:bg-slate-600'
+    : 'bg-muted-foreground'
 
   return (
     <div className="space-y-1">
       <div className="flex items-center justify-between text-xs">
-        <span className="text-slate-500 dark:text-slate-400 font-medium">{label}</span>
+        <span className="text-muted-foreground font-medium">{label}</span>
         <span className="text-foreground tabular-nums">{display}{pctVal != null ? ` (${pctVal}%)` : ''}</span>
       </div>
-      <div className="h-1.5 rounded-full bg-slate-200 dark:bg-slate-800 overflow-hidden">
+      <div className="h-1.5 rounded-full bg-secondary overflow-hidden">
         {pctVal != null && (
           <div className={cn('h-full rounded-full transition-all', barColorClass)} style={{ width: `${pctVal}%` }} />
         )}
@@ -232,7 +232,7 @@ export function ProjectInfoPanel({ info, edges }: { info: ProjectHoverInfo; edge
       <div>
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-bold text-foreground pr-2">{info.displayName}</h3>
-          <div className={cn('text-[10px] font-semibold px-1.5 py-0.5 rounded whitespace-nowrap', info.installed ? 'text-green-600 dark:text-green-400 bg-green-500/10' : (STATUS_COLORS[info.status] ?? 'text-slate-500 dark:text-slate-400'))}>
+          <div className={cn('text-[10px] font-semibold px-1.5 py-0.5 rounded whitespace-nowrap', info.installed ? 'text-green-600 dark:text-green-400 bg-green-500/10' : (STATUS_COLORS[info.status] ?? 'text-muted-foreground'))}>
             {info.installed ? 'INSTALLED' : (STATUS_LABELS[info.status] ?? info.status.toUpperCase())}
           </div>
         </div>
@@ -339,7 +339,7 @@ export function ProjectInfoPanel({ info, edges }: { info: ProjectHoverInfo; edge
                 <div className="min-w-0">
                   <p className="text-xs font-medium text-foreground">{step.title || step.description?.slice(0, 60)}</p>
                   {step.command && (
-                    <pre className="text-[10px] text-emerald-600 dark:text-emerald-400 font-mono mt-0.5 bg-slate-100 dark:bg-slate-800 rounded px-1.5 py-0.5 overflow-x-auto whitespace-pre-wrap break-all">
+                    <pre className="text-[10px] text-emerald-600 dark:text-emerald-400 font-mono mt-0.5 bg-muted rounded px-1.5 py-0.5 overflow-x-auto whitespace-pre-wrap break-all">
                       {step.command}
                     </pre>
                   )}
@@ -392,19 +392,19 @@ export function ClusterInfoPanel({ info }: { info: ClusterHoverInfo }) {
         <h4 className="text-[10px] font-semibold text-muted-foreground uppercase tracking-wider mb-2">Capacity</h4>
         <div className="grid grid-cols-2 gap-x-4 gap-y-1 text-xs">
           <div className="flex justify-between">
-            <span className="text-slate-500 dark:text-slate-400"><TechnicalAcronym term="CPU">CPU</TechnicalAcronym></span>
+            <span className="text-muted-foreground"><TechnicalAcronym term="CPU">CPU</TechnicalAcronym></span>
             <span className="text-foreground tabular-nums">{fmtNum(info.cpuCores)} cores</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-slate-500 dark:text-slate-400">Memory</span>
+            <span className="text-muted-foreground">Memory</span>
             <span className="text-foreground tabular-nums">{fmtNum(info.memGB)} GB</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-slate-500 dark:text-slate-400">Storage</span>
+            <span className="text-muted-foreground">Storage</span>
             <span className="text-foreground tabular-nums">{fmtNum(info.storageGB)} GB</span>
           </div>
           <div className="flex justify-between">
-            <span className="text-slate-500 dark:text-slate-400"><TechnicalAcronym term="PVC">PVC</TechnicalAcronym></span>
+            <span className="text-muted-foreground"><TechnicalAcronym term="PVC">PVC</TechnicalAcronym></span>
             <span className="text-foreground tabular-nums">{info.pvcBoundCount ?? '?'}/{info.pvcCount ?? '?'}</span>
           </div>
         </div>
@@ -668,7 +668,7 @@ export function DeployModeInfoPanel({ mode, phases, projects, onShowProject, ins
                             </span>
                           )}
                           {!installedProjects.has(proj.name) && (
-                            <span className="text-[9px] ml-1 px-1 py-0.5 rounded bg-slate-500/10 text-slate-500 dark:text-slate-400">
+                            <span className="text-[9px] ml-1 px-1 py-0.5 rounded bg-slate-500/10 text-muted-foreground">
                               deploy
                             </span>
                           )}

--- a/web/src/lib/chartColors.ts
+++ b/web/src/lib/chartColors.ts
@@ -51,6 +51,25 @@ export function getChartColor(index: number): string {
 }
 
 /**
+ * Get a chart color by index (1-8) as an `rgba()` string with the given alpha.
+ *
+ * ECharts gradient `colorStops` need a color with an alpha channel, which the
+ * `--chart-color-*` tokens don't carry. This resolves the token and applies the
+ * alpha so gradients stay in sync with the theme instead of duplicating literal
+ * `rgba(...)` values in components.
+ */
+export function getChartColorRgba(index: number, alpha: number): string {
+  const color = getChartColor(index)
+  const hex = color.replace('#', '')
+  const expanded = hex.length === 3 ? hex.split('').map(c => c + c).join('') : hex
+  if (!/^[0-9a-fA-F]{6}$/.test(expanded)) return color
+  const r = parseInt(expanded.slice(0, 2), 16)
+  const g = parseInt(expanded.slice(2, 4), 16)
+  const b = parseInt(expanded.slice(4, 6), 16)
+  return `rgba(${r},${g},${b},${alpha})`
+}
+
+/**
  * Get chart color by semantic name
  */
 export function getChartColorByName(name: 'warning' | 'success' | 'error' | 'info' | 'primary'): string {

--- a/web/src/lib/constants/ui.ts
+++ b/web/src/lib/constants/ui.ts
@@ -78,7 +78,28 @@ export const CHART_THEME = {
   emphasis: {
     shadow: getCSSVar('--chart-emphasis-shadow') || 'rgba(0,0,0,0.5)',
   },
+  /**
+   * Series palette — mirrors the `--chart-color-1..8` design tokens in
+   * index.css (also overridden per-theme by ThemeContext).
+   *
+   * Prefer `getChartColor(n)` from `lib/chartColors` inside component render
+   * paths: it re-reads the CSS variable on each call so a theme switch is
+   * picked up, whereas this array is resolved once at module load.
+   */
+  series: [
+    getCSSVar('--chart-color-1') || '#9333ea',
+    getCSSVar('--chart-color-2') || '#3b82f6',
+    getCSSVar('--chart-color-3') || '#10b981',
+    getCSSVar('--chart-color-4') || '#f59e0b',
+    getCSSVar('--chart-color-5') || '#ef4444',
+    getCSSVar('--chart-color-6') || '#06b6d4',
+    getCSSVar('--chart-color-7') || '#8b5cf6',
+    getCSSVar('--chart-color-8') || '#14b8a6',
+  ],
 } as const
+
+/** Default ECharts series palette, sourced from the `--chart-color-*` tokens */
+export const CHART_SERIES_COLORS = CHART_THEME.series
 
 // ── Legacy exports (backward compatibility) ─────────────────────────────
 export const CHART_TOOLTIP_BG = CHART_THEME.tooltip.bg


### PR DESCRIPTION
## Summary

Addresses the Auto-QA findings in #21640 (hardcoded colors) and #21641 (missing dark-mode support) for the subset of flagged locations that are genuine bugs rather than intentional dynamic/brand colors.

### Changes
- **`GPUUsageTrend.tsx`**, **`ResourceTrend.tsx`**, **`ResourceImbalanceDetector.tsx`**: replaced hardcoded hex/`rgba()` chart colors with `getChartColor()` / new `getChartColorRgba()` design-token helpers, so chart series colors follow the theme's `--chart-color-*` CSS variables instead of being frozen at specific hex values.
- **`lib/chartColors.ts`**: added `getChartColorRgba(index, alpha)` — resolves a chart color token and returns it as an `rgba()` string with the given alpha, for use in ECharts gradient `colorStops` (which need an alpha channel the CSS var tokens don't carry).
- **`lib/constants/ui.ts`**: exposed `CHART_SERIES_COLORS`, a token-backed series palette array mirroring `--chart-color-1..8`.
- **`BlueprintInfoPanels.tsx`**: replaced several hardcoded `text-slate-500 dark:text-slate-400` / `bg-slate-200 dark:bg-slate-800` / `bg-slate-100 dark:bg-slate-800` pairs with the existing semantic tokens (`text-muted-foreground`, `bg-secondary`, `bg-muted`) already used elsewhere in the codebase, so these panels pick up theme changes automatically instead of needing manual light/dark pairs.

### Investigated but intentionally left unchanged
Several other locations flagged by Auto-QA are dynamic/brand colors, not hardcoded design-system bugs, and were left as-is to avoid visual regressions without manual verification:
- `MarketplaceCard.tsx` / `MarketplaceThumbnail.tsx`: `backgroundColor`/gradient driven by per-item theme/category data (arbitrary user or CNCF brand colors), not a static value.
- `RepoPicker.tsx`: hex badge colors are explicitly annotated `// ai-quality-ignore` — they must match shields.io's fixed named-color palette pixel-for-pixel.
- `SBOMDashboard.tsx`: `backgroundColor: d.color` is a per-legend-item dynamic color.
- `WeatherAnimation.tsx`: decorative day/night gradient animation; flagged in the earlier Hive digest (#20963) as visually-sensitive work pending the Visual Verification Protocol.
- `SIEMDashboard.tsx` / `ClusterReadinessCard.tsx`: the flagged lines only set inline `width` (progress bar percentage), the surrounding colors already use `bg-secondary` tokens.
- `RiskAppetiteDashboard.tsx`: uses a fixed dark palette (`gray-700`/`gray-800`) throughout by design; a full token migration is a larger, higher-risk change better suited to its own PR with visual review.

Fixes #21640
Fixes #21641

## Testing
Per task constraints, `npm run build`/`lint`/`tsc` were not run. Changes are limited to color-token substitutions and Tailwind class renames using already-established helpers/tokens (`getChartColor`, `text-muted-foreground`, `bg-secondary`, `bg-muted`) used elsewhere in the codebase.
