### PR TITLE
[scanner] fix: extract hardcoded user-facing strings

### DIFF
--- a/web/src/components/cards/AlertRules.test.tsx
+++ b/web/src/components/cards/AlertRules.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, act, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { AlertRulesCard } from './AlertRules'
 import type { AlertRule } from '../../types/alerts'
+import { BTN } from '../../test-utils/buttonLabels'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -53,7 +54,7 @@ vi.mock('../alerts/AlertRuleEditor', () => ({
     mockAlertRuleEditor(props)
     return (
       <div data-testid="alert-rule-editor">
-        <button onClick={() => props.onCancel()}>Cancel</button>
+        <button onClick={() => props.onCancel()}>{BTN.cancel}</button>
         <button
           onClick={() =>
             props.onSave({
@@ -91,7 +92,7 @@ vi.mock('../../lib/cards/CardComponents', () => ({
   }) =>
     needsPagination ? (
       <div data-testid="pagination" data-page={currentPage} data-total={totalPages}>
-        <button onClick={() => onPageChange(currentPage + 1)}>Next</button>
+        <button onClick={() => onPageChange(currentPage + 1)}>{BTN.next}</button>
       </div>
     ) : null,
 }))
@@ -371,7 +372,7 @@ describe('AlertRulesCard', () => {
       render(<AlertRulesCard />)
 
       await userEvent.click(screen.getByTitle('editRule'))
-      await userEvent.click(screen.getByText('Cancel'))
+      await userEvent.click(screen.getByText(BTN.cancel))
 
       expect(mockUpdateRule).not.toHaveBeenCalled()
       expect(screen.queryByTestId('alert-rule-editor')).not.toBeInTheDocument()

--- a/web/src/components/cards/CrossClusterPolicyComparison.test.tsx
+++ b/web/src/components/cards/CrossClusterPolicyComparison.test.tsx
@@ -12,6 +12,7 @@ import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { BTN } from '../../test-utils/buttonLabels'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -68,7 +69,7 @@ vi.mock('./kyverno/KyvernoDetailModal', () => ({
   KyvernoDetailModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
     isOpen ? (
       <div data-testid="kyverno-modal">
-        <button onClick={onClose}>Close</button>
+        <button onClick={onClose}>{BTN.close}</button>
       </div>
     ) : null,
 }))

--- a/web/src/components/cards/GitOpsDrift.test.tsx
+++ b/web/src/components/cards/GitOpsDrift.test.tsx
@@ -12,6 +12,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import type { GitOpsDrift as GitOpsDriftType } from '../../hooks/useMCP'
+import { BTN } from '../../test-utils/buttonLabels'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -88,7 +89,7 @@ vi.mock('./deploy/GitOpsDriftDetailModal', () => ({
   GitOpsDriftDetailModal: ({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) =>
     isOpen ? (
       <div data-testid="drift-modal">
-        <button onClick={onClose}>Close</button>
+        <button onClick={onClose}>{BTN.close}</button>
       </div>
     ) : null,
 }))
@@ -265,7 +266,7 @@ describe('GitOpsDrift', () => {
       const { GitOpsDrift } = await import('./GitOpsDrift')
       render(<GitOpsDrift />)
       await userEvent.click(screen.getByText('Deployment/app'))
-      await userEvent.click(screen.getByText('Close'))
+      await userEvent.click(screen.getByText(BTN.close))
       expect(screen.queryByTestId('drift-modal')).not.toBeInTheDocument()
     })
   })

--- a/web/src/components/cards/__tests__/DynamicCard.test.tsx
+++ b/web/src/components/cards/__tests__/DynamicCard.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, waitFor, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { DynamicCard, Tier1CardRuntime, Tier2CardRuntime } from '../DynamicCard'
 import type { DynamicCardDefinition, DynamicCardDefinition_T1 } from '../../../lib/dynamic-cards/types'
+import { BTN } from '../../../test-utils/buttonLabels'
 
 // ---------------------------------------------------------------------------
 // Mocks
@@ -83,7 +84,7 @@ vi.mock('../../ui/Pagination', () => ({
   }) => (
     <div data-testid="pagination">
       <span>Page {currentPage} of {totalPages}</span>
-      <button onClick={() => onPageChange(currentPage + 1)}>Next</button>
+      <button onClick={() => onPageChange(currentPage + 1)}>{BTN.next}</button>
     </div>
   ),
 }))

--- a/web/src/components/clusters/components/ClusterCardCompact.test.tsx
+++ b/web/src/components/clusters/components/ClusterCardCompact.test.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, fireEvent } from '@testing-library/react'
 import type { ClusterInfo } from '../../../hooks/useMCP'
+import { BTN } from '../../../test-utils/buttonLabels'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
@@ -33,7 +34,7 @@ vi.mock('../../ui/StatusBadge', () => ({
 }))
 
 vi.mock('./ClusterGrid.common', () => ({
-  RemoveClusterButton: () => <button data-testid="remove-cluster-button">Remove</button>,
+  RemoveClusterButton: () => <button data-testid="remove-cluster-button">{BTN.remove}</button>,
   handleCardKeyDown: (callback: () => void) => (event: React.KeyboardEvent) => {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()

--- a/web/src/lib/dashboards/__tests__/DashboardRuntime.test.tsx
+++ b/web/src/lib/dashboards/__tests__/DashboardRuntime.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
+import { BTN } from '../../../test-utils/buttonLabels'
 
 /**
  * Dashboard runtime tests.
@@ -117,7 +118,7 @@ vi.mock('../../../components/dashboard/TemplatesModal', () => ({
         >
           Apply
         </button>
-        <button data-testid="templates-close" onClick={onClose}>Close</button>
+        <button data-testid="templates-close" onClick={onClose}>{BTN.close}</button>
       </div>
     ) : null
   ),

--- a/web/src/test-utils/buttonLabels.ts
+++ b/web/src/test-utils/buttonLabels.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared button label constants for use in test mock components.
+ *
+ * These constants centralise user-facing strings that appear in test
+ * harness / mock implementations so that updates to copy only need to
+ * happen in one place.
+ */
+export const BTN = {
+  close: 'Close',
+  cancel: 'Cancel',
+  next: 'Next',
+  remove: 'Remove',
+} as const


### PR DESCRIPTION
Fixes #21691

## Summary

Creates `web/src/test-utils/buttonLabels.ts` with shared `BTN` constants (`close`, `cancel`, `next`, `remove`) and updates the six test files flagged in the issue to import and use those constants instead of inline string literals.

No production code or i18n system changes — all hardcoded strings were in test mock components.

**Files changed:**
- `web/src/test-utils/buttonLabels.ts` *(new)* — shared button label constants
- `web/src/components/cards/AlertRules.test.tsx` — `'Cancel'`, `'Next'`
- `web/src/components/cards/CrossClusterPolicyComparison.test.tsx` — `'Close'`
- `web/src/components/cards/GitOpsDrift.test.tsx` — `'Close'`
- `web/src/components/cards/__tests__/DynamicCard.test.tsx` — `'Next'`
- `web/src/components/clusters/components/ClusterCardCompact.test.tsx` — `'Remove'`
- `web/src/lib/dashboards/__tests__/DashboardRuntime.test.tsx` — `'Close'`