### PR TITLE
[scanner] fix: resolve build and deploy workflow failure

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -213,7 +213,13 @@ jobs:
     needs: merge
     if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     runs-on: [self-hosted, kc, openshift]
-    timeout-minutes: 20
+    # 20m was too tight: deploy_helm retries up to MAX_ATTEMPTS=2 times, each
+    # bounded by `--timeout 10m` (=20m), plus recover_release (rollback
+    # --timeout 2m / uninstall --timeout 5m) and retry sleeps in between.
+    # That worst case exceeds 20m, causing the job to be cancelled by the
+    # runner before the retry loop can finish. Match deploy-pok-prod's 45m
+    # budget, which uses the same retry pattern.
+    timeout-minutes: 45
     environment: vllm-d
     concurrency:
       group: deploy-vllm-d


### PR DESCRIPTION
Fixes #21677

## Summary

The build-jobs (`linux/amd64`, `linux/arm64`) failures originally reported in
this issue were TypeScript compile errors (`moveCardToDashboard` Promise
mismatch, `CardEvent` typing, unused imports/params in `DashboardState.ts` /
`dashboardState.actions.ts`). Those are already fixed on `main` — the most
recent completed run (`#30355240675`) shows both `build` jobs passing.

The workflow is still not reporting a clean pass because the `deploy-vllm-d`
job's `timeout-minutes: 20` is too tight for its own retry logic:

- `deploy_helm` retries up to `MAX_ATTEMPTS=2`, each bounded by `--timeout 10m`
  (worst case 20m by itself)
- plus `recover_release` (`helm rollback --timeout 2m` / `helm uninstall
  --timeout 5m`) and `sleep 30` + `sleep 10` between attempts

That worst-case total exceeds the 20-minute job timeout, so the runner
cancels the job mid-deploy instead of letting it succeed or fail cleanly
(observed in run `#30355240675`, where both `build` jobs and `deploy-pok-prod`
succeeded, but `deploy-vllm-d` was cancelled at exactly the 20-minute mark).

## Fix

Increase `deploy-vllm-d`'s `timeout-minutes` from `20` to `45`, matching the
budget already used by the analogous `deploy-pok-prod` job, which shares the
same retry pattern.

## Verification

- Confirmed via GitHub Actions API that the `build (linux/amd64)` and `build
  (linux/arm64)` jobs pass on current `main` (run `#30355240675`).
- Confirmed `deploy-vllm-d`'s "Deploy with Helm" step in that same run started
  at `12:02:40` and was cancelled at `12:22:39` — exactly the 20-minute job
  timeout.
- No behavioral change to the deploy logic itself; only the timeout budget.
