### PR TITLE
[scanner] fix: split StatBlockFactoryModal and CustomDashboard

### DIFF
--- a/web/src/components/dashboard/CustomDashboard.tsx
+++ b/web/src/components/dashboard/CustomDashboard.tsx
@@ -1,7 +1,6 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { useParams, useNavigate, useLocation } from 'react-router-dom'
-import { GripVertical, Trash2, AlertTriangle } from 'lucide-react'
+import { Trash2 } from 'lucide-react'
 import {
   DndContext,
   closestCenter,
@@ -16,9 +15,7 @@ import {
   arrayMove,
   SortableContext,
   sortableKeyboardCoordinates,
-  useSortable,
   rectSortingStrategy } from '@dnd-kit/sortable'
-import { CSS } from '@dnd-kit/utilities'
 import { useTranslation } from 'react-i18next'
 import { api, BackendUnavailableError, UnauthenticatedError } from '../../lib/api'
 import { useDashboards, Dashboard } from '../../hooks/useDashboards'
@@ -27,9 +24,6 @@ import { useClusters } from '../../hooks/useMCP'
 import { useDrillDownActions } from '../../hooks/useDrillDown'
 import { useSidebarConfig } from '../../hooks/useSidebarConfig'
 import { useToast } from '../ui/Toast'
-import { CardWrapper } from '../cards/CardWrapper'
-import { CARD_COMPONENTS } from '../cards/cardRegistry'
-import { useCardCollapse } from '../../lib/cards/cardHooks'
 import { safeGetJSON, safeSetJSON, safeRemoveItem } from '../../lib/utils/localStorage'
 import { ROUTES } from '../../config/routes'
 import { AddCardModal } from './AddCardModal'
@@ -40,7 +34,6 @@ import { TemplatesModal } from './TemplatesModal'
 import { FloatingDashboardActions } from './FloatingDashboardActions'
 import { POLL_INTERVAL_MS } from '../../lib/constants/network'
 import { DashboardTemplate } from './templates'
-import { BaseModal } from '../../lib/modals'
 import { useModalState } from '../../lib/modals'
 import { formatCardTitle } from '../../lib/formatCardTitle'
 import { StatsOverview, StatBlockValue } from '../ui/StatsOverview'
@@ -50,185 +43,11 @@ import { DashboardHeader } from '../shared/DashboardHeader'
 import { DashboardHealthIndicator } from './DashboardHealthIndicator'
 import { useDashboardUndoRedo } from '../../hooks/useUndoRedo'
 import { setAutoRefreshPaused } from '../../lib/cache'
-
-interface Card {
-  id: string
-  card_type: string
-  config: Record<string, unknown>
-  position: { x: number; y: number; w: number; h: number }
-  title?: string
-}
-
-/** Clamp small cards in the md–lg range (768–1023px) for readability */
-const NARROW_MIN = 768
-const NARROW_MAX = 1023
-
-/** Minimum card column span at narrow viewports */
-const MIN_NARROW_COLS = 6
-
-/**
- * Minimum pixel height contributed by ONE row of card span. Effective
- * min-height = posH × this constant, so the "Resize height" menu has a
- * visible effect on `auto-rows-min` grids (#8289, #8298). Mirrors the
- * legacy `auto-rows-[minmax(180px,auto)]` baseline (180px per row).
- */
-const EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180
-
-/** Default row span when a card has no persisted position.h */
-const DEFAULT_CARD_ROW_SPAN = 2
-
-// Sortable card component
-interface SortableCardProps {
-  card: Card
-  onConfigure: () => void
-  onRemove: () => void
-  onWidthChange: (newWidth: number) => void
-  onHeightChange: (newHeight: number) => void
-  isDragging?: boolean
-  isRefreshing?: boolean
-  onRefresh?: () => void
-  lastUpdated?: Date | null
-  onInsertBefore?: () => void
-  onInsertAfter?: () => void
-}
-
-function SortableCard({ card, onConfigure, onRemove, onWidthChange, onHeightChange, isDragging, isRefreshing, onRefresh, lastUpdated, onInsertBefore: _onInsertBefore, onInsertAfter }: SortableCardProps) {
-  const { t } = useTranslation()
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: card.id })
-
-  // In the md–lg range (768–1023px), clamp small cards to min 6 cols
-  // so we get max 2 cards per row instead of cramped 3-up layout.
-  // Below 768px CSS already switches to a 1-column grid, so no clamping needed there.
-  const [isNarrowRange, setIsNarrowRange] = useState(() =>
-    typeof window !== 'undefined' &&
-    window.innerWidth >= NARROW_MIN &&
-    window.innerWidth <= NARROW_MAX
-  )
-  useEffect(() => {
-    const mq = window.matchMedia(`(min-width: ${NARROW_MIN}px) and (max-width: ${NARROW_MAX}px)`)
-    const handler = (e: MediaQueryListEvent) => setIsNarrowRange(e.matches)
-    if (mq.matches !== isNarrowRange) setIsNarrowRange(mq.matches)
-    mq.addEventListener('change', handler)
-    return () => mq.removeEventListener('change', handler)
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  const effectiveW = isNarrowRange && (card.position?.w || 4) < MIN_NARROW_COLS ? MIN_NARROW_COLS : (card.position?.w || 4)
-  const posH = card.position?.h || DEFAULT_CARD_ROW_SPAN
-
-  // Read collapse state so the cell can drop its minimum height when the
-  // card is collapsed (#6072). Without this, the grid leaves dead space
-  // under collapsed cards because every cell is forced to the expanded
-  // baseline height.
-  const { isCollapsed } = useCardCollapse(card.id)
-  const effectiveRowSpan = isCollapsed ? 1 : posH
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    gridColumn: `span ${effectiveW}`,
-    gridRow: `span ${effectiveRowSpan}`,
-    // Scale min-height by posH so the "Resize height" menu actually changes
-    // the card's visual height on an auto-rows-min grid (#8289, #8298).
-    minHeight: isCollapsed ? undefined : `${posH * EXPANDED_CARD_ROW_MIN_HEIGHT_PX}px`,
-    opacity: isDragging ? 0.5 : 1 }
-
-  const CardComponent = CARD_COMPONENTS[card.card_type]
-
-  if (!CardComponent) {
-    return (
-      <div ref={setNodeRef} style={style} className="relative group/card">
-        {onInsertAfter && (
-          <button
-            onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-            className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
-            aria-label="Add card"
-            title="Add card here"
-          >
-            +
-          </button>
-        )}
-        <CardWrapper
-          cardId={card.id}
-          cardType={card.card_type}
-          title={formatCardTitle(card.card_type)}
-          onConfigure={onConfigure}
-          onRemove={onRemove}
-          onWidthChange={onWidthChange}
-          onHeightChange={onHeightChange}
-          cardWidth={effectiveW}
-          cardHeight={card.position?.h || 2}
-          isRefreshing={isRefreshing}
-          onRefresh={onRefresh}
-          lastUpdated={lastUpdated}
-        >
-          <div className="flex items-center justify-center h-full text-muted-foreground">
-            {t('drilldown.unknownViewType')}: {card.card_type}
-          </div>
-        </CardWrapper>
-      </div>
-    )
-  }
-
-  return (
-    <div ref={setNodeRef} style={style} className="relative group/card">
-      {onInsertAfter && (
-        <button
-          onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
-          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
-          aria-label="Add card"
-          title="Add card here"
-        >
-          +
-        </button>
-      )}
-      {/* Drag handle */}
-      <div
-        {...attributes}
-        {...listeners}
-        className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-1 rounded cursor-grab active:cursor-grabbing opacity-0 hover:opacity-100 transition-opacity bg-secondary/80"
-      >
-        <GripVertical className="w-4 h-4 text-muted-foreground" />
-      </div>
-      <CardWrapper
-        cardId={card.id}
-        cardType={card.card_type}
-        title={card.title || formatCardTitle(card.card_type)}
-        onConfigure={onConfigure}
-        onRemove={onRemove}
-        onWidthChange={onWidthChange}
-        onHeightChange={onHeightChange}
-        cardWidth={effectiveW}
-        cardHeight={card.position?.h || 2}
-        isRefreshing={isRefreshing}
-        onRefresh={onRefresh}
-        lastUpdated={lastUpdated}
-      >
-        <CardComponent config={card.config ?? {}} />
-      </CardWrapper>
-    </div>
-  )
-}
-
-// Drag preview card
-function DragPreviewCard({ card }: { card: Card }) {
-  const CardComponent = CARD_COMPONENTS[card.card_type]
-
-  return (
-    <div
-      className="rounded-lg border border-purple-500 bg-card shadow-lg"
-      style={{ width: `${(card.position?.w || 4) * 80}px`, height: '200px' }}
-    >
-      <CardWrapper
-        cardId={card.id}
-        cardType={card.card_type}
-        title={card.title || formatCardTitle(card.card_type)}
-        cardWidth={card.position?.w || 4}
-      >
-        {CardComponent ? <CardComponent config={card.config ?? {}} /> : null}
-      </CardWrapper>
-    </div>
-  )
-}
+import type { Card } from './customDashboard/types'
+import { SortableCard } from './customDashboard/SortableCard'
+import { DragPreviewCard } from './customDashboard/DragPreviewCard'
+import { DashboardEmptyState } from './customDashboard/DashboardEmptyState'
+import { DashboardDeleteModal } from './customDashboard/DashboardDeleteModal'
 
 export function CustomDashboard() {
   const { id } = useParams<{ id: string }>()
@@ -669,33 +488,12 @@ export function CustomDashboard() {
       {/* Mission Suggestions */}
       <MissionSuggestions />
 
-      {/* Empty state */}
+      {/* Empty state or card grid */}
       {cards.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-24 text-center">
-          <div className="w-16 h-16 rounded-full bg-secondary/50 flex items-center justify-center mb-4">
-            <svg className="w-8 h-8 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
-            </svg>
-          </div>
-          <h2 className="text-lg font-medium text-foreground mb-2">{t('dashboard.empty.noCardsYet')}</h2>
-          <p className="text-muted-foreground mb-6 max-w-md">
-            {t('dashboard.empty.emptyDescription')}
-          </p>
-          <div className="flex gap-3">
-            <button
-              onClick={() => openAddCard()}
-              className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
-            >
-              {t('dashboard.empty.addCards')}
-            </button>
-            <button
-              onClick={() => openTemplates()}
-              className="px-4 py-2 bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
-            >
-              {t('dashboard.empty.startWithTemplate')}
-            </button>
-          </div>
-        </div>
+        <DashboardEmptyState
+          onAddCard={() => openAddCard()}
+          onOpenTemplates={() => openTemplates()}
+        />
       ) : (
         /* Card grid with drag and drop */
         <DndContext
@@ -802,44 +600,15 @@ export function CustomDashboard() {
       />
 
       {/* Delete Confirmation Modal */}
-      <BaseModal isOpen={isDeleteConfirmOpen} onClose={closeDeleteConfirm} size="md">
-        <BaseModal.Header
-          title={t('dashboard.delete.title')}
-          description={t('dashboard.delete.confirm', { name: sidebarItem?.name || dashboard?.name || 'this dashboard' })}
-          icon={Trash2}
-          onClose={closeDeleteConfirm}
-          showBack={false}
-        />
-        <BaseModal.Content>
-          <div className="flex items-start gap-3 p-4 rounded-lg bg-red-500/10 border border-red-500/20">
-            <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-            <div>
-              <p className="text-sm text-foreground font-medium">{t('dashboard.delete.warning')}</p>
-              <p className="text-sm text-muted-foreground mt-1">
-                {t('dashboard.delete.details')}
-              </p>
-            </div>
-          </div>
-        </BaseModal.Content>
-        <BaseModal.Footer>
-          <button
-            onClick={closeDeleteConfirm}
-            className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            {t('actions.cancel')}
-          </button>
-          <button
-            onClick={() => {
-              closeDeleteConfirm()
-              handleDeleteDashboard()
-            }}
-            className="flex items-center gap-2 px-4 py-2 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors"
-          >
-            <Trash2 className="w-4 h-4" />
-            {t('dashboard.delete.title')}
-          </button>
-        </BaseModal.Footer>
-      </BaseModal>
+      <DashboardDeleteModal
+        isOpen={isDeleteConfirmOpen}
+        onClose={closeDeleteConfirm}
+        onConfirm={() => {
+          closeDeleteConfirm()
+          handleDeleteDashboard()
+        }}
+        dashboardName={sidebarItem?.name || dashboard?.name || 'this dashboard'}
+      />
     </div>
   )
 }

--- a/web/src/components/dashboard/StatBlockFactoryModal.tsx
+++ b/web/src/components/dashboard/StatBlockFactoryModal.tsx
@@ -1,255 +1,38 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useEffect, useRef, startTransition } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
-  Plus, X, Save, Trash2, Activity, Sparkles,
+  Plus, X, Save, Activity, Sparkles,
   CheckCircle, GripVertical, Eye, EyeOff,
-  Maximize2, Minimize2,
-  Server, Database, Cpu, MemoryStick, HardDrive, Zap,
-  CheckCircle2, XCircle, AlertTriangle, BarChart3,
-  Layers, Box, Shield, Lock, Globe, Cloud, GitBranch,
-  Terminal, Code, Wifi, WifiOff, Clock, Users,
-  Gauge, TrendingUp, TrendingDown, ArrowUpRight, Flame,
-  HelpCircle,
-  type LucideIcon } from 'lucide-react'
+  Maximize2, Minimize2 } from 'lucide-react'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
 import { cn } from '../../lib/cn'
 import {
   saveDynamicStatsDefinition,
   deleteDynamicStatsDefinition,
   getAllDynamicStats } from '../../lib/dynamic-cards'
