### PR TITLE
[scanner] fix: close remaining QA coverage and flicker gaps

### DIFF
--- a/web/src/components/dashboard/__tests__/ContextualNudgeBanner.test.tsx
+++ b/web/src/components/dashboard/__tests__/ContextualNudgeBanner.test.tsx
@@ -1,0 +1,52 @@
+import React from 'react'
+/**
+ * Coverage for ContextualNudgeBanner.tsx (Auto-QA #21690 — missing test file).
+ *
+ * Verifies per-nudge-type rendering (customize / pwa-install), the
+ * drag-hint no-op case, and the action/dismiss callbacks.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ContextualNudgeBanner } from '../ContextualNudgeBanner'
+
+describe('ContextualNudgeBanner', () => {
+  it('renders nothing for the drag-hint nudge type', () => {
+    const { container } = render(
+      <ContextualNudgeBanner nudgeType="drag-hint" onAction={vi.fn()} onDismiss={vi.fn()} />,
+    )
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the customize nudge copy and action label', () => {
+    render(<ContextualNudgeBanner nudgeType="customize" onAction={vi.fn()} onDismiss={vi.fn()} />)
+
+    expect(screen.getByText('Make it yours')).toBeVisible()
+    expect(screen.getByText('Add a card')).toBeVisible()
+  })
+
+  it('renders the pwa-install nudge copy and action label', () => {
+    render(<ContextualNudgeBanner nudgeType="pwa-install" onAction={vi.fn()} onDismiss={vi.fn()} />)
+
+    expect(screen.getByText('Quick access')).toBeVisible()
+    expect(screen.getByText('Install widget')).toBeVisible()
+  })
+
+  it('invokes onAction when the action button is clicked', () => {
+    const onAction = vi.fn()
+    render(<ContextualNudgeBanner nudgeType="customize" onAction={onAction} onDismiss={vi.fn()} />)
+
+    fireEvent.click(screen.getByText('Add a card'))
+
+    expect(onAction).toHaveBeenCalledTimes(1)
+  })
+
+  it('invokes onDismiss when the dismiss button is clicked', () => {
+    const onDismiss = vi.fn()
+    render(<ContextualNudgeBanner nudgeType="pwa-install" onAction={vi.fn()} onDismiss={onDismiss} />)
+
+    fireEvent.click(screen.getByTitle('Dismiss'))
+
+    expect(onDismiss).toHaveBeenCalledTimes(1)
+  })
+})

--- a/web/src/components/dashboard/__tests__/cardFactoryManageTab.test.tsx
+++ b/web/src/components/dashboard/__tests__/cardFactoryManageTab.test.tsx
@@ -1,0 +1,78 @@
+import React from 'react'
+/**
+ * Coverage for cardFactoryManageTab.tsx (Auto-QA #21690 — missing test file).
+ *
+ * Verifies the empty-state rendering, the list rendering (title, tier badge,
+ * description, id/createdAt metadata) and the delete affordance callback.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ManageCardsTab } from '../cardFactoryManageTab'
+import type { DynamicCardDefinition } from '../../../lib/dynamic-cards/types'
+
+function makeCard(overrides: Partial<DynamicCardDefinition> = {}): DynamicCardDefinition {
+  return {
+    id: 'card-1',
+    title: 'My Card',
+    description: 'A description',
+    tier: 'tier1',
+    createdAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+    ...overrides,
+  } as DynamicCardDefinition
+}
+
+describe('ManageCardsTab', () => {
+  it('renders the empty state when there are no existing cards', () => {
+    render(<ManageCardsTab existingCards={[]} onDeleteRequest={vi.fn()} />)
+
+    expect(screen.getByText('dashboard.cardFactory.noCustomCards')).toBeVisible()
+    expect(screen.getByText('dashboard.cardFactory.useDeclarativeOrCode')).toBeVisible()
+  })
+
+  it('renders a declarative (tier1) badge for tier1 cards', () => {
+    render(<ManageCardsTab existingCards={[makeCard({ tier: 'tier1' })]} onDeleteRequest={vi.fn()} />)
+
+    expect(screen.getByText('My Card')).toBeVisible()
+    expect(screen.getByText('dashboard.cardFactory.declarativeBadge')).toBeVisible()
+  })
+
+  it('renders a custom-code badge for non-tier1 cards', () => {
+    render(<ManageCardsTab existingCards={[makeCard({ tier: 'tier2' as unknown as DynamicCardDefinition['tier'] })]} onDeleteRequest={vi.fn()} />)
+
+    expect(screen.getByText('dashboard.cardFactory.customCodeBadge')).toBeVisible()
+  })
+
+  it('omits the description paragraph when description is empty', () => {
+    render(<ManageCardsTab existingCards={[makeCard({ description: '' })]} onDeleteRequest={vi.fn()} />)
+
+    expect(screen.queryByText('A description')).not.toBeInTheDocument()
+  })
+
+  it('renders id and createdAt metadata for each card', () => {
+    render(<ManageCardsTab existingCards={[makeCard({ id: 'abc-123' })]} onDeleteRequest={vi.fn()} />)
+
+    expect(screen.getByText(/ID: abc-123/)).toBeVisible()
+  })
+
+  it('invokes onDeleteRequest with the card id when the delete button is clicked', () => {
+    const onDeleteRequest = vi.fn()
+    render(<ManageCardsTab existingCards={[makeCard({ id: 'card-42' })]} onDeleteRequest={onDeleteRequest} />)
+
+    fireEvent.click(screen.getByTitle('dashboard.cardFactory.deleteCard'))
+
+    expect(onDeleteRequest).toHaveBeenCalledWith('card-42')
+    expect(onDeleteRequest).toHaveBeenCalledTimes(1)
+  })
+
+  it('renders one row per card when multiple cards are given', () => {
+    render(
+      <ManageCardsTab
+        existingCards={[makeCard({ id: 'a', title: 'Card A' }), makeCard({ id: 'b', title: 'Card B' })]}
+        onDeleteRequest={vi.fn()}
+      />,
+    )
+
+    expect(screen.getByText('Card A')).toBeVisible()
+    expect(screen.getByText('Card B')).toBeVisible()
+  })
+})

--- a/web/src/components/marketplace/__tests__/CNCFProgressBanner.test.tsx
+++ b/web/src/components/marketplace/__tests__/CNCFProgressBanner.test.tsx
@@ -1,0 +1,101 @@
+import React from 'react'
+/**
+ * Coverage for CNCFProgressBanner.tsx (Auto-QA #21690 — missing test file).
+ *
+ * Verifies the null-render guard, progress percentage/label rendering,
+ * collapse/expand toggle (with localStorage persistence), and cross-tab
+ * sync via the `storage` event (fix #6006).
+ */
+import { describe, it, expect, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CNCFProgressBanner } from '../CNCFProgressBanner'
+import type { CNCFStats } from '../../../hooks/useMarketplace'
+
+const BANNER_COLLAPSED_KEY = 'kc-cncf-banner-collapsed'
+
+function makeStats(overrides: Partial<CNCFStats> = {}): CNCFStats {
+  return {
+    total: 10,
+    completed: 4,
+    graduatedTotal: 5,
+    incubatingTotal: 3,
+    helpWanted: 2,
+    ...overrides,
+  } as CNCFStats
+}
+
+describe('CNCFProgressBanner', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders nothing when stats.total is 0', () => {
+    const { container } = render(<CNCFProgressBanner stats={makeStats({ total: 0 })} />)
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it('renders the computed percentage and completed/total copy', () => {
+    render(<CNCFProgressBanner stats={makeStats({ completed: 4, total: 10 })} />)
+
+    expect(screen.getByText('40%')).toBeVisible()
+    expect(screen.getByText('4 of 10 cards implemented')).toBeVisible()
+  })
+
+  it('is expanded by default and shows stats + action links', () => {
+    render(<CNCFProgressBanner stats={makeStats()} />)
+
+    expect(screen.getByText(/Graduated/)).toBeVisible()
+    expect(screen.getByText(/Incubating/)).toBeVisible()
+    expect(screen.getByText(/Help Wanted/)).toBeVisible()
+    expect(screen.getByText('Browse Issues')).toBeVisible()
+    expect(screen.getByText('Contributor Guide')).toBeVisible()
+  })
+
+  it('starts collapsed when localStorage has the collapsed flag set', () => {
+    localStorage.setItem(BANNER_COLLAPSED_KEY, 'true')
+    render(<CNCFProgressBanner stats={makeStats()} />)
+
+    expect(screen.queryByText('Browse Issues')).not.toBeInTheDocument()
+  })
+
+  it('toggles collapse state and persists it to localStorage on click', () => {
+    render(<CNCFProgressBanner stats={makeStats()} />)
+
+    expect(screen.getByText('Browse Issues')).toBeVisible()
+
+    fireEvent.click(screen.getByText('CNCF Project Coverage'))
+
+    expect(screen.queryByText('Browse Issues')).not.toBeInTheDocument()
+    expect(localStorage.getItem(BANNER_COLLAPSED_KEY)).toBe('true')
+
+    fireEvent.click(screen.getByText('CNCF Project Coverage'))
+
+    expect(screen.getByText('Browse Issues')).toBeVisible()
+    expect(localStorage.getItem(BANNER_COLLAPSED_KEY)).toBe('false')
+  })
+
+  it('syncs collapsed state across tabs via the storage event', () => {
+    render(<CNCFProgressBanner stats={makeStats()} />)
+
+    expect(screen.getByText('Browse Issues')).toBeVisible()
+
+    fireEvent(
+      window,
+      Object.assign(new Event('storage'), { key: BANNER_COLLAPSED_KEY, newValue: 'true' }),
+    )
+
+    expect(screen.queryByText('Browse Issues')).not.toBeInTheDocument()
+  })
+
+  it('ignores storage events for unrelated keys', () => {
+    render(<CNCFProgressBanner stats={makeStats()} />)
+
+    fireEvent(
+      window,
+      Object.assign(new Event('storage'), { key: 'some-other-key', newValue: 'true' }),
+    )
+
+    expect(screen.getByText('Browse Issues')).toBeVisible()
+  })
+})


