### PR TITLE
[scanner] fix: resolve pre-existing lint violations in ProviderKeyForm, SearchInput, VulnerabilitySummary

### DIFF
--- a/web/src/components/agent/ProviderKeyForm.tsx
+++ b/web/src/components/agent/ProviderKeyForm.tsx
@@ -3,6 +3,7 @@ import type { TFunction } from 'i18next'
 import { cn } from '../../lib/cn'
 import { AgentIcon } from './AgentIcon'
 import { PROVIDER_INFO, providerToIconMap, type KeyStatus } from './apiKeySettingsTypes'
+import { Input } from '../ui/Input'
 
 interface ProviderKeyFormProps {
   keyStatus: KeyStatus
@@ -121,7 +122,7 @@ export function ProviderKeyForm({
       {editingProvider === keyStatus.provider ? (
         <div className="mt-3 space-y-2">
           <div className="relative">
-            <input
+            <Input
               type={showKey ? 'text' : 'password'}
               value={newKeyValue}
               onChange={(e) => {
@@ -129,13 +130,13 @@ export function ProviderKeyForm({
                 onSetEditError(null)
               }}
               placeholder={PROVIDER_INFO[keyStatus.provider]?.placeholder || t('agent.enterApiKey')}
-              className="w-full px-3 py-2 pr-10 text-sm bg-background border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary"
+              className="px-3 py-2 pr-10 text-sm bg-background border-border focus:ring-1 focus:ring-primary"
               autoFocus
             />
             <button
               type="button"
               onClick={() => onSetShowKey(!showKey)}
-              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground"
+              className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-muted-foreground hover:text-foreground z-10"
             >
               {showKey ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
             </button>
@@ -216,13 +217,13 @@ export function ProviderKeyForm({
               <p className="text-xs text-muted-foreground">
                 {t('agent.baseUrlHint', 'Override the endpoint this provider talks to. Leave blank to use the compiled-in default. The {{env}} environment variable takes precedence when set.', { env: keyStatus.baseURLEnvVar })}
               </p>
-              <input
+              <Input
                 type="text"
                 value={baseURLDraft[keyStatus.provider] ?? ''}
                 onChange={(e) => onSetBaseURLDraft(keyStatus.provider, e.target.value)}
                 placeholder="http://<service>.<namespace>.svc.cluster.local:8080"
                 disabled={keyStatus.baseURLSource === 'env'}
-                className="w-full px-3 py-2 text-sm bg-background border border-border rounded-lg text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-1 focus:ring-primary disabled:opacity-50"
+                className="px-3 py-2 text-sm bg-background border-border focus:ring-1 focus:ring-primary"
               />
               {baseURLError[keyStatus.provider] && (
                 <p className="text-xs text-destructive flex items-center gap-1">

--- a/web/src/components/layout/navbar/SearchInput.tsx
+++ b/web/src/components/layout/navbar/SearchInput.tsx
@@ -1,6 +1,7 @@
 import { Search, Command } from 'lucide-react'
 import { useFeatureHints } from '../../../hooks/useFeatureHints'
 import { FeatureHintTooltip } from '../../ui/FeatureHintTooltip'
+import { Input } from '../../ui/Input'
 
 interface SearchInputProps {
   inputRef: React.RefObject<HTMLInputElement | null>
@@ -32,8 +33,8 @@ export function SearchInput({
   return (
     <>
       <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground" />
-      <input
-        ref={inputRef}
+      <Input
+        ref={inputRef as React.Ref<HTMLInputElement>}
         type="text"
         id="global-search"
         name="global-search"
@@ -52,7 +53,7 @@ export function SearchInput({
         }}
         onBlur={onBlur}
         placeholder={placeholder}
-        className="w-full pl-10 pr-16 py-2 bg-secondary rounded-lg text-sm text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500/50"
+        className="pl-10 pr-16 py-2 bg-secondary rounded-lg text-sm focus:ring-2 focus:ring-purple-500/50"
       />
       <kbd className="absolute right-3 top-1/2 -translate-y-1/2 hidden sm:flex items-center gap-1 px-1.5 py-0.5 text-xs text-muted-foreground bg-secondary rounded" aria-hidden="true">
         <Command className="w-3 h-3" /><span>K</span>

--- a/web/src/components/security/VulnerabilitySummary.tsx
+++ b/web/src/components/security/VulnerabilitySummary.tsx
@@ -87,8 +87,15 @@ export function VulnerabilitySummary({ securityCardsKey, defaultSecurityCards }:
     })
   }, [isDemoMode, cachedSecurityIssues])
 
-  const rbacBindings = isDemoMode ? getMockRBACData() : []
-  const complianceChecks = isDemoMode ? getMockComplianceData() : []
+  // Stable references: only recompute when isDemoMode changes
+  const rbacBindings = useMemo(
+    () => isDemoMode ? getMockRBACData() : [],
+    [isDemoMode]
+  )
+  const complianceChecks = useMemo(
+    () => isDemoMode ? getMockComplianceData() : [],
+    [isDemoMode]
+  )
 
   const globalFilteredIssues = useMemo(() => {
     let result = securityIssues


### PR DESCRIPTION
Pre-existing `no-restricted-syntax` and `react-hooks/exhaustive-deps` violations are blocking unrelated PR #21694. This fixes them on main directly.

## Violations fixed

### `no-restricted-syntax` — raw `<input>` elements
**Rule:** "Use `<Input>` from `components/ui/Input.tsx` instead of raw `<input>`."

- **`web/src/components/agent/ProviderKeyForm.tsx`**: two raw `<input>` elements (password field + base-URL field) replaced with `<Input>`. The show/hide toggle button is a sibling to `<Input>` within an outer `<div className="relative">`, so positioning is unaffected.
- **`web/src/components/layout/navbar/SearchInput.tsx`**: one raw `<input>` replaced with `<Input>`. Absolute-positioned `<Search>` icon and `<kbd>` are siblings in the React fragment and remain positioned relative to the parent container.

### `react-hooks/exhaustive-deps` — unstable inline array references
**Rule:** "The `X` conditional could make the dependencies of useMemo change on every render."

- **`web/src/components/security/VulnerabilitySummary.tsx`**: `rbacBindings` and `complianceChecks` were computed as inline ternary expressions (`isDemoMode ? getMockData() : []`) whose `[]` fallback creates a new array reference on every render, causing `filteredRBAC` and `filteredCompliance` useMemos to recompute unnecessarily. Fixed by wrapping both in their own `useMemo([isDemoMode])`.

## Behaviour unchanged
All logic, props, and rendering output are preserved. The `<Input>` component forwards all `InputHTMLAttributes`, accepts `ref`, and merges the custom `className` via tailwind-merge, so the visual appearance matches the original styling.

Closes the new-violation regression that would fail the lint-warning gate for new PRs targeting main.