### PR TITLE
✨ Split GPUReservations.tsx: extract useGPUDashboardCards, useGPUCalendarState, useGPUReservationForm

### DIFF
--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -27,34 +27,23 @@ import { cn } from '../../lib/cn'
 import { Input } from '../ui/Input'
 import { useGPUReservations } from '../../hooks/useGPUReservations'
 import { useGPUUtilizations } from '../../hooks/useGPUUtilizations'
-import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
-import { getDefaultCardWidth } from '../cards/cardRegistry'
+import type { CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
 import { StatusBadge } from '../ui/StatusBadge'
 import { AddCardModal } from '../dashboard/AddCardModal'
-import { safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
 import { useRefreshIndicator } from '../../hooks/useRefreshIndicator'
-import {
-  KeyboardSensor,
-  PointerSensor,
-  useSensor,
-  useSensors,
-  DragEndEvent } from '@dnd-kit/core'
-import {
-  arrayMove,
-  sortableKeyboardCoordinates } from '@dnd-kit/sortable'
 
 // Extracted sub-components and constants
 import { GPU_KEYS } from './gpu-constants'
-import type { GpuDashCard } from './SortableGpuCard'
-import { DEFAULT_GPU_CARDS } from './SortableGpuCard'
 import { GPUOverviewTab } from './GPUOverviewTab'
 import { GPUCalendarTab } from './GPUCalendarTab'
-import type { CalendarBar } from './GPUCalendarTab'
 import { GPUReservationsTab } from './GPUReservationsTab'
 import { GPUInventoryTab } from './GPUInventoryTab'
 import { GPUDashboardTab } from './GPUDashboardTab'
 import { computeGPUOverviewStats } from './gpuOverviewStats'
 import { CompactErrorBoundary } from '../CompactErrorBoundary'
+import { useGPUDashboardCards } from './useGPUDashboardCards'
+import { useGPUCalendarState } from './useGPUCalendarState'
+import { useGPUReservationForm } from './useGPUReservationForm'
 
 type ViewTab = 'overview' | 'calendar' | 'quotas' | 'inventory' | 'dashboard'
 
@@ -92,74 +81,21 @@ export function GPUReservations() {
   const { resourceQuotas } = useResourceQuotas(undefined, undefined, gpuLiveMode)
   const { showToast } = useToast()
   const [activeTab, setActiveTab] = useState<ViewTab>('overview')
-  const [currentMonth, setCurrentMonth] = useState(new Date())
-  const [showReservationForm, setShowReservationForm] = useState(false)
   const [expandedReservationId, setExpandedReservationId] = useState<string | null>(null)
-  const [editingReservation, setEditingReservation] = useState<GPUReservation | null>(null)
-  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
-  const [isDeleting, setIsDeleting] = useState(false)
   const [showOnlyMine, setShowOnlyMine] = useState(false)
   const [searchTerm, setSearchTerm] = useState('')
-  const [prefillDate, setPrefillDate] = useState<string | null>(null)
   const { isOpen: showAddCardModal, open: openAddCardModal, close: closeAddCardModal } = useModalState()
 
-  // Dashboard tab: customizable GPU cards persisted to localStorage
-  const GPU_DASHBOARD_STORAGE_KEY = 'gpu-dashboard-tab-cards'
-  const [dashboardCards, setDashboardCards] = useState<GpuDashCard[]>(() => {
-    const stored = safeGetJSON<GpuDashCard[] | string[]>(GPU_DASHBOARD_STORAGE_KEY)
-    if (!stored || stored.length === 0) return DEFAULT_GPU_CARDS
-    // Migrate from old string[] format
-    if (typeof stored[0] === 'string') {
-      const migrated = (stored as string[]).map(type => ({ type, width: getDefaultCardWidth(type) }))
-      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, migrated)
-      return migrated
-    }
-    return stored as GpuDashCard[]
-  })
-  const handleAddDashboardCards = (suggestions: Array<{ type: string; title: string; visualization: string; config: Record<string, unknown> }>) => {
-    setDashboardCards(prev => {
-      const updated = [...prev, ...suggestions.map(s => ({ type: s.type, width: getDefaultCardWidth(s.type) }))]
-      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
-      return updated
-    })
-    closeAddCardModal()
-  }
-  const handleRemoveDashboardCard = (index: number) => {
-    setDashboardCards(prev => {
-      const updated = prev.filter((_, i) => i !== index)
-      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
-      return updated
-    })
-  }
-  const handleDashCardWidthChange = (index: number, newWidth: number) => {
-    setDashboardCards(prev => {
-      const updated = prev.map((c, i) => i === index ? { ...c, width: newWidth } : c)
-      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
-      return updated
-    })
-  }
-
-  // Drag-and-drop for dashboard tab card reordering
-  const gpuDashSensors = useSensors(
-    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
-  )
-  const dashCardIds = dashboardCards.map((c, i) => `gpu-dash-${c.type}-${i}`)
-  const handleDashDragEnd = (event: DragEndEvent) => {
-    const { active, over } = event
-    if (over && active.id !== over.id) {
-      const oldIndex = dashCardIds.indexOf(active.id as string)
-      const newIndex = dashCardIds.indexOf(over.id as string)
-      if (oldIndex !== -1 && newIndex !== -1) {
-        setDashboardCards(prev => {
-          const updated = arrayMove(prev, oldIndex, newIndex)
-          safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
-          return updated
-        })
-      }
-    }
-  }
-
+  // Dashboard card state + DnD
+  const {
+    dashboardCards,
+    dashCardIds,
+    gpuDashSensors,
+    handleAddDashboardCards,
+    handleRemoveDashboardCard,
+    handleDashCardWidthChange,
+    handleDashDragEnd,
+  } = useGPUDashboardCards()
 
   // API-backed reservations
   const {
@@ -187,16 +123,13 @@ export function GPUReservations() {
   // Filtered reservations respecting "My Reservations" toggle, cluster selection, and keyword search
   const filteredReservations = useMemo(() => {
     let filtered = allReservations || []
-    // Filter by cluster selection
     if (!isAllClustersSelected) {
       filtered = filtered.filter(r => selectedClusters.some(c => r.cluster.startsWith(c)))
     }
-    // Filter by user
     if (showOnlyMine && user) {
       const login = user.github_login?.toLowerCase()
       filtered = filtered.filter(r => r.user_name.toLowerCase() === login)
     }
-    // Filter by keyword search
     if (searchTerm.trim()) {
       const term = searchTerm.trim().toLowerCase()
       filtered = filtered.filter(r =>
@@ -206,9 +139,6 @@ export function GPUReservations() {
         (r.cluster ?? '').toLowerCase().includes(term) ||
         (r.status ?? '').toLowerCase().includes(term) ||
         (r.gpu_type && r.gpu_type.toLowerCase().includes(term)) ||
-        // Match against any accepted GPU type so searching
-        // for "H100" finds multi-type reservations that list H100
-        // among their acceptable alternatives.
         (r.gpu_types && r.gpu_types.some(t => t.toLowerCase().includes(term))) ||
         (r.description && r.description.toLowerCase().includes(term)) ||
         (r.notes && r.notes.toLowerCase().includes(term))
@@ -245,12 +175,7 @@ export function GPUReservations() {
   })()
 
   // Namespaces known to have existing reservations, grouped by cluster.
-  // Fallback source for the Create Reservation dropdown when useNamespaces()
-  // can't surface a namespace (e.g. user lacks cluster-wide list RBAC AND
-  // the namespace has no running pods, so neither health-check discovery
-  // nor the /api/mcp/pods-based REST fallback sees it).
   const knownNamespacesByCluster = useMemo(() => {
-    // Use a Map<string, Set<string>> to dedupe in O(1) per entry.
     const byCluster = new Map<string, Set<string>>()
     for (const r of (allReservations || [])) {
       if (!r.cluster || !r.namespace) continue
@@ -276,197 +201,34 @@ export function GPUReservations() {
     gpuClusters,
   }), [nodes, gpuQuotas, gpuClusters, filteredReservations])
 
-  // Calendar helpers
-  const getDaysInMonth = (date: Date) => {
-    const year = date.getFullYear()
-    const month = date.getMonth()
-    const firstDay = new Date(year, month, 1)
-    const lastDay = new Date(year, month + 1, 0)
-    const daysInMonth = lastDay.getDate()
-    const startingDay = firstDay.getDay()
-    return { daysInMonth, startingDay }
-  }
+  // Calendar state: month navigation + week layout
+  const {
+    currentMonth,
+    calendarWeeks,
+    getGPUCountForDay,
+    prevMonth,
+    nextMonth,
+  } = useGPUCalendarState(filteredReservations)
 
-  const { daysInMonth, startingDay } = getDaysInMonth(currentMonth)
-
-  // Get the start/end day index (0-based from month start) for a reservation within the visible month.
-  // Duration is added to the ORIGINAL start time first, then day boundaries are derived.
-  const getReservationDayRange = useCallback((r: GPUReservation) => {
-    if (!r.start_date) return null
-    const MS_PER_HOUR = 3_600_000
-    const DEFAULT_DURATION_HOURS = 24
-
-    const originalStart = new Date(r.start_date)
-    const durationHours = r.duration_hours || DEFAULT_DURATION_HOURS
-    // Compute end from the exact original timestamp, not a midnight-normalized one
-    const exactEnd = new Date(originalStart.getTime() + durationHours * MS_PER_HOUR)
-
-    // Normalize to day boundaries for calendar range display
-    const start = new Date(originalStart)
-    start.setHours(0, 0, 0, 0)
-    const end = new Date(exactEnd)
-    end.setHours(23, 59, 59, 999)
-
-    const monthStart = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
-    monthStart.setHours(0, 0, 0, 0)
-    const monthEnd = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0)
-    monthEnd.setHours(23, 59, 59, 999)
-
-    if (end < monthStart || start > monthEnd) return null
-
-    const clampedStart = start < monthStart ? 1 : start.getDate()
-    const clampedEnd = end > monthEnd ? daysInMonth : end.getDate()
-    return { startDay: clampedStart, endDay: clampedEnd }
-  }, [currentMonth, daysInMonth])
-
-  // Compute spanning reservation rows per calendar week
-  const calendarWeeks = useMemo(() => {
-    const totalCells = startingDay + daysInMonth
-    const numWeeks = Math.ceil(totalCells / 7)
-    const weeks: { days: (number | null)[]; bars: CalendarBar[] }[] = []
-
-    // Build week arrays
-    for (let w = 0; w < numWeeks; w++) {
-      const days: (number | null)[] = []
-      for (let col = 0; col < 7; col++) {
-        const cellIndex = w * 7 + col
-        const day = cellIndex - startingDay + 1
-        days.push(day >= 1 && day <= daysInMonth ? day : null)
-      }
-      weeks.push({ days, bars: [] })
-    }
-
-    // For each reservation, compute which weeks it spans and assign row slots
-    // Track row occupancy per week: rowOccupancy[weekIndex][row] = reservationId or null
-    const rowOccupancy: (string | null)[][] = weeks.map(() => [])
-
-    // Sort reservations by start day then by duration (longer first) for stable layout
-    const sortedReservations = [...filteredReservations]
-      .map(r => ({ r, range: getReservationDayRange(r) }))
-      .filter((x): x is { r: GPUReservation; range: { startDay: number; endDay: number } } => x.range !== null)
-      .sort((a, b) => a.range.startDay - b.range.startDay || (b.range.endDay - b.range.startDay) - (a.range.endDay - a.range.startDay))
-
-    for (const { r, range } of sortedReservations) {
-      // Find which weeks this reservation touches
-      for (let w = 0; w < weeks.length; w++) {
-        const weekStartDay = weeks[w].days.find(d => d !== null) ?? 1
-        const weekEndDay = [...weeks[w].days].reverse().find(d => d !== null) ?? daysInMonth
-
-        if (range.startDay > weekEndDay || range.endDay < weekStartDay) continue
-
-        // Compute column range within this week
-        const barStartDay = Math.max(range.startDay, weekStartDay)
-        const barEndDay = Math.min(range.endDay, weekEndDay)
-        const startCol = weeks[w].days.indexOf(barStartDay)
-        const endCol = weeks[w].days.indexOf(barEndDay)
-        if (startCol === -1 || endCol === -1) continue
-
-        // Find a free row slot
-        let row = 0
-        while (true) {
-          if (!rowOccupancy[w][row]) break
-          if (rowOccupancy[w][row] !== r.id) {
-            // Check if this row has a conflict in the column range
-            let conflict = false
-            for (const bar of weeks[w].bars) {
-              if (bar.row === row) {
-                const barEnd = bar.startCol + bar.spanCols - 1
-                if (!(endCol < bar.startCol || startCol > barEnd)) {
-                  conflict = true
-                  break
-                }
-              }
-            }
-            if (!conflict) break
-          }
-          row++
-        }
-        rowOccupancy[w][row] = r.id
-
-        weeks[w].bars.push({
-          reservation: r,
-          startCol,
-          spanCols: endCol - startCol + 1,
-          row,
-          isStart: barStartDay === range.startDay,
-          isEnd: barEndDay === range.endDay })
-      }
-    }
-
-    return weeks
-  }, [filteredReservations, startingDay, daysInMonth, getReservationDayRange])
-
-  // Get GPU count reserved on a specific day
-  const getGPUCountForDay = (day: number) => {
-    const MS_PER_HOUR = 3_600_000
-    const DEFAULT_DURATION_HOURS = 24
-    const date = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day)
-    date.setHours(0, 0, 0, 0)
-    let total = 0
-    for (const r of filteredReservations) {
-      if (!r.start_date) continue
-      const originalStart = new Date(r.start_date)
-      const durationHours = r.duration_hours || DEFAULT_DURATION_HOURS
-      // Compute end from the exact original timestamp, then normalize to day boundaries
-      const exactEnd = new Date(originalStart.getTime() + durationHours * MS_PER_HOUR)
-      const start = new Date(originalStart)
-      start.setHours(0, 0, 0, 0)
-      const end = new Date(exactEnd)
-      end.setHours(23, 59, 59, 999)
-      if (date >= start && date <= end) {
-        total += r.gpu_count
-      }
-    }
-    return total
-  }
-
-  const prevMonth = () => {
-    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1))
-  }
-
-  const nextMonth = () => {
-    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1))
-  }
-
-  // Handlers
-  const handleDeleteReservation = async () => {
-    if (!deleteConfirmId) return
-    setIsDeleting(true)
-    try {
-      await apiDeleteReservation(deleteConfirmId)
-      showToast('GPU reservation deleted', 'success')
-    } catch (err: unknown) {
-      showToast(`Failed to delete: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error')
-    } finally {
-      setIsDeleting(false)
-      setDeleteConfirmId(null)
-    }
-  }
-
-  // Named callbacks for multi-state transitions — keeps JSX clean and ensures
-  // the paired state updates are always applied atomically (React 19 batches
-  // all setState calls within the same synchronous function).
-  const openCreateForm = useCallback(() => {
-    setEditingReservation(null)
-    setShowReservationForm(true)
-  }, [])
-
-  const openEditForm = useCallback((r: GPUReservation) => {
-    setEditingReservation(r)
-    setShowReservationForm(true)
-  }, [])
-
-  const closeReservationForm = useCallback(() => {
-    setShowReservationForm(false)
-    setEditingReservation(null)
-    setPrefillDate(null)
-  }, [])
-
-  const openCreateFormForDate = useCallback((dateStr: string) => {
-    setPrefillDate(dateStr)
-    setEditingReservation(null)
-    setShowReservationForm(true)
-  }, [])
+  // Reservation form / delete-confirmation state
+  const {
+    showReservationForm,
+    editingReservation,
+    deleteConfirmId,
+    isDeleting,
+    prefillDate,
+    deleteConfirmReservation,
+    setDeleteConfirmId,
+    handleDeleteReservation,
+    openCreateForm,
+    openEditForm,
+    closeReservationForm,
+    openCreateFormForDate,
+  } = useGPUReservationForm({
+    allReservations,
+    onDelete: apiDeleteReservation,
+    onShowToast: showToast,
+  })
 
   const goToReservation = useCallback((id: string) => {
     setExpandedReservationId(id)
@@ -475,16 +237,10 @@ export function GPUReservations() {
 
   const toggleShowOnlyMine = useCallback(() => {
     setShowOnlyMine(prev => {
-      // Navigate to reservations tab when the filter is being switched on so
-      // users immediately see the filtered list.
       if (!prev) setActiveTab('quotas')
       return !prev
     })
   }, [])
-
-  const deleteConfirmReservation = deleteConfirmId
-    ? allReservations.find(r => r.id === deleteConfirmId)
-    : null
 
   const isLoading = nodesLoading && nodes.length === 0 && reservationsLoading
 
@@ -674,7 +430,7 @@ export function GPUReservations() {
       <AddCardModal
         isOpen={showAddCardModal}
         onClose={closeAddCardModal}
-        onAddCards={handleAddDashboardCards}
+        onAddCards={(suggestions) => { handleAddDashboardCards(suggestions); closeAddCardModal() }}
         existingCardTypes={dashboardCards.map(c => c.type)}
       />
 

--- a/web/src/components/gpu/useGPUCalendarState.ts
+++ b/web/src/components/gpu/useGPUCalendarState.ts
@@ -1,0 +1,154 @@
+import { useState, useCallback, useMemo } from 'react'
+import type { GPUReservation } from '../../hooks/useGPUReservations'
+import type { CalendarBar } from './GPUCalendarTab'
+
+export function useGPUCalendarState(filteredReservations: GPUReservation[]) {
+  const [currentMonth, setCurrentMonth] = useState(new Date())
+
+  const getDaysInMonth = (date: Date) => {
+    const year = date.getFullYear()
+    const month = date.getMonth()
+    const firstDay = new Date(year, month, 1)
+    const lastDay = new Date(year, month + 1, 0)
+    const daysInMonth = lastDay.getDate()
+    const startingDay = firstDay.getDay()
+    return { daysInMonth, startingDay }
+  }
+
+  const { daysInMonth, startingDay } = getDaysInMonth(currentMonth)
+
+  // Get the start/end day index (0-based from month start) for a reservation within the visible month.
+  const getReservationDayRange = useCallback((r: GPUReservation) => {
+    if (!r.start_date) return null
+    const MS_PER_HOUR = 3_600_000
+    const DEFAULT_DURATION_HOURS = 24
+
+    const originalStart = new Date(r.start_date)
+    const durationHours = r.duration_hours || DEFAULT_DURATION_HOURS
+    const exactEnd = new Date(originalStart.getTime() + durationHours * MS_PER_HOUR)
+
+    const start = new Date(originalStart)
+    start.setHours(0, 0, 0, 0)
+    const end = new Date(exactEnd)
+    end.setHours(23, 59, 59, 999)
+
+    const monthStart = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), 1)
+    monthStart.setHours(0, 0, 0, 0)
+    const monthEnd = new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 0)
+    monthEnd.setHours(23, 59, 59, 999)
+
+    if (end < monthStart || start > monthEnd) return null
+
+    const clampedStart = start < monthStart ? 1 : start.getDate()
+    const clampedEnd = end > monthEnd ? daysInMonth : end.getDate()
+    return { startDay: clampedStart, endDay: clampedEnd }
+  }, [currentMonth, daysInMonth])
+
+  // Compute spanning reservation rows per calendar week
+  const calendarWeeks = useMemo(() => {
+    const totalCells = startingDay + daysInMonth
+    const numWeeks = Math.ceil(totalCells / 7)
+    const weeks: { days: (number | null)[]; bars: CalendarBar[] }[] = []
+
+    for (let w = 0; w < numWeeks; w++) {
+      const days: (number | null)[] = []
+      for (let col = 0; col < 7; col++) {
+        const cellIndex = w * 7 + col
+        const day = cellIndex - startingDay + 1
+        days.push(day >= 1 && day <= daysInMonth ? day : null)
+      }
+      weeks.push({ days, bars: [] })
+    }
+
+    const rowOccupancy: (string | null)[][] = weeks.map(() => [])
+
+    const sortedReservations = [...filteredReservations]
+      .map(r => ({ r, range: getReservationDayRange(r) }))
+      .filter((x): x is { r: GPUReservation; range: { startDay: number; endDay: number } } => x.range !== null)
+      .sort((a, b) => a.range.startDay - b.range.startDay || (b.range.endDay - b.range.startDay) - (a.range.endDay - a.range.startDay))
+
+    for (const { r, range } of sortedReservations) {
+      for (let w = 0; w < weeks.length; w++) {
+        const weekStartDay = weeks[w].days.find(d => d !== null) ?? 1
+        const weekEndDay = [...weeks[w].days].reverse().find(d => d !== null) ?? daysInMonth
+
+        if (range.startDay > weekEndDay || range.endDay < weekStartDay) continue
+
+        const barStartDay = Math.max(range.startDay, weekStartDay)
+        const barEndDay = Math.min(range.endDay, weekEndDay)
+        const startCol = weeks[w].days.indexOf(barStartDay)
+        const endCol = weeks[w].days.indexOf(barEndDay)
+        if (startCol === -1 || endCol === -1) continue
+
+        let row = 0
+        while (true) {
+          if (!rowOccupancy[w][row]) break
+          if (rowOccupancy[w][row] !== r.id) {
+            let conflict = false
+            for (const bar of weeks[w].bars) {
+              if (bar.row === row) {
+                const barEnd = bar.startCol + bar.spanCols - 1
+                if (!(endCol < bar.startCol || startCol > barEnd)) {
+                  conflict = true
+                  break
+                }
+              }
+            }
+            if (!conflict) break
+          }
+          row++
+        }
+        rowOccupancy[w][row] = r.id
+
+        weeks[w].bars.push({
+          reservation: r,
+          startCol,
+          spanCols: endCol - startCol + 1,
+          row,
+          isStart: barStartDay === range.startDay,
+          isEnd: barEndDay === range.endDay,
+        })
+      }
+    }
+
+    return weeks
+  }, [filteredReservations, startingDay, daysInMonth, getReservationDayRange])
+
+  const getGPUCountForDay = (day: number) => {
+    const MS_PER_HOUR = 3_600_000
+    const DEFAULT_DURATION_HOURS = 24
+    const date = new Date(currentMonth.getFullYear(), currentMonth.getMonth(), day)
+    date.setHours(0, 0, 0, 0)
+    let total = 0
+    for (const r of filteredReservations) {
+      if (!r.start_date) continue
+      const originalStart = new Date(r.start_date)
+      const durationHours = r.duration_hours || DEFAULT_DURATION_HOURS
+      const exactEnd = new Date(originalStart.getTime() + durationHours * MS_PER_HOUR)
+      const start = new Date(originalStart)
+      start.setHours(0, 0, 0, 0)
+      const end = new Date(exactEnd)
+      end.setHours(23, 59, 59, 999)
+      if (date >= start && date <= end) {
+        total += r.gpu_count
+      }
+    }
+    return total
+  }
+
+  const prevMonth = () => {
+    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() - 1, 1))
+  }
+
+  const nextMonth = () => {
+    setCurrentMonth(new Date(currentMonth.getFullYear(), currentMonth.getMonth() + 1, 1))
+  }
+
+  return {
+    currentMonth,
+    calendarWeeks,
+    getGPUCountForDay,
+    prevMonth,
+    nextMonth,
+  }
+}

--- a/web/src/components/gpu/useGPUDashboardCards.ts
+++ b/web/src/components/gpu/useGPUDashboardCards.ts
@@ -1,0 +1,85 @@
+import { useState } from 'react'
+import {
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core'
+import { arrayMove, sortableKeyboardCoordinates } from '@dnd-kit/sortable'
+import { getDefaultCardWidth } from '../cards/cardRegistry'
+import type { GpuDashCard } from './SortableGpuCard'
+import { DEFAULT_GPU_CARDS } from './SortableGpuCard'
+import { safeGetJSON, safeSetJSON } from '../../lib/utils/localStorage'
+
+const GPU_DASHBOARD_STORAGE_KEY = 'gpu-dashboard-tab-cards'
+
+export function useGPUDashboardCards() {
+  const [dashboardCards, setDashboardCards] = useState<GpuDashCard[]>(() => {
+    const stored = safeGetJSON<GpuDashCard[] | string[]>(GPU_DASHBOARD_STORAGE_KEY)
+    if (!stored || stored.length === 0) return DEFAULT_GPU_CARDS
+    // Migrate from old string[] format
+    if (typeof stored[0] === 'string') {
+      const migrated = (stored as string[]).map(type => ({ type, width: getDefaultCardWidth(type) }))
+      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, migrated)
+      return migrated
+    }
+    return stored as GpuDashCard[]
+  })
+
+  const gpuDashSensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  const dashCardIds = dashboardCards.map((c, i) => `gpu-dash-${c.type}-${i}`)
+
+  const handleAddDashboardCards = (suggestions: Array<{ type: string; title: string; visualization: string; config: Record<string, unknown> }>) => {
+    setDashboardCards(prev => {
+      const updated = [...prev, ...suggestions.map(s => ({ type: s.type, width: getDefaultCardWidth(s.type) }))]
+      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
+      return updated
+    })
+  }
+
+  const handleRemoveDashboardCard = (index: number) => {
+    setDashboardCards(prev => {
+      const updated = prev.filter((_, i) => i !== index)
+      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
+      return updated
+    })
+  }
+
+  const handleDashCardWidthChange = (index: number, newWidth: number) => {
+    setDashboardCards(prev => {
+      const updated = prev.map((c, i) => i === index ? { ...c, width: newWidth } : c)
+      safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
+      return updated
+    })
+  }
+
+  const handleDashDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event
+    if (over && active.id !== over.id) {
+      const oldIndex = dashCardIds.indexOf(active.id as string)
+      const newIndex = dashCardIds.indexOf(over.id as string)
+      if (oldIndex !== -1 && newIndex !== -1) {
+        setDashboardCards(prev => {
+          const updated = arrayMove(prev, oldIndex, newIndex)
+          safeSetJSON(GPU_DASHBOARD_STORAGE_KEY, updated)
+          return updated
+        })
+      }
+    }
+  }
+
+  return {
+    dashboardCards,
+    dashCardIds,
+    gpuDashSensors,
+    handleAddDashboardCards,
+    handleRemoveDashboardCard,
+    handleDashCardWidthChange,
+    handleDashDragEnd,
+  }
+}

--- a/web/src/components/gpu/useGPUReservationForm.ts
+++ b/web/src/components/gpu/useGPUReservationForm.ts
@@ -1,0 +1,75 @@
+import { useState, useCallback } from 'react'
+import type { GPUReservation } from '../../hooks/useGPUReservations'
+
+interface UseGPUReservationFormOptions {
+  allReservations: GPUReservation[]
+  onDelete: (id: string) => Promise<void>
+  onShowToast: (msg: string, type: 'success' | 'error') => void
+}
+
+export function useGPUReservationForm({
+  allReservations,
+  onDelete,
+  onShowToast,
+}: UseGPUReservationFormOptions) {
+  const [showReservationForm, setShowReservationForm] = useState(false)
+  const [editingReservation, setEditingReservation] = useState<GPUReservation | null>(null)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [prefillDate, setPrefillDate] = useState<string | null>(null)
+
+  const handleDeleteReservation = async () => {
+    if (!deleteConfirmId) return
+    setIsDeleting(true)
+    try {
+      await onDelete(deleteConfirmId)
+      onShowToast('GPU reservation deleted', 'success')
+    } catch (err: unknown) {
+      onShowToast(`Failed to delete: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error')
+    } finally {
+      setIsDeleting(false)
+      setDeleteConfirmId(null)
+    }
+  }
+
+  const openCreateForm = useCallback(() => {
+    setEditingReservation(null)
+    setShowReservationForm(true)
+  }, [])
+
+  const openEditForm = useCallback((r: GPUReservation) => {
+    setEditingReservation(r)
+    setShowReservationForm(true)
+  }, [])
+
+  const closeReservationForm = useCallback(() => {
+    setShowReservationForm(false)
+    setEditingReservation(null)
+    setPrefillDate(null)
+  }, [])
+
+  const openCreateFormForDate = useCallback((dateStr: string) => {
+    setPrefillDate(dateStr)
+    setEditingReservation(null)
+    setShowReservationForm(true)
+  }, [])
+
+  const deleteConfirmReservation = deleteConfirmId
+    ? allReservations.find(r => r.id === deleteConfirmId)
+    : null
+
+  return {
+    showReservationForm,
+    editingReservation,
+    deleteConfirmId,
+    isDeleting,
+    prefillDate,
+    deleteConfirmReservation,
+    setDeleteConfirmId,
+    handleDeleteReservation,
+    openCreateForm,
+    openEditForm,
+    closeReservationForm,
+    openCreateFormForDate,
+  }
+}


### PR DESCRIPTION
Fixes #21612

## Summary

`GPUReservations.tsx` had ~40 hook calls in a single component (~29 KB), making it hard to read and maintain. This PR extracts three cohesive custom hooks without changing any runtime behaviour:

| New hook | Extracted responsibility |
|---|---|
| `useGPUDashboardCards` | Dashboard card list, localStorage persistence, DnD sensors & drag-end handler |
| `useGPUCalendarState` | Current-month state, calendar-week layout computation, GPU-count-per-day helper |
| `useGPUReservationForm` | Reservation form visibility, editing/delete-confirm state, open/close callbacks, delete handler |

`GPUReservations.tsx` retains only the cross-cutting orchestration (data fetching, global filters, derived stats, tab routing, JSX) and is reduced to ~27 hook calls.

## Changes
- `web/src/components/gpu/useGPUDashboardCards.ts` — new hook
- `web/src/components/gpu/useGPUCalendarState.ts` — new hook
- `web/src/components/gpu/useGPUReservationForm.ts` — new hook
- `web/src/components/gpu/GPUReservations.tsx` — refactored to consume the three hooks; removes `@dnd-kit` imports that are no longer needed here