-import type { StatsDefinition, StatBlockDefinition, StatBlockColor, StatBlockValueSource } from '../../lib/stats/types'
+import type { StatBlockColor } from '../../lib/stats/types'
 import { COLOR_CLASSES } from '../../lib/stats/types'
 import { AiGenerationPanel } from './AiGenerationPanel'
 import { InlineAIAssist } from './InlineAIAssist'
 import { STAT_BLOCK_SYSTEM_PROMPT, STAT_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { useAIMode } from '../../hooks/useAIMode'
 import { StatusBadge } from '../ui/StatusBadge'
-
-// Demo/preview constants
-const DEMO_STAT_VALUE = 42 // Placeholder value shown in stat block previews
-const SAVE_MESSAGE_TIMEOUT_MS = 3000 // Duration to display save/error messages before auto-clearing
-const STAT_BLOCK_ID_PREFIX = 'stat-block'
-
-function createStatBlockId(): string {
-  const randomId = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
-    ? crypto.randomUUID()
-    : `${Date.now()}-${String(Math.random()).replace('0.', '')}`
-
-  return `${STAT_BLOCK_ID_PREFIX}-${randomId}`
-}
-
-interface StatBlockFactoryModalProps {
-  isOpen: boolean
-  onClose: () => void
-  onStatsCreated?: (type: string) => void
-  /** When true, renders content inline without BaseModal wrapper (used by Console Studio) */
-  embedded?: boolean
-}
-
-type Tab = 'builder' | 'ai' | 'manage'
-
-const AVAILABLE_COLORS: StatBlockColor[] = [
-  'purple', 'blue', 'green', 'yellow', 'orange', 'red', 'cyan', 'gray',
-]
-
-const POPULAR_ICONS = [
-  'Server', 'Database', 'Cpu', 'MemoryStick', 'HardDrive', 'Zap',
-  'CheckCircle2', 'XCircle', 'AlertTriangle', 'Activity', 'BarChart3',
-  'Layers', 'Box', 'Shield', 'Lock', 'Globe', 'Cloud', 'GitBranch',
-  'Terminal', 'Code', 'Wifi', 'WifiOff', 'Clock', 'Users',
-  'Gauge', 'TrendingUp', 'TrendingDown', 'ArrowUpRight', 'Flame',
-]
-
-const VALUE_FORMATS = [
-  { value: '', label: 'None' },
-  { value: 'number', label: 'Number (K/M)' },
-  { value: 'percent', label: 'Percent' },
-  { value: 'bytes', label: 'Bytes' },
-  { value: 'currency', label: 'Currency' },
-  { value: 'duration', label: 'Duration' },
-]
-
-interface BlockEditorItem {
-  id: string
-  label: string
-  icon: string
-  color: StatBlockColor
-  field: string
-  format: string
-  tooltip: string
-}
-
-const ICON_MAP: Record<string, LucideIcon> = {
-  Server, Database, Cpu, MemoryStick, HardDrive, Zap,
-  CheckCircle2, XCircle, AlertTriangle, Activity, BarChart3,
-  Layers, Box, Shield, Lock, Globe, Cloud, GitBranch,
-  Terminal, Code, Wifi, WifiOff, Clock, Users,
-  Gauge, TrendingUp, TrendingDown, ArrowUpRight, Flame,
-  HelpCircle }
-
-function getIcon(name: string): LucideIcon {
-  return ICON_MAP[name] ?? HelpCircle
-}
-
-function createEmptyBlock(): BlockEditorItem {
-  return {
-    id: createStatBlockId(),
-    label: '',
-    icon: 'Activity',
-    color: 'purple',
-    field: '',
-    format: '',
-    tooltip: '' }
-}
-
-// ============================================================================
-// Smart Defaults — suggest icon and color based on label
-// ============================================================================
-
-interface SmartDefault {
-  icon: string
-  color: StatBlockColor
-}
-
-const SMART_DEFAULTS: { pattern: RegExp; defaults: SmartDefault }[] = [
-  { pattern: /^(healthy|running|active|up|online|success)$/i, defaults: { icon: 'CheckCircle2', color: 'green' } },
-  { pattern: /^(error|failed|down|offline|critical)$/i, defaults: { icon: 'XCircle', color: 'red' } },
-  { pattern: /^(warning|pending|degraded|issue|alert)$/i, defaults: { icon: 'AlertTriangle', color: 'yellow' } },
-  { pattern: /^(total|count|all|sum|instances?)$/i, defaults: { icon: 'Server', color: 'purple' } },
-  { pattern: /^cpu/i, defaults: { icon: 'Cpu', color: 'blue' } },
-  { pattern: /^mem/i, defaults: { icon: 'MemoryStick', color: 'cyan' } },
-  { pattern: /^(disk|storage)/i, defaults: { icon: 'HardDrive', color: 'orange' } },
-  { pattern: /^(network|traffic|bandwidth)/i, defaults: { icon: 'Wifi', color: 'blue' } },
-  { pattern: /^(latency|response|time)/i, defaults: { icon: 'Clock', color: 'yellow' } },
-  { pattern: /^(user|session)/i, defaults: { icon: 'Users', color: 'blue' } },
-  { pattern: /^(security|auth|permission)/i, defaults: { icon: 'Shield', color: 'red' } },
-  { pattern: /^(deploy|release|version)/i, defaults: { icon: 'GitBranch', color: 'purple' } },
-  { pattern: /^(node|cluster|server)/i, defaults: { icon: 'Server', color: 'blue' } },
-  { pattern: /^(pod|container)/i, defaults: { icon: 'Box', color: 'cyan' } },
-  { pattern: /^(namespace|scope)/i, defaults: { icon: 'Layers', color: 'blue' } },
-]
-
-function getSmartDefault(label: string): SmartDefault | null {
-  const trimmed = label.trim()
-  if (!trimmed) return null
-  for (const { pattern, defaults } of SMART_DEFAULTS) {
-    if (pattern.test(trimmed)) return defaults
-  }
-  return null
-}
-
-// ============================================================================
-// Inline AI assist result type
-// ============================================================================
-
-interface StatAssistResult {
-  title?: string
-  blocks?: {
-    label: string
-    icon: string
-    color: string
-    field: string
-    format?: string
-    tooltip?: string
-  }[]
-}
-
-function validateStatAssistResult(data: unknown): { valid: true; result: StatAssistResult } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.blocks && !obj.title) return { valid: false, error: 'Response must include title or blocks' }
-  return { valid: true, result: obj as StatAssistResult }
-}
-
-// ============================================================================
-// Live preview of stat blocks matching the StatsRuntime look
-// ============================================================================
-
-function StatsPreview({ title, blocks }: { title: string; blocks: BlockEditorItem[] }) {
-  const visibleBlocks = blocks.filter(b => b.label.trim())
-  if (visibleBlocks.length === 0) {
-    return (
-      <div className="flex items-center justify-center py-6 text-muted-foreground/40">
-        <Activity className="w-6 h-6 mr-2" />
-        <span className="text-sm">Add blocks to see preview</span>
-      </div>
-    )
-  }
-
-  const gridCols =
-    visibleBlocks.length <= 4 ? 'grid-cols-2 md:grid-cols-4' :
-    visibleBlocks.length <= 6 ? 'grid-cols-3 md:grid-cols-6' :
-    'grid-cols-4 lg:grid-cols-8'
-
-  return (
-    <div>
-      <div className="flex items-center gap-2 mb-3">
-        <Activity className="w-4 h-4 text-muted-foreground" />
-        <span className="text-sm font-medium text-muted-foreground">{title || 'Stats Overview'}</span>
-      </div>
-      <div className={`grid ${gridCols} gap-4`}>
-        {visibleBlocks.map(block => {
-          const IconComponent = getIcon(block.icon)
-          const colorClass = COLOR_CLASSES[block.color] || 'text-foreground'
-          return (
-            <div key={block.id} className="glass p-4 rounded-lg">
-              <div className="flex items-center gap-2 mb-2">
-                <IconComponent className={`w-5 h-5 shrink-0 ${colorClass}`} />
-                <span className="text-sm text-muted-foreground truncate">{block.label}</span>
-              </div>
-              <div className="text-3xl font-bold text-foreground">{DEMO_STAT_VALUE}</div>
-              {block.field && (
-                <div className="text-xs text-muted-foreground">{block.field}</div>
-              )}
-            </div>
-          )
-        })}
-      </div>
-    </div>
-  )
-}
-
-// AI generation result schema
-interface AiStatBlockResult {
-  title: string
-  type: string
-  blocks: {
-    id: string
-    label: string
-    icon: string
-    color: string
-    field: string
-    format: string
-    tooltip: string
-  }[]
-}
-
-const VALID_COLORS = new Set(AVAILABLE_COLORS)
-
-function validateStatBlockResult(
-  data: unknown,
-): { valid: true; result: AiStatBlockResult } | { valid: false; error: string } {
-  const obj = data as Record<string, unknown>
-  if (!obj.title || typeof obj.title !== 'string') {
-    return { valid: false, error: 'Missing or invalid "title"' }
-  }
-  if (!obj.blocks || !Array.isArray(obj.blocks) || obj.blocks.length === 0) {
-    return { valid: false, error: 'Missing or empty "blocks" array' }
-  }
-
-  // Auto-correct invalid colors to 'purple'
-  for (const block of obj.blocks as Record<string, unknown>[]) {
-    if (!block.color || !VALID_COLORS.has(block.color as StatBlockColor)) {
-      block.color = 'purple'
-    }
-  }
-
-  return { valid: true, result: obj as unknown as AiStatBlockResult }
-}
-
-// ============================================================================
-// Main Component
-// ============================================================================
+import type { StatBlockFactoryModalProps, Tab, BlockEditorItem, StatAssistResult, AiStatBlockResult } from './statBlockFactoryModal.types'
+import {
+  AVAILABLE_COLORS,
+  POPULAR_ICONS,
+  VALUE_FORMATS,
+  SAVE_MESSAGE_TIMEOUT_MS,
+  getIcon,
+  getSmartDefault,
+  createEmptyBlock,
+  createStatBlockId,
+  validateStatAssistResult,
+  validateStatBlockResult,
+  buildStatBlockDefinitions,
+  buildStatsDefinition } from './statBlockFactoryModal.utils'
+import { StatsPreview } from './StatBlockFactoryPreview'
+import { StatBlockManageTab } from './StatBlockManageTab'
 
 export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedded = false }: StatBlockFactoryModalProps) {
   const { t } = useTranslation()
@@ -267,7 +50,7 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
   const [gridCols, setGridCols] = useState<number>(0) // 0 = auto
 
   // Manage state
-  const [existingStats, setExistingStats] = useState<StatsDefinition[]>([])
+  const [existingStats, setExistingStats] = useState(() => getAllDynamicStats())
   const [deleteConfirmType, setDeleteConfirmType] = useState<string | null>(null)
   const [saveMessage, setSaveMessage] = useState<string | null>(null)
 
@@ -331,27 +114,7 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
       return
     }
 
