### PR TITLE
[scanner] fix: resolve release workflow failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -397,6 +397,18 @@ jobs:
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely a transient registry pull error), retrying in 30s..."
+          sleep 30
+
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry
@@ -480,6 +492,18 @@ jobs:
           merge-multiple: true
 
       - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+        continue-on-error: true
+
+      - name: Wait before Buildx retry
+        if: steps.buildx.outcome == 'failure'
+        run: |
+          echo "::warning::Docker Buildx setup failed (likely a transient registry pull error), retrying in 30s..."
+          sleep 30
+
+      - name: Set up Docker Buildx (retry)
+        if: steps.buildx.outcome == 'failure'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to GitHub Container Registry


### PR DESCRIPTION
Fixes #21680

## Root cause

The Release workflow's `docker-build (linux/amd64)` job failed at the **Set up Docker Buildx** step during builder bootstrap:

```
#1 ERROR: Error response from daemon: Head "https://registry-1.docker.io/v2/moby/buildkit/manifests/buildx-stable-1":
received unexpected HTTP status: 502 Bad Gateway
```

This is a transient Docker Hub registry error while pulling the `moby/buildkit:buildx-stable-1` builder image — not a code or configuration bug. The `linux/arm64` matrix leg in the same run completed successfully, confirming the actual multi-platform build/push logic works fine.

The `docker-build` job already has a wait-and-retry pattern for the image build/push step (`Wait before retry` + `Build and push per-platform image (retry)`), but the earlier `Set up Docker Buildx` step had no such resilience, so a single transient registry hiccup during bootstrap failed the whole job.

## Fix

Apply the same wait-and-retry pattern already used for the build/push step to the `Set up Docker Buildx` step, in both the `docker-build` and `docker-manifest` jobs (both call `docker/setup-buildx-action`):
- Mark the first attempt `continue-on-error: true`
- On failure, log a warning and wait 30s
- Retry `docker/setup-buildx-action` once

This mirrors the existing retry convention in this workflow and should prevent transient Docker Hub 502s from failing the nightly/weekly release.

## Testing

This is a CI workflow-only change (`.github/workflows/release.yml`); no frontend/backend code was touched, so `web/build`/`web/lint` are not applicable. YAML syntax was validated with `python3 -c "import yaml; yaml.safe_load(...)"`.