### PR DESCRIPTION
Fixes #21684, Fixes #21690, Fixes #21692, Fixes #21707

## Summary

- **#21690** (missing test coverage): added unit tests for three of the flagged components — `ManageCardsTab` (`cardFactoryManageTab.tsx`), `ContextualNudgeBanner.tsx`, and `CNCFProgressBanner.tsx` — covering empty/loaded states, badge variants, collapse/expand + localStorage persistence, cross-tab `storage` sync, and callback wiring. 19 new tests, all passing.
- **#21684** and **#21707**: verified already fixed on `main` by prior PRs #21685 and #21708, which added `agentSelectorUtils.test.ts` and `statBlockFactoryModal.utils.test.ts` respectively. No further changes needed; both issues were already closed as completed.
- **#21692** (UI flicker patterns): audited every finding.
  - The "consecutive setState calls" hits (`useDurabilityMonitor`, `useMissions.provider`, `useTour`, `useVersionCheckCore`, `useRewards`) are synchronous same-tick updates. This repo is on **React 19** (`web/package.json`), which automatically batches state updates everywhere (event handlers, timeouts, promises, native listeners) — there is no intermediate paint/flicker risk. One flagged pair (`useDurabilityMonitor.tsx:50/52`) is a ref assignment mistaken for `setState`.
  - The `useLayoutEffect` usages (`ThemeContext.tsx`, `MissionControlDialog.tsx`, `PipelineFlow.tsx`, `CardDataContext.tsx`) all have inline comments documenting the intentional pre-paint DOM-timing rationale (e.g. "prevents a flash of the previous theme's colors").
  - Several "missing skeleton/Suspense" hits point at `*.test.tsx` files, not components.
  - No code changes were warranted for this finding; verified with evidence rather than modified to avoid unnecessary/incorrect refactors.

## Testing
- `npx vitest run` on the 3 new test files: 3 files / 19 tests passed.
- `npx eslint` on the 3 new test files: clean.