-    const statBlocks: StatBlockDefinition[] = blocks
-      .filter(b => b.label.trim())
-      .map((b, idx) => ({
-        id: b.id || `block_${idx}`,
-        label: b.label,
-        icon: b.icon,
-        color: b.color,
-        visible: true,
-        order: idx,
-        valueSource: b.field ? {
-          field: b.field,
-          format: (b.format || undefined) as StatBlockValueSource['format'] } : undefined,
-        tooltip: b.tooltip || undefined }))
-
-    const definition: StatsDefinition = {
-      type,
-      title: title.trim() || 'Custom Stats',
-      blocks: statBlocks,
-      defaultCollapsed: false,
-      grid: gridCols > 0 ? { columns: gridCols } : undefined }
-
+    const definition = buildStatsDefinition(type, title, blocks, gridCols)
     saveDynamicStatsDefinition(definition)
     setSaveMessage(`Stats "${definition.title}" created!`)
     onStatsCreated?.(type)
@@ -389,7 +152,7 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
   // Smart default suggestions per block
   const smartDefaults = blocks.map(b => getSmartDefault(b.label))
 
-  const applySmartDefault = (idx: number, defaults: SmartDefault) => {
+  const applySmartDefault = (idx: number, defaults: { icon: string; color: StatBlockColor }) => {
     setBlocks(prev => prev.map((b, i) => i === idx ? { ...b, icon: defaults.icon, color: defaults.color } : b))
   }
 
@@ -709,19 +472,16 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
             )}
             onSave={(result) => {
               const type = result.type || `custom_${Date.now()}`
-              const statBlocks: StatBlockDefinition[] = result.blocks.map((b, idx) => ({
-                id: b.id || `block_${idx}`,
+              const statBlocks = buildStatBlockDefinitions(result.blocks.map(b => ({
+                id: b.id,
                 label: b.label,
                 icon: b.icon,
                 color: (AVAILABLE_COLORS.includes(b.color as StatBlockColor) ? b.color : 'purple') as StatBlockColor,
-                visible: true,
-                order: idx,
-                valueSource: b.field ? {
-                  field: b.field,
-                  format: (b.format || undefined) as StatBlockValueSource['format'] } : undefined,
-                tooltip: b.tooltip || undefined }))
+                field: b.field,
+                format: b.format || '',
+                tooltip: b.tooltip || '' })))
 
-              const definition: StatsDefinition = {
+              const definition = {
                 type,
                 title: result.title || 'AI-Generated Stats',
                 blocks: statBlocks,
@@ -740,60 +500,10 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
 
         {/* Manage tab */}
         {tab === 'manage' && (
-          <div className="space-y-3">
-            {existingStats.length === 0 ? (
-              <div className="flex flex-col items-center justify-center py-8 text-center">
-                <Activity className="w-8 h-8 text-muted-foreground/40 mb-2" />
-                <p className="text-sm text-muted-foreground">{t('dashboard.statFactory.noCustomStats')}</p>
-                <p className="text-xs text-muted-foreground/70 mt-1">
-                  {t('dashboard.statFactory.useBuildTab')}
-                </p>
-              </div>
-            ) : (
-              existingStats.map(stats => (
-                <div key={stats.type} className="rounded-lg bg-card/50 border border-border p-3 flex items-start gap-3">
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2">
-                      <Activity className="w-4 h-4 text-purple-400 shrink-0" />
-                      <span className="text-sm font-medium text-foreground">{stats.title || stats.type}</span>
-                      <StatusBadge color="purple" size="xs">
-                        {t('dashboard.statFactory.blocksCount', { count: stats.blocks.length })}
-                      </StatusBadge>
-                    </div>
-                    <p className="text-xs text-muted-foreground mt-0.5">
-                      Type: {stats.type}
-                    </p>
-                    <div className="flex gap-1 mt-1.5 flex-wrap">
-                      {stats.blocks.slice(0, 8).map(block => {
-                        const BlockIcon = getIcon(block.icon)
-                        return (
-                          <span
-                            key={block.id}
-                            className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-secondary/50 text-muted-foreground"
-                          >
-                            <BlockIcon className={cn('w-3 h-3', COLOR_CLASSES[block.color])} />
-                            {block.label}
-                          </span>
-                        )
-                      })}
-                      {stats.blocks.length > 8 && (
-                        <span className="text-xs px-1.5 py-0.5 text-muted-foreground">
-                          +{stats.blocks.length - 8} more
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                  <button
-                    onClick={() => setDeleteConfirmType(stats.type)}
-                    className="p-1.5 min-h-11 min-w-11 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors shrink-0"
-                    title={t('dashboard.statFactory.deleteStatBlock')}
-                  >
-                    <Trash2 className="w-4 h-4" />
-                  </button>
-                </div>
-              ))
-            )}
-          </div>
+          <StatBlockManageTab
+            existingStats={existingStats}
+            onDeleteRequest={setDeleteConfirmType}
+          />
         )}
     </>
   )

--- a/web/src/components/dashboard/StatBlockFactoryPreview.tsx
+++ b/web/src/components/dashboard/StatBlockFactoryPreview.tsx
@@ -1,0 +1,55 @@
+import { Activity } from 'lucide-react'
+import { COLOR_CLASSES } from '../../lib/stats/types'
+import {
+  DEMO_STAT_VALUE,
+  getIcon } from './statBlockFactoryModal.utils'
+import type { BlockEditorItem } from './statBlockFactoryModal.types'
+
+interface StatsPreviewProps {
+  title: string
+  blocks: BlockEditorItem[]
+}
+
+export function StatsPreview({ title, blocks }: StatsPreviewProps) {
+  const visibleBlocks = blocks.filter(b => b.label.trim())
+  if (visibleBlocks.length === 0) {
+    return (
+      <div className="flex items-center justify-center py-6 text-muted-foreground/40">
+        <Activity className="w-6 h-6 mr-2" />
+        <span className="text-sm">Add blocks to see preview</span>
+      </div>
+    )
+  }
+
+  const gridCols =
+    visibleBlocks.length <= 4 ? 'grid-cols-2 md:grid-cols-4' :
+    visibleBlocks.length <= 6 ? 'grid-cols-3 md:grid-cols-6' :
+    'grid-cols-4 lg:grid-cols-8'
+
+  return (
+    <div>
+      <div className="flex items-center gap-2 mb-3">
+        <Activity className="w-4 h-4 text-muted-foreground" />
+        <span className="text-sm font-medium text-muted-foreground">{title || 'Stats Overview'}</span>
+      </div>
+      <div className={`grid ${gridCols} gap-4`}>
+        {visibleBlocks.map(block => {
+          const IconComponent = getIcon(block.icon)
+          const colorClass = COLOR_CLASSES[block.color] || 'text-foreground'
+          return (
+            <div key={block.id} className="glass p-4 rounded-lg">
+              <div className="flex items-center gap-2 mb-2">
+                <IconComponent className={`w-5 h-5 shrink-0 ${colorClass}`} />
+                <span className="text-sm text-muted-foreground truncate">{block.label}</span>
+              </div>
+              <div className="text-3xl font-bold text-foreground">{DEMO_STAT_VALUE}</div>
+              {block.field && (
+                <div className="text-xs text-muted-foreground">{block.field}</div>
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/StatBlockManageTab.tsx
+++ b/web/src/components/dashboard/StatBlockManageTab.tsx
@@ -1,0 +1,75 @@
+import { Activity, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../lib/cn'
+import { COLOR_CLASSES } from '../../lib/stats/types'
+import type { StatsDefinition } from '../../lib/stats/types'
+import { StatusBadge } from '../ui/StatusBadge'
+import { getIcon } from './statBlockFactoryModal.utils'
+
+interface StatBlockManageTabProps {
+  existingStats: StatsDefinition[]
+  onDeleteRequest: (type: string) => void
+}
+
+export function StatBlockManageTab({ existingStats, onDeleteRequest }: StatBlockManageTabProps) {
+  const { t } = useTranslation()
+
+  if (existingStats.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 text-center">
+        <Activity className="w-8 h-8 text-muted-foreground/40 mb-2" />
+        <p className="text-sm text-muted-foreground">{t('dashboard.statFactory.noCustomStats')}</p>
+        <p className="text-xs text-muted-foreground/70 mt-1">
+          {t('dashboard.statFactory.useBuildTab')}
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {existingStats.map(stats => (
+        <div key={stats.type} className="rounded-lg bg-card/50 border border-border p-3 flex items-start gap-3">
+          <div className="flex-1 min-w-0">
+            <div className="flex items-center gap-2">
+              <Activity className="w-4 h-4 text-purple-400 shrink-0" />
+              <span className="text-sm font-medium text-foreground">{stats.title || stats.type}</span>
+              <StatusBadge color="purple" size="xs">
+                {t('dashboard.statFactory.blocksCount', { count: stats.blocks.length })}
+              </StatusBadge>
+            </div>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Type: {stats.type}
+            </p>
+            <div className="flex gap-1 mt-1.5 flex-wrap">
+              {stats.blocks.slice(0, 8).map(block => {
+                const BlockIcon = getIcon(block.icon)
+                return (
+                  <span
+                    key={block.id}
+                    className="inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-secondary/50 text-muted-foreground"
+                  >
+                    <BlockIcon className={cn('w-3 h-3', COLOR_CLASSES[block.color])} />
+                    {block.label}
+                  </span>
+                )
+              })}
+              {stats.blocks.length > 8 && (
+                <span className="text-xs px-1.5 py-0.5 text-muted-foreground">
+                  +{stats.blocks.length - 8} more
+                </span>
+              )}
+            </div>
+          </div>
+          <button
+            onClick={() => onDeleteRequest(stats.type)}
+            className="p-1.5 min-h-11 min-w-11 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors shrink-0"
+            title={t('dashboard.statFactory.deleteStatBlock')}
+          >
+            <Trash2 className="w-4 h-4" />
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/dashboard/customDashboard/DashboardDeleteModal.tsx
+++ b/web/src/components/dashboard/customDashboard/DashboardDeleteModal.tsx
@@ -1,0 +1,52 @@
+import { AlertTriangle, Trash2 } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { BaseModal } from '../../../lib/modals'
+
+interface DashboardDeleteModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onConfirm: () => void
+  dashboardName: string
+}
+
+export function DashboardDeleteModal({ isOpen, onClose, onConfirm, dashboardName }: DashboardDeleteModalProps) {
+  const { t } = useTranslation()
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="md">
+      <BaseModal.Header
+        title={t('dashboard.delete.title')}
+        description={t('dashboard.delete.confirm', { name: dashboardName })}
+        icon={Trash2}
+        onClose={onClose}
+        showBack={false}
+      />
+      <BaseModal.Content>
+        <div className="flex items-start gap-3 p-4 rounded-lg bg-red-500/10 border border-red-500/20">
+          <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+          <div>
+            <p className="text-sm text-foreground font-medium">{t('dashboard.delete.warning')}</p>
+            <p className="text-sm text-muted-foreground mt-1">
+              {t('dashboard.delete.details')}
+            </p>
+          </div>
+        </div>
+      </BaseModal.Content>
+      <BaseModal.Footer>
+        <button
+          onClick={onClose}
+          className="px-4 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {t('actions.cancel')}
+        </button>
+        <button
+          onClick={onConfirm}
+          className="flex items-center gap-2 px-4 py-2 bg-red-500/20 text-red-400 rounded-lg hover:bg-red-500/30 transition-colors"
+        >
+          <Trash2 className="w-4 h-4" />
+          {t('dashboard.delete.title')}
+        </button>
+      </BaseModal.Footer>
+    </BaseModal>
+  )
+}

--- a/web/src/components/dashboard/customDashboard/DashboardEmptyState.tsx
+++ b/web/src/components/dashboard/customDashboard/DashboardEmptyState.tsx
@@ -1,0 +1,38 @@
+import { useTranslation } from 'react-i18next'
+
+interface DashboardEmptyStateProps {
+  onAddCard: () => void
+  onOpenTemplates: () => void
+}
+
+export function DashboardEmptyState({ onAddCard, onOpenTemplates }: DashboardEmptyStateProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="flex flex-col items-center justify-center py-24 text-center">
+      <div className="w-16 h-16 rounded-full bg-secondary/50 flex items-center justify-center mb-4">
+        <svg className="w-8 h-8 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M4 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1V5zM14 5a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1V5zM4 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1H5a1 1 0 01-1-1v-4zM14 15a1 1 0 011-1h4a1 1 0 011 1v4a1 1 0 01-1 1h-4a1 1 0 01-1-1v-4z" />
+        </svg>
+      </div>
+      <h2 className="text-lg font-medium text-foreground mb-2">{t('dashboard.empty.noCardsYet')}</h2>
+      <p className="text-muted-foreground mb-6 max-w-md">
+        {t('dashboard.empty.emptyDescription')}
+      </p>
+      <div className="flex gap-3">
+        <button
+          onClick={onAddCard}
+          className="px-4 py-2 bg-purple-500/20 text-purple-400 rounded-lg hover:bg-purple-500/30 transition-colors"
+        >
+          {t('dashboard.empty.addCards')}
+        </button>
+        <button
+          onClick={onOpenTemplates}
+          className="px-4 py-2 bg-secondary text-foreground rounded-lg hover:bg-secondary/80 transition-colors"
+        >
+          {t('dashboard.empty.startWithTemplate')}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/customDashboard/DragPreviewCard.tsx
+++ b/web/src/components/dashboard/customDashboard/DragPreviewCard.tsx
@@ -1,0 +1,24 @@
+import { CardWrapper } from '../../cards/CardWrapper'
+import { CARD_COMPONENTS } from '../../cards/cardRegistry'
+import { formatCardTitle } from '../../../lib/formatCardTitle'
+import type { Card } from './types'
+
+export function DragPreviewCard({ card }: { card: Card }) {
+  const CardComponent = CARD_COMPONENTS[card.card_type]
+
+  return (
+    <div
+      className="rounded-lg border border-purple-500 bg-card shadow-lg"
+      style={{ width: `${(card.position?.w || 4) * 80}px`, height: '200px' }}
+    >
+      <CardWrapper
+        cardId={card.id}
+        cardType={card.card_type}
+        title={card.title || formatCardTitle(card.card_type)}
+        cardWidth={card.position?.w || 4}
+      >
+        {CardComponent ? <CardComponent config={card.config ?? {}} /> : null}
+      </CardWrapper>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/customDashboard/SortableCard.tsx
+++ b/web/src/components/dashboard/customDashboard/SortableCard.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from 'react'
+import { GripVertical } from 'lucide-react'
+import { CSS } from '@dnd-kit/utilities'
+import { useSortable } from '@dnd-kit/sortable'
+import { useTranslation } from 'react-i18next'
+import { CardWrapper } from '../../cards/CardWrapper'
+import { CARD_COMPONENTS } from '../../cards/cardRegistry'
+import { useCardCollapse } from '../../../lib/cards/cardHooks'
+import { formatCardTitle } from '../../../lib/formatCardTitle'
+import type { Card } from './types'
+
+/** Clamp small cards in the md–lg range (768–1023px) for readability */
+const NARROW_MIN = 768
+const NARROW_MAX = 1023
+
+/** Minimum card column span at narrow viewports */
+const MIN_NARROW_COLS = 6
+
+/**
+ * Minimum pixel height contributed by ONE row of card span. Effective
+ * min-height = posH × this constant, so the "Resize height" menu has a
+ * visible effect on `auto-rows-min` grids (#8289, #8298). Mirrors the
+ * legacy `auto-rows-[minmax(180px,auto)]` baseline (180px per row).
+ */
+const EXPANDED_CARD_ROW_MIN_HEIGHT_PX = 180
+
+/** Default row span when a card has no persisted position.h */
+const DEFAULT_CARD_ROW_SPAN = 2
+
+export interface SortableCardProps {
+  card: Card
+  onConfigure: () => void
+  onRemove: () => void
+  onWidthChange: (newWidth: number) => void
+  onHeightChange: (newHeight: number) => void
+  isDragging?: boolean
+  isRefreshing?: boolean
+  onRefresh?: () => void
+  lastUpdated?: Date | null
+  onInsertBefore?: () => void
+  onInsertAfter?: () => void
+}
+
+export function SortableCard({ card, onConfigure, onRemove, onWidthChange, onHeightChange, isDragging, isRefreshing, onRefresh, lastUpdated, onInsertBefore: _onInsertBefore, onInsertAfter }: SortableCardProps) {
+  const { t } = useTranslation()
+  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: card.id })
+
+  // In the md–lg range (768–1023px), clamp small cards to min 6 cols
+  // so we get max 2 cards per row instead of cramped 3-up layout.
+  // Below 768px CSS already switches to a 1-column grid, so no clamping needed there.
+  const [isNarrowRange, setIsNarrowRange] = useState(() =>
+    typeof window !== 'undefined' &&
+    window.innerWidth >= NARROW_MIN &&
+    window.innerWidth <= NARROW_MAX
+  )
+  useEffect(() => {
+    const mq = window.matchMedia(`(min-width: ${NARROW_MIN}px) and (max-width: ${NARROW_MAX}px)`)
+    const handler = (e: MediaQueryListEvent) => setIsNarrowRange(e.matches)
+    if (mq.matches !== isNarrowRange) setIsNarrowRange(mq.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const effectiveW = isNarrowRange && (card.position?.w || 4) < MIN_NARROW_COLS ? MIN_NARROW_COLS : (card.position?.w || 4)
+  const posH = card.position?.h || DEFAULT_CARD_ROW_SPAN
+
+  // Read collapse state so the cell can drop its minimum height when the
+  // card is collapsed (#6072). Without this, the grid leaves dead space
+  // under collapsed cards because every cell is forced to the expanded
+  // baseline height.
+  const { isCollapsed } = useCardCollapse(card.id)
+  const effectiveRowSpan = isCollapsed ? 1 : posH
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    gridColumn: `span ${effectiveW}`,
+    gridRow: `span ${effectiveRowSpan}`,
+    // Scale min-height by posH so the "Resize height" menu actually changes
+    // the card's visual height on an auto-rows-min grid (#8289, #8298).
+    minHeight: isCollapsed ? undefined : `${posH * EXPANDED_CARD_ROW_MIN_HEIGHT_PX}px`,
+    opacity: isDragging ? 0.5 : 1 }
+
+  const CardComponent = CARD_COMPONENTS[card.card_type]
+
+  if (!CardComponent) {
+    return (
+      <div ref={setNodeRef} style={style} className="relative group/card">
+        {onInsertAfter && (
+          <button
+            onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+            className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+            aria-label="Add card"
+            title="Add card here"
+          >
+            +
+          </button>
+        )}
+        <CardWrapper
+          cardId={card.id}
+          cardType={card.card_type}
+          title={formatCardTitle(card.card_type)}
+          onConfigure={onConfigure}
+          onRemove={onRemove}
+          onWidthChange={onWidthChange}
+          onHeightChange={onHeightChange}
+          cardWidth={effectiveW}
+          cardHeight={card.position?.h || 2}
+          isRefreshing={isRefreshing}
+          onRefresh={onRefresh}
+          lastUpdated={lastUpdated}
+        >
+          <div className="flex items-center justify-center h-full text-muted-foreground">
+            {t('drilldown.unknownViewType')}: {card.card_type}
+          </div>
+        </CardWrapper>
+      </div>
+    )
+  }
+
+  return (
+    <div ref={setNodeRef} style={style} className="relative group/card">
+      {onInsertAfter && (
+        <button
+          onClick={(e) => { e.stopPropagation(); onInsertAfter() }}
+          className="absolute top-1/2 -translate-y-1/2 right-2 z-20 opacity-0 group-hover/card:opacity-100 focus-visible:opacity-100 focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-primary transition-all w-6 h-6 rounded-full bg-primary text-primary-foreground flex items-center justify-center text-sm font-bold shadow-lg hover:scale-110 ring-2 ring-background"
+          aria-label="Add card"
+          title="Add card here"
+        >
+          +
+        </button>
+      )}
+      {/* Drag handle */}
+      <div
+        {...attributes}
+        {...listeners}
+        className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-1 rounded cursor-grab active:cursor-grabbing opacity-0 hover:opacity-100 transition-opacity bg-secondary/80"
+      >
+        <GripVertical className="w-4 h-4 text-muted-foreground" />
+      </div>
+      <CardWrapper
+        cardId={card.id}
+        cardType={card.card_type}
+        title={card.title || formatCardTitle(card.card_type)}
+        onConfigure={onConfigure}
+        onRemove={onRemove}
+        onWidthChange={onWidthChange}
+        onHeightChange={onHeightChange}
+        cardWidth={effectiveW}
+        cardHeight={card.position?.h || 2}
+        isRefreshing={isRefreshing}
+        onRefresh={onRefresh}
+        lastUpdated={lastUpdated}
+      >
+        <CardComponent config={card.config ?? {}} />
+      </CardWrapper>
+    </div>
+  )
+}

--- a/web/src/components/dashboard/customDashboard/types.ts
+++ b/web/src/components/dashboard/customDashboard/types.ts
@@ -1,0 +1,7 @@
+export interface Card {
+  id: string
+  card_type: string
+  config: Record<string, unknown>
+  position: { x: number; y: number; w: number; h: number }
+  title?: string
+}

--- a/web/src/components/dashboard/statBlockFactoryModal.types.ts
+++ b/web/src/components/dashboard/statBlockFactoryModal.types.ts
@@ -1,0 +1,47 @@
+import type { StatBlockColor } from '../../lib/stats/types'
+
+export interface StatBlockFactoryModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onStatsCreated?: (type: string) => void
+  /** When true, renders content inline without BaseModal wrapper (used by Console Studio) */
+  embedded?: boolean
+}
+
+export type Tab = 'builder' | 'ai' | 'manage'
+
+export interface BlockEditorItem {
+  id: string
+  label: string
+  icon: string
+  color: StatBlockColor
+  field: string
+  format: string
+  tooltip: string
+}
+
+export interface StatAssistResult {
+  title?: string
+  blocks?: {
+    label: string
+    icon: string
+    color: string
+    field: string
+    format?: string
+    tooltip?: string
+  }[]
+}
+
+export interface AiStatBlockResult {
+  title: string
+  type: string
+  blocks: {
+    id: string
+    label: string
+    icon: string
+    color: string
+    field: string
+    format: string
+    tooltip: string
+  }[]
+}

--- a/web/src/components/dashboard/statBlockFactoryModal.utils.ts
+++ b/web/src/components/dashboard/statBlockFactoryModal.utils.ts
@@ -1,0 +1,164 @@
+import {
+  Server, Database, Cpu, MemoryStick, HardDrive, Zap,
+  CheckCircle2, XCircle, AlertTriangle, Activity, BarChart3,
+  Layers, Box, Shield, Lock, Globe, Cloud, GitBranch,
+  Terminal, Code, Wifi, WifiOff, Clock, Users,
+  Gauge, TrendingUp, TrendingDown, ArrowUpRight, Flame,
+  HelpCircle,
+  type LucideIcon } from 'lucide-react'
+import type { StatBlockColor, StatBlockValueSource, StatBlockDefinition, StatsDefinition } from '../../lib/stats/types'
+import type { BlockEditorItem, StatAssistResult, AiStatBlockResult } from './statBlockFactoryModal.types'
+
+// Demo/preview constants
+export const DEMO_STAT_VALUE = 42 // Placeholder value shown in stat block previews
+export const SAVE_MESSAGE_TIMEOUT_MS = 3000 // Duration to display save/error messages before auto-clearing
+export const STAT_BLOCK_ID_PREFIX = 'stat-block'
+
+export const AVAILABLE_COLORS: StatBlockColor[] = [
+  'purple', 'blue', 'green', 'yellow', 'orange', 'red', 'cyan', 'gray',
+]
+
+export const POPULAR_ICONS = [
+  'Server', 'Database', 'Cpu', 'MemoryStick', 'HardDrive', 'Zap',
+  'CheckCircle2', 'XCircle', 'AlertTriangle', 'Activity', 'BarChart3',
+  'Layers', 'Box', 'Shield', 'Lock', 'Globe', 'Cloud', 'GitBranch',
+  'Terminal', 'Code', 'Wifi', 'WifiOff', 'Clock', 'Users',
+  'Gauge', 'TrendingUp', 'TrendingDown', 'ArrowUpRight', 'Flame',
+]
+
+export const VALUE_FORMATS = [
+  { value: '', label: 'None' },
+  { value: 'number', label: 'Number (K/M)' },
+  { value: 'percent', label: 'Percent' },
+  { value: 'bytes', label: 'Bytes' },
+  { value: 'currency', label: 'Currency' },
+  { value: 'duration', label: 'Duration' },
+]
+
+export const ICON_MAP: Record<string, LucideIcon> = {
+  Server, Database, Cpu, MemoryStick, HardDrive, Zap,
+  CheckCircle2, XCircle, AlertTriangle, Activity, BarChart3,
+  Layers, Box, Shield, Lock, Globe, Cloud, GitBranch,
+  Terminal, Code, Wifi, WifiOff, Clock, Users,
+  Gauge, TrendingUp, TrendingDown, ArrowUpRight, Flame,
+  HelpCircle }
+
+export const VALID_COLORS = new Set(AVAILABLE_COLORS)
+
+// ============================================================================
+// Smart Defaults — suggest icon and color based on label
+// ============================================================================
+
+interface SmartDefault {
+  icon: string
+  color: StatBlockColor
+}
+
+const SMART_DEFAULTS: { pattern: RegExp; defaults: SmartDefault }[] = [
+  { pattern: /^(healthy|running|active|up|online|success)$/i, defaults: { icon: 'CheckCircle2', color: 'green' } },
+  { pattern: /^(error|failed|down|offline|critical)$/i, defaults: { icon: 'XCircle', color: 'red' } },
+  { pattern: /^(warning|pending|degraded|issue|alert)$/i, defaults: { icon: 'AlertTriangle', color: 'yellow' } },
+  { pattern: /^(total|count|all|sum|instances?)$/i, defaults: { icon: 'Server', color: 'purple' } },
+  { pattern: /^cpu/i, defaults: { icon: 'Cpu', color: 'blue' } },
+  { pattern: /^mem/i, defaults: { icon: 'MemoryStick', color: 'cyan' } },
+  { pattern: /^(disk|storage)/i, defaults: { icon: 'HardDrive', color: 'orange' } },
+  { pattern: /^(network|traffic|bandwidth)/i, defaults: { icon: 'Wifi', color: 'blue' } },
+  { pattern: /^(latency|response|time)/i, defaults: { icon: 'Clock', color: 'yellow' } },
+  { pattern: /^(user|session)/i, defaults: { icon: 'Users', color: 'blue' } },
+  { pattern: /^(security|auth|permission)/i, defaults: { icon: 'Shield', color: 'red' } },
+  { pattern: /^(deploy|release|version)/i, defaults: { icon: 'GitBranch', color: 'purple' } },
+  { pattern: /^(node|cluster|server)/i, defaults: { icon: 'Server', color: 'blue' } },
+  { pattern: /^(pod|container)/i, defaults: { icon: 'Box', color: 'cyan' } },
+  { pattern: /^(namespace|scope)/i, defaults: { icon: 'Layers', color: 'blue' } },
+]
+
+export function getIcon(name: string): LucideIcon {
+  return ICON_MAP[name] ?? HelpCircle
+}
+
+export function getSmartDefault(label: string): SmartDefault | null {
+  const trimmed = label.trim()
+  if (!trimmed) return null
+  for (const { pattern, defaults } of SMART_DEFAULTS) {
+    if (pattern.test(trimmed)) return defaults
+  }
+  return null
+}
+
+export function createStatBlockId(): string {
+  const randomId = typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : `${Date.now()}-${String(Math.random()).replace('0.', '')}`
+
+  return `${STAT_BLOCK_ID_PREFIX}-${randomId}`
+}
+
+export function createEmptyBlock(): BlockEditorItem {
+  return {
+    id: createStatBlockId(),
+    label: '',
+    icon: 'Activity',
+    color: 'purple',
+    field: '',
+    format: '',
+    tooltip: '' }
+}
+
+export function validateStatAssistResult(data: unknown): { valid: true; result: StatAssistResult } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.blocks && !obj.title) return { valid: false, error: 'Response must include title or blocks' }
+  return { valid: true, result: obj as StatAssistResult }
+}
+
+export function validateStatBlockResult(
+  data: unknown,
+): { valid: true; result: AiStatBlockResult } | { valid: false; error: string } {
+  const obj = data as Record<string, unknown>
+  if (!obj.title || typeof obj.title !== 'string') {
+    return { valid: false, error: 'Missing or invalid "title"' }
+  }
+  if (!obj.blocks || !Array.isArray(obj.blocks) || obj.blocks.length === 0) {
+    return { valid: false, error: 'Missing or empty "blocks" array' }
+  }
+
+  // Auto-correct invalid colors to 'purple'
+  for (const block of obj.blocks as Record<string, unknown>[]) {
+    if (!block.color || !VALID_COLORS.has(block.color as StatBlockColor)) {
+      block.color = 'purple'
+    }
+  }
+
+  return { valid: true, result: obj as unknown as AiStatBlockResult }
+}
+
+export function buildStatBlockDefinitions(
+  blocks: BlockEditorItem[],
+): StatBlockDefinition[] {
+  return blocks
+    .filter(b => b.label.trim())
+    .map((b, idx) => ({
+      id: b.id || `block_${idx}`,
+      label: b.label,
+      icon: b.icon,
+      color: b.color,
+      visible: true,
+      order: idx,
+      valueSource: b.field ? {
+        field: b.field,
+        format: (b.format || undefined) as StatBlockValueSource['format'] } : undefined,
+      tooltip: b.tooltip || undefined }))
+}
+
+export function buildStatsDefinition(
+  type: string,
+  title: string,
+  blocks: BlockEditorItem[],
+  gridCols: number,
+): StatsDefinition {
+  return {
+    type,
+    title: title.trim() || 'Custom Stats',
+    blocks: buildStatBlockDefinitions(blocks),
+    defaultCollapsed: false,
+    grid: gridCols > 0 ? { columns: gridCols } : undefined }
+}


### PR DESCRIPTION
Fixes #21649

Splits two 800+ line components into focused sub-components following established project patterns. No behavior changes.

## StatBlockFactoryModal.tsx (851 → 561 lines)
- Extract types to `statBlockFactoryModal.types.ts`
- Extract pure functions/constants to `statBlockFactoryModal.utils.ts`
- Extract `StatsPreview` sub-component to `StatBlockFactoryPreview.tsx`
- Extract manage tab to `StatBlockManageTab.tsx`
- Remove `/* eslint-disable max-lines */` comment

## CustomDashboard.tsx (845 → 614 lines)
- Extract `Card` type to `customDashboard/types.ts`
- Extract `SortableCard` to `customDashboard/SortableCard.tsx`
- Extract `DragPreviewCard` to `customDashboard/DragPreviewCard.tsx`
- Extract empty state to `customDashboard/DashboardEmptyState.tsx`
- Extract delete modal to `customDashboard/DashboardDeleteModal.tsx`
- Remove `/* eslint-disable max-lines */` comment