### PR TITLE
🌱 Split AlertRuleEditor.tsx into focused sub-components

### DIFF
--- a/web/src/components/alerts/AlertRuleBasicInfo.tsx
+++ b/web/src/components/alerts/AlertRuleBasicInfo.tsx
@@ -1,6 +1,8 @@
 import { Bell, BellOff } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import type { AlertSeverity } from '../../types/alerts'
+import { Input } from '../ui/Input'
+import { TextArea } from '../ui/TextArea'
 
 interface SeverityOption {
   value: AlertSeverity
@@ -41,16 +43,15 @@ export function AlertRuleBasicInfo({
         <label htmlFor="alertRuleName" className="block text-sm font-medium text-foreground mb-1">
           {t('alerts.ruleName')} *
         </label>
-        <input
+        <Input
           id="alertRuleName"
           name="alertRuleName"
           type="text"
           value={name}
           onChange={e => onNameChange(e.target.value)}
           placeholder={t('alerts.ruleNamePlaceholder')}
-          className={`w-full px-3 py-2 rounded-lg bg-secondary border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-            errors.name ? 'border-red-500' : 'border-border'
-          }`}
+          error={Boolean(errors.name)}
+          className="focus:ring-purple-500"
         />
         {errors.name && (
           <span className="block text-xs text-red-400 mt-1">{errors.name}</span>
@@ -61,14 +62,14 @@ export function AlertRuleBasicInfo({
         <label htmlFor="alertRuleDescription" className="block text-sm font-medium text-foreground mb-1">
           {t('alerts.description')}
         </label>
-        <textarea
+        <TextArea
           id="alertRuleDescription"
           name="alertRuleDescription"
           value={description}
           onChange={e => onDescriptionChange(e.target.value)}
           placeholder={t('alerts.descriptionPlaceholder')}
           rows={2}
-          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 resize-none"
+          className="focus:ring-purple-500"
         />
       </div>
 

--- a/web/src/components/alerts/AlertRuleBasicInfo.tsx
+++ b/web/src/components/alerts/AlertRuleBasicInfo.tsx
@@ -1,0 +1,120 @@
+import { Bell, BellOff } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import type { AlertSeverity } from '../../types/alerts'
+
+interface SeverityOption {
+  value: AlertSeverity
+  label: string
+  color: string
+}
+
+interface AlertRuleBasicInfoProps {
+  name: string
+  onNameChange: (value: string) => void
+  description: string
+  onDescriptionChange: (value: string) => void
+  severity: AlertSeverity
+  onSeverityChange: (value: AlertSeverity) => void
+  enabled: boolean
+  onEnabledChange: (value: boolean) => void
+  errors: Record<string, string>
+  severityOptions: SeverityOption[]
+}
+
+export function AlertRuleBasicInfo({
+  name,
+  onNameChange,
+  description,
+  onDescriptionChange,
+  severity,
+  onSeverityChange,
+  enabled,
+  onEnabledChange,
+  errors,
+  severityOptions,
+}: AlertRuleBasicInfoProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label htmlFor="alertRuleName" className="block text-sm font-medium text-foreground mb-1">
+          {t('alerts.ruleName')} *
+        </label>
+        <input
+          id="alertRuleName"
+          name="alertRuleName"
+          type="text"
+          value={name}
+          onChange={e => onNameChange(e.target.value)}
+          placeholder={t('alerts.ruleNamePlaceholder')}
+          className={`w-full px-3 py-2 rounded-lg bg-secondary border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
+            errors.name ? 'border-red-500' : 'border-border'
+          }`}
+        />
+        {errors.name && (
+          <span className="block text-xs text-red-400 mt-1">{errors.name}</span>
+        )}
+      </div>
+
+      <div>
+        <label htmlFor="alertRuleDescription" className="block text-sm font-medium text-foreground mb-1">
+          {t('alerts.description')}
+        </label>
+        <textarea
+          id="alertRuleDescription"
+          name="alertRuleDescription"
+          value={description}
+          onChange={e => onDescriptionChange(e.target.value)}
+          placeholder={t('alerts.descriptionPlaceholder')}
+          rows={2}
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 resize-none"
+        />
+      </div>
+
+      <div className="flex items-center gap-4">
+        <div>
+          <label className="block text-sm font-medium text-foreground mb-1">
+            {t('alerts.severity')}
+          </label>
+          <div className="flex gap-2">
+            {severityOptions.map(opt => (
+              <button
+                key={opt.value}
+                onClick={() => onSeverityChange(opt.value)}
+                className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-2 transition-colors ${
+                  severity === opt.value
+                    ? `${opt.color}/20 border border-${opt.value === 'critical' ? 'red' : opt.value === 'warning' ? 'orange' : 'blue'}-500/50 text-foreground`
+                    : 'bg-secondary border border-border text-muted-foreground hover:text-foreground'
+                }`}
+                aria-label={`Set severity to ${opt.label}`}
+                aria-pressed={severity === opt.value}
+              >
+                <span className={`w-2 h-2 rounded-full ${opt.color}`} aria-hidden="true" />
+                {opt.label}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2 ml-auto">
+          <button
+            onClick={() => onEnabledChange(!enabled)}
+            className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-2 transition-colors ${
+              enabled
+                ? 'bg-green-500/20 border border-green-500/50 text-green-400'
+                : 'bg-secondary border border-border text-muted-foreground'
+            }`}
+            aria-label={enabled ? 'Disable alert rule' : 'Enable alert rule'}
+            aria-pressed={enabled}
+          >
+            {enabled
+              ? <Bell className="w-4 h-4" aria-hidden="true" />
+              : <BellOff className="w-4 h-4" aria-hidden="true" />}
+            {enabled ? t('alerts.enabled') : t('alerts.disabled')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/alerts/AlertRuleChannels.tsx
+++ b/web/src/components/alerts/AlertRuleChannels.tsx
@@ -1,0 +1,222 @@
+import { Bell, Trash2, Webhook, Siren, ShieldAlert } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Slack } from '@/lib/icons'
+import type { AlertChannel } from '../../types/alerts'
+
+interface AlertRuleChannelsProps {
+  channels: AlertChannel[]
+  onAddChannel: (type: AlertChannel['type']) => void
+  onRemoveChannel: (index: number) => void
+  onUpdateChannel: (index: number, updates: Partial<AlertChannel>) => void
+  errors: Record<string, string>
+}
+
+export function AlertRuleChannels({
+  channels,
+  onAddChannel,
+  onRemoveChannel,
+  onUpdateChannel,
+  errors,
+}: AlertRuleChannelsProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="space-y-4">
+      {errors.channels && (
+        <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-xs text-red-400">
+          {errors.channels}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between">
+        <h4 className="text-sm font-medium text-foreground">{t('alerts.notificationChannels')}</h4>
+        <div className="flex gap-2">
+          <button
+            onClick={() => onAddChannel('browser')}
+            className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
+            aria-label="Add browser notification channel"
+          >
+            <Bell className="w-3 h-3" aria-hidden="true" />
+            {t('alerts.browser')}
+          </button>
+          <button
+            onClick={() => onAddChannel('slack')}
+            className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
+            aria-label="Add Slack notification channel"
+          >
+            <Slack className="w-3 h-3" aria-hidden="true" />
+            {t('alerts.slack')}
+          </button>
+          <button
+            onClick={() => onAddChannel('webhook')}
+            className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
+            aria-label="Add webhook notification channel"
+          >
+            <Webhook className="w-3 h-3" aria-hidden="true" />
+            {t('alerts.webhook')}
+          </button>
+          <button
+            onClick={() => onAddChannel('pagerduty')}
+            className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
+            aria-label="Add PagerDuty notification channel"
+          >
+            <Siren className="w-3 h-3" aria-hidden="true" />
+            PagerDuty
+          </button>
+          <button
+            onClick={() => onAddChannel('opsgenie')}
+            className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
+            aria-label="Add OpsGenie notification channel"
+          >
+            <ShieldAlert className="w-3 h-3" aria-hidden="true" />
+            OpsGenie
+          </button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        {channels.map((channel, index) => (
+          <div
+            key={index}
+            className="p-3 rounded-lg bg-secondary/30 border border-border/50"
+          >
+            <div className="flex items-center justify-between mb-2">
+              <div className="flex items-center gap-2">
+                {channel.type === 'browser' && <Bell className="w-4 h-4" aria-hidden="true" />}
+                {channel.type === 'slack' && <Slack className="w-4 h-4" aria-hidden="true" />}
+                {channel.type === 'webhook' && <Webhook className="w-4 h-4" aria-hidden="true" />}
+                {channel.type === 'pagerduty' && <Siren className="w-4 h-4" aria-hidden="true" />}
+                {channel.type === 'opsgenie' && <ShieldAlert className="w-4 h-4" aria-hidden="true" />}
+                <span className="text-sm font-medium text-foreground capitalize">
+                  {channel.type}
+                </span>
+              </div>
+              <div className="flex items-center gap-2">
+                <button
+                  onClick={() => onUpdateChannel(index, { enabled: !channel.enabled })}
+                  className={`px-2 py-1 text-xs rounded transition-colors ${
+                    channel.enabled
+                      ? 'bg-green-500/20 text-green-400'
+                      : 'bg-secondary text-muted-foreground'
+                  }`}
+                  aria-label={`${channel.enabled ? 'Disable' : 'Enable'} ${channel.type} channel`}
+                >
+                  {channel.enabled ? 'On' : 'Off'}
+                </button>
+                {channels.length > 1 && (
+                  <button
+                    onClick={() => onRemoveChannel(index)}
+                    className="p-1 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
+                    aria-label={`Remove ${channel.type} channel`}
+                  >
+                    <Trash2 className="w-4 h-4" aria-hidden="true" />
+                  </button>
+                )}
+              </div>
+            </div>
+
+            {channel.type === 'slack' && (
+              <div className="space-y-2">
+                <label htmlFor={`alertRuleSlackWebhookUrl-${index}`} className="sr-only">
+                  {t('alerts.slackWebhookUrl')}
+                </label>
+                <input
+                  id={`alertRuleSlackWebhookUrl-${index}`}
+                  name={`alertRuleSlackWebhookUrl-${index}`}
+                  type="text"
+                  placeholder={t('alerts.slackWebhookUrlPlaceholder')}
+                  value={channel.config.slackWebhookUrl || ''}
+                  onChange={e =>
+                    onUpdateChannel(index, {
+                      config: { ...channel.config, slackWebhookUrl: e.target.value },
+                    })
+                  }
+                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                />
+                <label htmlFor={`alertRuleSlackChannel-${index}`} className="sr-only">
+                  {t('alerts.slackChannel')}
+                </label>
+                <input
+                  id={`alertRuleSlackChannel-${index}`}
+                  name={`alertRuleSlackChannel-${index}`}
+                  type="text"
+                  placeholder={t('alerts.slackChannelPlaceholder')}
+                  value={channel.config.slackChannel || ''}
+                  onChange={e =>
+                    onUpdateChannel(index, {
+                      config: { ...channel.config, slackChannel: e.target.value },
+                    })
+                  }
+                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                />
+              </div>
+            )}
+
+            {channel.type === 'webhook' && (
+              <>
+                <label htmlFor={`alertRuleWebhookUrl-${index}`} className="sr-only">
+                  {t('alerts.webhookUrl')}
+                </label>
+                <input
+                  id={`alertRuleWebhookUrl-${index}`}
+                  name={`alertRuleWebhookUrl-${index}`}
+                  type="text"
+                  placeholder={t('alerts.webhookUrlPlaceholder')}
+                  value={channel.config.webhookUrl || ''}
+                  onChange={e =>
+                    onUpdateChannel(index, {
+                      config: { ...channel.config, webhookUrl: e.target.value },
+                    })
+                  }
+                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                />
+              </>
+            )}
+
+            {channel.type === 'pagerduty' && (
+              <>
+                <label htmlFor={`alertRulePagerdutyRoutingKey-${index}`} className="sr-only">
+                  {t('alerts.pagerdutyRoutingKey')}
+                </label>
+                <input
+                  id={`alertRulePagerdutyRoutingKey-${index}`}
+                  name={`alertRulePagerdutyRoutingKey-${index}`}
+                  type="password"
+                  placeholder={t('alerts.pagerdutyRoutingKeyPlaceholder')}
+                  value={channel.config.pagerdutyRoutingKey || ''}
+                  onChange={e =>
+                    onUpdateChannel(index, {
+                      config: { ...channel.config, pagerdutyRoutingKey: e.target.value },
+                    })
+                  }
+                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                />
+              </>
+            )}
+
+            {channel.type === 'opsgenie' && (
+              <>
+                <label htmlFor={`alertRuleOpsgenieApiKey-${index}`} className="sr-only">
+                  {t('alerts.opsgenieApiKey')}
+                </label>
+                <input
+                  id={`alertRuleOpsgenieApiKey-${index}`}
+                  name={`alertRuleOpsgenieApiKey-${index}`}
+                  type="password"
+                  placeholder={t('alerts.opsgenieApiKeyPlaceholder')}
+                  value={channel.config.opsgenieApiKey || ''}
+                  onChange={e =>
+                    onUpdateChannel(index, {
+                      config: { ...channel.config, opsgenieApiKey: e.target.value },
+                    })
+                  }
+                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                />
+              </>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/alerts/AlertRuleChannels.tsx
+++ b/web/src/components/alerts/AlertRuleChannels.tsx
@@ -1,6 +1,7 @@
 import { Bell, Trash2, Webhook, Siren, ShieldAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Slack } from '@/lib/icons'
+import { Input } from '../ui/Input'
 import type { AlertChannel } from '../../types/alerts'
 
 interface AlertRuleChannelsProps {
@@ -120,7 +121,7 @@ export function AlertRuleChannels({
                 <label htmlFor={`alertRuleSlackWebhookUrl-${index}`} className="sr-only">
                   {t('alerts.slackWebhookUrl')}
                 </label>
-                <input
+                <Input
                   id={`alertRuleSlackWebhookUrl-${index}`}
                   name={`alertRuleSlackWebhookUrl-${index}`}
                   type="text"
@@ -131,12 +132,12 @@ export function AlertRuleChannels({
                       config: { ...channel.config, slackWebhookUrl: e.target.value },
                     })
                   }
-                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                  className="focus:ring-purple-500"
                 />
                 <label htmlFor={`alertRuleSlackChannel-${index}`} className="sr-only">
                   {t('alerts.slackChannel')}
                 </label>
-                <input
+                <Input
                   id={`alertRuleSlackChannel-${index}`}
                   name={`alertRuleSlackChannel-${index}`}
                   type="text"
@@ -147,7 +148,7 @@ export function AlertRuleChannels({
                       config: { ...channel.config, slackChannel: e.target.value },
                     })
                   }
-                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                  className="focus:ring-purple-500"
                 />
               </div>
             )}
@@ -157,7 +158,7 @@ export function AlertRuleChannels({
                 <label htmlFor={`alertRuleWebhookUrl-${index}`} className="sr-only">
                   {t('alerts.webhookUrl')}
                 </label>
-                <input
+                <Input
                   id={`alertRuleWebhookUrl-${index}`}
                   name={`alertRuleWebhookUrl-${index}`}
                   type="text"
@@ -168,7 +169,7 @@ export function AlertRuleChannels({
                       config: { ...channel.config, webhookUrl: e.target.value },
                     })
                   }
-                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                  className="focus:ring-purple-500"
                 />
               </>
             )}
@@ -178,7 +179,7 @@ export function AlertRuleChannels({
                 <label htmlFor={`alertRulePagerdutyRoutingKey-${index}`} className="sr-only">
                   {t('alerts.pagerdutyRoutingKey')}
                 </label>
-                <input
+                <Input
                   id={`alertRulePagerdutyRoutingKey-${index}`}
                   name={`alertRulePagerdutyRoutingKey-${index}`}
                   type="password"
@@ -189,7 +190,7 @@ export function AlertRuleChannels({
                       config: { ...channel.config, pagerdutyRoutingKey: e.target.value },
                     })
                   }
-                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                  className="focus:ring-purple-500"
                 />
               </>
             )}
@@ -199,7 +200,7 @@ export function AlertRuleChannels({
                 <label htmlFor={`alertRuleOpsgenieApiKey-${index}`} className="sr-only">
                   {t('alerts.opsgenieApiKey')}
                 </label>
-                <input
+                <Input
                   id={`alertRuleOpsgenieApiKey-${index}`}
                   name={`alertRuleOpsgenieApiKey-${index}`}
                   type="password"
@@ -210,7 +211,7 @@ export function AlertRuleChannels({
                       config: { ...channel.config, opsgenieApiKey: e.target.value },
                     })
                   }
-                  className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+                  className="focus:ring-purple-500"
                 />
               </>
             )}

--- a/web/src/components/alerts/AlertRuleCondition.tsx
+++ b/web/src/components/alerts/AlertRuleCondition.tsx
@@ -1,6 +1,8 @@
 import { Server } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../../lib/constants/time'
+import { Input } from '../ui/Input'
+import { Select } from '../ui/Select'
 import type { AlertConditionType } from '../../types/alerts'
 
 type WeatherConditionType = 'severe_storm' | 'extreme_heat' | 'heavy_rain' | 'snow' | 'high_wind'
@@ -99,18 +101,19 @@ export function AlertRuleCondition({
             {t('alerts.thresholdPercent')}
           </label>
           <div className="flex items-center gap-2">
-            <input
-              id="alertRuleThreshold"
-              name="alertRuleThreshold"
-              type="number"
-              min={1}
-              max={100}
-              value={threshold}
-              onChange={e => onThresholdChange(Number(e.target.value))}
-              className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                errors.threshold ? 'border-red-500' : 'border-border'
-              }`}
-            />
+            <div className="w-24">
+              <Input
+                id="alertRuleThreshold"
+                name="alertRuleThreshold"
+                type="number"
+                min={1}
+                max={100}
+                value={threshold}
+                onChange={e => onThresholdChange(Number(e.target.value))}
+                error={Boolean(errors.threshold)}
+                className="focus:ring-purple-500"
+              />
+            </div>
             <span className="text-sm text-muted-foreground">%</span>
           </div>
           {errors.threshold && (
@@ -125,18 +128,19 @@ export function AlertRuleCondition({
             {t('alerts.restartCountThreshold')}
           </label>
           <div className="flex items-center gap-2">
-            <input
-              id="alertRuleRestartThreshold"
-              name="alertRuleRestartThreshold"
-              type="number"
-              min={1}
-              max={100}
-              value={threshold}
-              onChange={e => onThresholdChange(Number(e.target.value))}
-              className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                errors.threshold ? 'border-red-500' : 'border-border'
-              }`}
-            />
+            <div className="w-24">
+              <Input
+                id="alertRuleRestartThreshold"
+                name="alertRuleRestartThreshold"
+                type="number"
+                min={1}
+                max={100}
+                value={threshold}
+                onChange={e => onThresholdChange(Number(e.target.value))}
+                error={Boolean(errors.threshold)}
+                className="focus:ring-purple-500"
+              />
+            </div>
             <span className="text-sm text-muted-foreground">restarts</span>
           </div>
         </div>
@@ -148,19 +152,19 @@ export function AlertRuleCondition({
             <label htmlFor="alertRuleWeatherCondition" className="block text-xs text-muted-foreground mb-1">
               {t('alerts.weatherCondition')}
             </label>
-            <select
+            <Select
               id="alertRuleWeatherCondition"
               name="alertRuleWeatherCondition"
               value={weatherCondition}
               onChange={e => onWeatherConditionChange(e.target.value as WeatherConditionType)}
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+              className="focus:ring-purple-500"
             >
               <option value="severe_storm">{t('alerts.weather.severeStorm')}</option>
               <option value="extreme_heat">{t('alerts.weather.extremeHeat')}</option>
               <option value="heavy_rain">{t('alerts.weather.heavyRain')}</option>
               <option value="snow">{t('alerts.weather.snow')}</option>
               <option value="high_wind">{t('alerts.weather.highWind')}</option>
-            </select>
+            </Select>
           </div>
 
           {weatherCondition === 'extreme_heat' && (
@@ -169,18 +173,19 @@ export function AlertRuleCondition({
                 {t('alerts.temperatureThreshold')}
               </label>
               <div className="flex items-center gap-2">
-                <input
-                  id="alertRuleTemperatureThreshold"
-                  name="alertRuleTemperatureThreshold"
-                  type="number"
-                  min={-50}
-                  max={150}
-                  value={temperatureThreshold}
-                  onChange={e => onTemperatureThresholdChange(Number(e.target.value))}
-                  className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                    errors.temperatureThreshold ? 'border-red-500' : 'border-border'
-                  }`}
-                />
+                <div className="w-24">
+                  <Input
+                    id="alertRuleTemperatureThreshold"
+                    name="alertRuleTemperatureThreshold"
+                    type="number"
+                    min={-50}
+                    max={150}
+                    value={temperatureThreshold}
+                    onChange={e => onTemperatureThresholdChange(Number(e.target.value))}
+                    error={Boolean(errors.temperatureThreshold)}
+                    className="focus:ring-purple-500"
+                  />
+                </div>
                 <span className="text-sm text-muted-foreground">°F</span>
               </div>
               {errors.temperatureThreshold && (
@@ -195,18 +200,19 @@ export function AlertRuleCondition({
                 {t('alerts.windSpeedThreshold')}
               </label>
               <div className="flex items-center gap-2">
-                <input
-                  id="alertRuleWindSpeedThreshold"
-                  name="alertRuleWindSpeedThreshold"
-                  type="number"
-                  min={1}
-                  max={200}
-                  value={windSpeedThreshold}
-                  onChange={e => onWindSpeedThresholdChange(Number(e.target.value))}
-                  className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                    errors.windSpeedThreshold ? 'border-red-500' : 'border-border'
-                  }`}
-                />
+                <div className="w-24">
+                  <Input
+                    id="alertRuleWindSpeedThreshold"
+                    name="alertRuleWindSpeedThreshold"
+                    type="number"
+                    min={1}
+                    max={200}
+                    value={windSpeedThreshold}
+                    onChange={e => onWindSpeedThresholdChange(Number(e.target.value))}
+                    error={Boolean(errors.windSpeedThreshold)}
+                    className="focus:ring-purple-500"
+                  />
+                </div>
                 <span className="text-sm text-muted-foreground">mph</span>
               </div>
               {errors.windSpeedThreshold && (
@@ -236,16 +242,19 @@ export function AlertRuleCondition({
               {preset.label}
             </button>
           ))}
-          <input
-            id="alertRuleDuration"
-            name="alertRuleDuration"
-            type="number"
-            min={0}
-            max={3600}
-            value={duration}
-            onChange={e => onDurationChange(Number(e.target.value))}
-            className="w-20 px-2 py-1.5 text-xs rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-          />
+          <div className="w-20">
+            <Input
+              id="alertRuleDuration"
+              name="alertRuleDuration"
+              type="number"
+              min={0}
+              max={3600}
+              value={duration}
+              onChange={e => onDurationChange(Number(e.target.value))}
+              inputSize="sm"
+              className="focus:ring-purple-500"
+            />
+          </div>
           <span className="text-xs text-muted-foreground">{t('alerts.durationHint')}</span>
         </div>
       </div>

--- a/web/src/components/alerts/AlertRuleCondition.tsx
+++ b/web/src/components/alerts/AlertRuleCondition.tsx
@@ -1,0 +1,280 @@
+import { Server } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../../lib/constants/time'
+import type { AlertConditionType } from '../../types/alerts'
+
+type WeatherConditionType = 'severe_storm' | 'extreme_heat' | 'heavy_rain' | 'snow' | 'high_wind'
+
+/** Preset duration options shown as clickable chips in the condition editor. */
+const DURATION_PRESETS = [
+  { label: 'Immediate', value: 0 },
+  { label: '1 min', value: SECONDS_PER_MINUTE },
+  { label: '5 min', value: 5 * SECONDS_PER_MINUTE },
+  { label: '15 min', value: 15 * SECONDS_PER_MINUTE },
+  { label: '1 hour', value: SECONDS_PER_HOUR },
+] as const
+
+interface ConditionTypeOption {
+  value: AlertConditionType
+  label: string
+  description: string
+}
+
+interface AvailableCluster {
+  name: string
+}
+
+interface AlertRuleConditionProps {
+  conditionType: AlertConditionType
+  onConditionTypeChange: (type: AlertConditionType) => void
+  threshold: number
+  onThresholdChange: (value: number) => void
+  duration: number
+  onDurationChange: (value: number) => void
+  selectedClusters: string[]
+  onToggleCluster: (name: string) => void
+  weatherCondition: WeatherConditionType
+  onWeatherConditionChange: (cond: WeatherConditionType) => void
+  temperatureThreshold: number
+  onTemperatureThresholdChange: (value: number) => void
+  windSpeedThreshold: number
+  onWindSpeedThresholdChange: (value: number) => void
+  errors: Record<string, string>
+  availableClusters: AvailableCluster[]
+  conditionTypes: ConditionTypeOption[]
+}
+
+export function AlertRuleCondition({
+  conditionType,
+  onConditionTypeChange,
+  threshold,
+  onThresholdChange,
+  duration,
+  onDurationChange,
+  selectedClusters,
+  onToggleCluster,
+  weatherCondition,
+  onWeatherConditionChange,
+  temperatureThreshold,
+  onTemperatureThresholdChange,
+  windSpeedThreshold,
+  onWindSpeedThresholdChange,
+  errors,
+  availableClusters,
+  conditionTypes,
+}: AlertRuleConditionProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="space-y-4">
+      <h4 className="text-sm font-medium text-foreground">{t('alerts.condition')}</h4>
+
+      <div>
+        <label className="block text-xs text-muted-foreground mb-2">
+          {t('alerts.conditionType')}
+        </label>
+        <div className="grid grid-cols-2 gap-2">
+          {conditionTypes.map(type => (
+            <button
+              key={type.value}
+              onClick={() => onConditionTypeChange(type.value)}
+              className={`p-3 rounded-lg text-left transition-colors ${
+                conditionType === type.value
+                  ? 'bg-purple-500/20 border border-purple-500/50'
+                  : 'bg-secondary border border-border hover:bg-secondary/80'
+              }`}
+              aria-label={`${type.label}: ${type.description}`}
+              aria-pressed={conditionType === type.value}
+            >
+              <span className="text-sm font-medium text-foreground">{type.label}</span>
+              <span className="block text-xs text-muted-foreground mt-0.5">{type.description}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {['gpu_usage', 'memory_pressure'].includes(conditionType) && (
+        <div>
+          <label htmlFor="alertRuleThreshold" className="block text-xs text-muted-foreground mb-1">
+            {t('alerts.thresholdPercent')}
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="alertRuleThreshold"
+              name="alertRuleThreshold"
+              type="number"
+              min={1}
+              max={100}
+              value={threshold}
+              onChange={e => onThresholdChange(Number(e.target.value))}
+              className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
+                errors.threshold ? 'border-red-500' : 'border-border'
+              }`}
+            />
+            <span className="text-sm text-muted-foreground">%</span>
+          </div>
+          {errors.threshold && (
+            <span className="block text-xs text-red-400 mt-1">{errors.threshold}</span>
+          )}
+        </div>
+      )}
+
+      {conditionType === 'pod_crash' && (
+        <div>
+          <label htmlFor="alertRuleRestartThreshold" className="block text-xs text-muted-foreground mb-1">
+            {t('alerts.restartCountThreshold')}
+          </label>
+          <div className="flex items-center gap-2">
+            <input
+              id="alertRuleRestartThreshold"
+              name="alertRuleRestartThreshold"
+              type="number"
+              min={1}
+              max={100}
+              value={threshold}
+              onChange={e => onThresholdChange(Number(e.target.value))}
+              className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
+                errors.threshold ? 'border-red-500' : 'border-border'
+              }`}
+            />
+            <span className="text-sm text-muted-foreground">restarts</span>
+          </div>
+        </div>
+      )}
+
+      {conditionType === 'weather_alerts' && (
+        <div className="space-y-3">
+          <div>
+            <label htmlFor="alertRuleWeatherCondition" className="block text-xs text-muted-foreground mb-1">
+              {t('alerts.weatherCondition')}
+            </label>
+            <select
+              id="alertRuleWeatherCondition"
+              name="alertRuleWeatherCondition"
+              value={weatherCondition}
+              onChange={e => onWeatherConditionChange(e.target.value as WeatherConditionType)}
+              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+            >
+              <option value="severe_storm">{t('alerts.weather.severeStorm')}</option>
+              <option value="extreme_heat">{t('alerts.weather.extremeHeat')}</option>
+              <option value="heavy_rain">{t('alerts.weather.heavyRain')}</option>
+              <option value="snow">{t('alerts.weather.snow')}</option>
+              <option value="high_wind">{t('alerts.weather.highWind')}</option>
+            </select>
+          </div>
+
+          {weatherCondition === 'extreme_heat' && (
+            <div>
+              <label htmlFor="alertRuleTemperatureThreshold" className="block text-xs text-muted-foreground mb-1">
+                {t('alerts.temperatureThreshold')}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="alertRuleTemperatureThreshold"
+                  name="alertRuleTemperatureThreshold"
+                  type="number"
+                  min={-50}
+                  max={150}
+                  value={temperatureThreshold}
+                  onChange={e => onTemperatureThresholdChange(Number(e.target.value))}
+                  className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
+                    errors.temperatureThreshold ? 'border-red-500' : 'border-border'
+                  }`}
+                />
+                <span className="text-sm text-muted-foreground">°F</span>
+              </div>
+              {errors.temperatureThreshold && (
+                <span className="block text-xs text-red-400 mt-1">{errors.temperatureThreshold}</span>
+              )}
+            </div>
+          )}
+
+          {weatherCondition === 'high_wind' && (
+            <div>
+              <label htmlFor="alertRuleWindSpeedThreshold" className="block text-xs text-muted-foreground mb-1">
+                {t('alerts.windSpeedThreshold')}
+              </label>
+              <div className="flex items-center gap-2">
+                <input
+                  id="alertRuleWindSpeedThreshold"
+                  name="alertRuleWindSpeedThreshold"
+                  type="number"
+                  min={1}
+                  max={200}
+                  value={windSpeedThreshold}
+                  onChange={e => onWindSpeedThresholdChange(Number(e.target.value))}
+                  className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
+                    errors.windSpeedThreshold ? 'border-red-500' : 'border-border'
+                  }`}
+                />
+                <span className="text-sm text-muted-foreground">mph</span>
+              </div>
+              {errors.windSpeedThreshold && (
+                <span className="block text-xs text-red-400 mt-1">{errors.windSpeedThreshold}</span>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      <div>
+        <label htmlFor="alertRuleDuration" className="block text-xs text-muted-foreground mb-1">
+          {t('alerts.durationSeconds')}
+        </label>
+        <div className="flex items-center gap-2 flex-wrap">
+          {DURATION_PRESETS.map(preset => (
+            <button
+              key={preset.value}
+              type="button"
+              onClick={() => onDurationChange(preset.value)}
+              className={`px-2.5 py-1.5 text-xs rounded-lg border transition-colors ${
+                duration === preset.value
+                  ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
+                  : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {preset.label}
+            </button>
+          ))}
+          <input
+            id="alertRuleDuration"
+            name="alertRuleDuration"
+            type="number"
+            min={0}
+            max={3600}
+            value={duration}
+            onChange={e => onDurationChange(Number(e.target.value))}
+            className="w-20 px-2 py-1.5 text-xs rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
+          />
+          <span className="text-xs text-muted-foreground">{t('alerts.durationHint')}</span>
+        </div>
+      </div>
+
+      {availableClusters.length > 1 && (
+        <div>
+          <label className="block text-xs text-muted-foreground mb-2">
+            Clusters (leave empty for all)
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {availableClusters.map(cluster => (
+              <button
+                key={cluster.name}
+                onClick={() => onToggleCluster(cluster.name)}
+                className={`px-2 py-1 text-xs rounded-lg flex items-center gap-1 transition-colors ${
+                  selectedClusters.includes(cluster.name)
+                    ? 'bg-purple-500/20 border border-purple-500/50 text-purple-400'
+                    : 'bg-secondary border border-border text-muted-foreground hover:text-foreground'
+                }`}
+                aria-label={`${selectedClusters.includes(cluster.name) ? 'Deselect' : 'Select'} cluster ${cluster.name}`}
+                aria-pressed={selectedClusters.includes(cluster.name)}
+              >
+                <Server className="w-3 h-3" aria-hidden="true" />
+                {cluster.name}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/alerts/AlertRuleEditor.tsx
+++ b/web/src/components/alerts/AlertRuleEditor.tsx
@@ -1,11 +1,8 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { Trash2, Server, Bell, BellOff, Bot, Webhook, Siren, ShieldAlert } from 'lucide-react'
-import { Slack } from '@/lib/icons'
+import { Bell, Bot } from 'lucide-react'
 import { useClusters } from '../../hooks/useMCP'
 import { BaseModal, ConfirmDialog, useModalState } from '../../lib/modals'
-import { SECONDS_PER_MINUTE, SECONDS_PER_HOUR } from '../../lib/constants/time'
 import type {
   AlertRule,
   AlertCondition,
@@ -13,34 +10,28 @@ import type {
   AlertSeverity,
   AlertConditionType,
 } from '../../types/alerts'
+import { AlertRuleBasicInfo } from './AlertRuleBasicInfo'
+import { AlertRuleCondition } from './AlertRuleCondition'
+import { AlertRuleChannels } from './AlertRuleChannels'
 
 // Validation thresholds for alert conditions
-const PERCENTAGE_MIN = 1 // Minimum percentage threshold
-const PERCENTAGE_MAX = 100 // Maximum percentage threshold
-const RESTART_COUNT_MIN = 1 // Minimum restart count for pod crashes
-const TEMPERATURE_MIN = -50 // Minimum temperature in Fahrenheit
-const TEMPERATURE_MAX = 150 // Maximum temperature in Fahrenheit
-const WIND_SPEED_MIN = 1 // Minimum wind speed in mph
-const WIND_SPEED_MAX = 200 // Maximum wind speed in mph
+const PERCENTAGE_MIN = 1
+const PERCENTAGE_MAX = 100
+const RESTART_COUNT_MIN = 1
+const TEMPERATURE_MIN = -50
+const TEMPERATURE_MAX = 150
+const WIND_SPEED_MIN = 1
+const WIND_SPEED_MAX = 200
 
 // Default values for new alert rules (used in unsaved-changes detection)
-const DEFAULT_THRESHOLD = 90 // Default GPU/memory threshold percentage
-const DEFAULT_DURATION_SECS = 60 // Default condition duration in seconds
-const DEFAULT_TEMPERATURE_F = 100 // Default temperature threshold in Fahrenheit
-const DEFAULT_WIND_SPEED_MPH = 40 // Default wind speed threshold in mph
-
-/** Preset duration options shown as clickable chips in the rule editor */
-const DURATION_PRESETS = [
-  { label: 'Immediate', value: 0 },
-  { label: '1 min', value: SECONDS_PER_MINUTE },
-  { label: '5 min', value: 5 * SECONDS_PER_MINUTE },
-  { label: '15 min', value: 15 * SECONDS_PER_MINUTE },
-  { label: '1 hour', value: SECONDS_PER_HOUR },
-] as const
+const DEFAULT_THRESHOLD = 90
+const DEFAULT_DURATION_SECS = 60
+const DEFAULT_TEMPERATURE_F = 100
+const DEFAULT_WIND_SPEED_MPH = 40
 
 interface AlertRuleEditorProps {
   isOpen?: boolean
-  rule?: AlertRule // If editing existing rule
+  rule?: AlertRule
   onSave: (rule: Omit<AlertRule, 'id' | 'createdAt' | 'updatedAt'>) => void
   onCancel: () => void
 }
@@ -62,6 +53,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     { value: 'warning', label: t('alerts.severityOptions.warning'), color: 'bg-orange-500' },
     { value: 'info', label: t('alerts.severityOptions.info'), color: 'bg-blue-500' },
   ]
+
   const { deduplicatedClusters: clusters } = useClusters()
 
   // Form state
@@ -81,10 +73,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     rule?.condition.clusters || []
   )
   // Namespace filter - for future use
-  const [selectedNamespaces] = useState<string[]>(
-    rule?.condition.namespaces || []
-  )
-  // Weather alert specific state
+  const [selectedNamespaces] = useState<string[]>(rule?.condition.namespaces || [])
   const [weatherCondition, setWeatherCondition] = useState<'severe_storm' | 'extreme_heat' | 'heavy_rain' | 'snow' | 'high_wind'>(
     rule?.condition.weatherCondition || 'severe_storm'
   )
@@ -151,8 +140,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     }
 
     // Issue 9257 — validation messages previously hardcoded English strings
-    // even though the translation keys already exist (alerts.thresholdRange,
-    // alerts.restartCountMin, alerts.temperatureRange, alerts.windSpeedRange).
+    // even though the translation keys already exist.
     if (conditionType === 'gpu_usage' || conditionType === 'memory_pressure') {
       if (threshold < PERCENTAGE_MIN || threshold > PERCENTAGE_MAX) {
         newErrors.threshold = t('alerts.thresholdRange', { min: PERCENTAGE_MIN, max: PERCENTAGE_MAX })
@@ -174,9 +162,7 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
       }
     }
 
-    // Issue 9254 — previously a rule could be saved with zero enabled
-    // notification channels, which meant the rule fired silently. Refuse to
-    // save without at least one enabled channel.
+    // Issue 9254 — refuse to save without at least one enabled channel
     const enabledChannelCount = channels.filter(ch => ch.enabled).length
     if (enabledChannelCount === 0) {
       newErrors.channels = t('alerts.atLeastOneChannelRequired', 'Enable at least one notification channel, or no one will be notified when this rule fires.')
@@ -197,7 +183,6 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
       duration: duration > 0 ? duration : undefined,
       clusters: selectedClusters.length > 0 ? selectedClusters : undefined,
       namespaces: selectedNamespaces.length > 0 ? selectedNamespaces : undefined,
-      // Weather alert specific fields
       weatherCondition: conditionType === 'weather_alerts' ? weatherCondition : undefined,
       temperatureThreshold: conditionType === 'weather_alerts' && weatherCondition === 'extreme_heat' ? temperatureThreshold : undefined,
       windSpeedThreshold: conditionType === 'weather_alerts' && weatherCondition === 'high_wind' ? windSpeedThreshold : undefined,
@@ -236,7 +221,6 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
     )
   }
 
-  // Get available clusters
   const availableClusters = clusters.filter(c => c.reachable !== false)
 
   return (
@@ -260,503 +244,46 @@ export function AlertRuleEditor({ isOpen = true, rule, onSave, onCancel }: Alert
 
       <BaseModal.Content className="max-h-[60vh]">
         <div className="space-y-6">
-          {/* Basic Info */}
-          <div className="space-y-4">
-            <div>
-              <label htmlFor="alertRuleName" className="block text-sm font-medium text-foreground mb-1">
-                {t('alerts.ruleName')} *
-              </label>
-              <input
-                id="alertRuleName"
-                name="alertRuleName"
-                type="text"
-                value={name}
-                onChange={e => setName(e.target.value)}
-                placeholder={t('alerts.ruleNamePlaceholder')}
-                className={`w-full px-3 py-2 rounded-lg bg-secondary border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                  errors.name ? 'border-red-500' : 'border-border'
-                }`}
-              />
-              {errors.name && (
-                <span className="block text-xs text-red-400 mt-1">{errors.name}</span>
-              )}
-            </div>
+          <AlertRuleBasicInfo
+            name={name}
+            onNameChange={setName}
+            description={description}
+            onDescriptionChange={setDescription}
+            severity={severity}
+            onSeverityChange={setSeverity}
+            enabled={enabled}
+            onEnabledChange={setEnabled}
+            errors={errors}
+            severityOptions={SEVERITY_OPTIONS}
+          />
 
-            <div>
-              <label htmlFor="alertRuleDescription" className="block text-sm font-medium text-foreground mb-1">
-                {t('alerts.description')}
-              </label>
-              <textarea
-                id="alertRuleDescription"
-                name="alertRuleDescription"
-                value={description}
-                onChange={e => setDescription(e.target.value)}
-                placeholder={t('alerts.descriptionPlaceholder')}
-                rows={2}
-                className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 resize-none"
-              />
-            </div>
+          <AlertRuleCondition
+            conditionType={conditionType}
+            onConditionTypeChange={setAlertConditionType}
+            threshold={threshold}
+            onThresholdChange={setThreshold}
+            duration={duration}
+            onDurationChange={setDuration}
+            selectedClusters={selectedClusters}
+            onToggleCluster={toggleCluster}
+            weatherCondition={weatherCondition}
+            onWeatherConditionChange={setWeatherCondition}
+            temperatureThreshold={temperatureThreshold}
+            onTemperatureThresholdChange={setTemperatureThreshold}
+            windSpeedThreshold={windSpeedThreshold}
+            onWindSpeedThresholdChange={setWindSpeedThreshold}
+            errors={errors}
+            availableClusters={availableClusters}
+            conditionTypes={CONDITION_TYPES}
+          />
 
-            <div className="flex items-center gap-4">
-              <div>
-                <label className="block text-sm font-medium text-foreground mb-1">
-                  {t('alerts.severity')}
-                </label>
-                <div className="flex gap-2">
-                  {SEVERITY_OPTIONS.map(opt => (
-                    <button
-                      key={opt.value}
-                      onClick={() => setSeverity(opt.value)}
-                      className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-2 transition-colors ${
-                        severity === opt.value
-                          ? `${opt.color}/20 border border-${opt.value === 'critical' ? 'red' : opt.value === 'warning' ? 'orange' : 'blue'}-500/50 text-foreground`
-                          : 'bg-secondary border border-border text-muted-foreground hover:text-foreground'
-                      }`}
-                      aria-label={`Set severity to ${opt.label}`}
-                      aria-pressed={severity === opt.value}
-                    >
-                      <span className={`w-2 h-2 rounded-full ${opt.color}`} aria-hidden="true" />
-                      {opt.label}
-                    </button>
-                  ))}
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2 ml-auto">
-                <button
-                  onClick={() => setEnabled(!enabled)}
-                  className={`px-3 py-1.5 rounded-lg text-sm flex items-center gap-2 transition-colors ${
-                    enabled
-                      ? 'bg-green-500/20 border border-green-500/50 text-green-400'
-                      : 'bg-secondary border border-border text-muted-foreground'
-                  }`}
-                  aria-label={enabled ? 'Disable alert rule' : 'Enable alert rule'}
-                  aria-pressed={enabled}
-                >
-                  {enabled ? <Bell className="w-4 h-4" aria-hidden="true" /> : <BellOff className="w-4 h-4" aria-hidden="true" />}
-                  {enabled ? t('alerts.enabled') : t('alerts.disabled')}
-                </button>
-              </div>
-            </div>
-          </div>
-
-          {/* Condition */}
-          <div className="space-y-4">
-            <h4 className="text-sm font-medium text-foreground">{t('alerts.condition')}</h4>
-
-            <div>
-              <label className="block text-xs text-muted-foreground mb-2">
-                {t('alerts.conditionType')}
-              </label>
-              <div className="grid grid-cols-2 gap-2">
-                {CONDITION_TYPES.map(type => (
-                  <button
-                    key={type.value}
-                    onClick={() => setAlertConditionType(type.value)}
-                    className={`p-3 rounded-lg text-left transition-colors ${
-                      conditionType === type.value
-                        ? 'bg-purple-500/20 border border-purple-500/50'
-                        : 'bg-secondary border border-border hover:bg-secondary/80'
-                    }`}
-                    aria-label={`${type.label}: ${type.description}`}
-                    aria-pressed={conditionType === type.value}
-                  >
-                    <span className="text-sm font-medium text-foreground">{type.label}</span>
-                    <span className="block text-xs text-muted-foreground mt-0.5">{type.description}</span>
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            {/* Threshold input */}
-            {['gpu_usage', 'memory_pressure'].includes(conditionType) && (
-              <div>
-                <label htmlFor="alertRuleThreshold" className="block text-xs text-muted-foreground mb-1">
-                  {t('alerts.thresholdPercent')}
-                </label>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="alertRuleThreshold"
-                    name="alertRuleThreshold"
-                    type="number"
-                    min={1}
-                    max={100}
-                    value={threshold}
-                    onChange={e => setThreshold(Number(e.target.value))}
-                    className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                      errors.threshold ? 'border-red-500' : 'border-border'
-                    }`}
-                  />
-                  <span className="text-sm text-muted-foreground">%</span>
-                </div>
-                {errors.threshold && (
-                  <span className="block text-xs text-red-400 mt-1">{errors.threshold}</span>
-                )}
-              </div>
-            )}
-
-            {conditionType === 'pod_crash' && (
-              <div>
-                <label htmlFor="alertRuleRestartThreshold" className="block text-xs text-muted-foreground mb-1">
-                  {t('alerts.restartCountThreshold')}
-                </label>
-                <div className="flex items-center gap-2">
-                  <input
-                    id="alertRuleRestartThreshold"
-                    name="alertRuleRestartThreshold"
-                    type="number"
-                    min={1}
-                    max={100}
-                    value={threshold}
-                    onChange={e => setThreshold(Number(e.target.value))}
-                    className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                      errors.threshold ? 'border-red-500' : 'border-border'
-                    }`}
-                  />
-                  <span className="text-sm text-muted-foreground">restarts</span>
-                </div>
-              </div>
-            )}
-
-            {/* Weather alert configuration */}
-            {conditionType === 'weather_alerts' && (
-              <div className="space-y-3">
-                <div>
-                  <label htmlFor="alertRuleWeatherCondition" className="block text-xs text-muted-foreground mb-1">
-                    {t('alerts.weatherCondition')}
-                  </label>
-                  <select
-                    id="alertRuleWeatherCondition"
-                    name="alertRuleWeatherCondition"
-                    value={weatherCondition}
-                    onChange={e => setWeatherCondition(e.target.value as typeof weatherCondition)}
-                    className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                  >
-                    <option value="severe_storm">{t('alerts.weather.severeStorm')}</option>
-                    <option value="extreme_heat">{t('alerts.weather.extremeHeat')}</option>
-                    <option value="heavy_rain">{t('alerts.weather.heavyRain')}</option>
-                    <option value="snow">{t('alerts.weather.snow')}</option>
-                    <option value="high_wind">{t('alerts.weather.highWind')}</option>
-                  </select>
-                </div>
-
-                {weatherCondition === 'extreme_heat' && (
-                  <div>
-                    <label htmlFor="alertRuleTemperatureThreshold" className="block text-xs text-muted-foreground mb-1">
-                      {t('alerts.temperatureThreshold')}
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        id="alertRuleTemperatureThreshold"
-                        name="alertRuleTemperatureThreshold"
-                        type="number"
-                        min={-50}
-                        max={150}
-                        value={temperatureThreshold}
-                        onChange={e => setTemperatureThreshold(Number(e.target.value))}
-                        className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                          errors.temperatureThreshold ? 'border-red-500' : 'border-border'
-                        }`}
-                      />
-                      <span className="text-sm text-muted-foreground">°F</span>
-                    </div>
-                    {errors.temperatureThreshold && (
-                      <span className="block text-xs text-red-400 mt-1">{errors.temperatureThreshold}</span>
-                    )}
-                  </div>
-                )}
-
-                {weatherCondition === 'high_wind' && (
-                  <div>
-                    <label htmlFor="alertRuleWindSpeedThreshold" className="block text-xs text-muted-foreground mb-1">
-                      {t('alerts.windSpeedThreshold')}
-                    </label>
-                    <div className="flex items-center gap-2">
-                      <input
-                        id="alertRuleWindSpeedThreshold"
-                        name="alertRuleWindSpeedThreshold"
-                        type="number"
-                        min={1}
-                        max={200}
-                        value={windSpeedThreshold}
-                        onChange={e => setWindSpeedThreshold(Number(e.target.value))}
-                        className={`w-24 px-3 py-2 rounded-lg bg-secondary border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500 ${
-                          errors.windSpeedThreshold ? 'border-red-500' : 'border-border'
-                        }`}
-                      />
-                      <span className="text-sm text-muted-foreground">mph</span>
-                    </div>
-                    {errors.windSpeedThreshold && (
-                      <span className="block text-xs text-red-400 mt-1">{errors.windSpeedThreshold}</span>
-                    )}
-                  </div>
-                )}
-              </div>
-            )}
-
-            {/* Duration */}
-            <div>
-              <label htmlFor="alertRuleDuration" className="block text-xs text-muted-foreground mb-1">
-                {t('alerts.durationSeconds')}
-              </label>
-              <div className="flex items-center gap-2 flex-wrap">
-                {DURATION_PRESETS.map(preset => (
-                  <button
-                    key={preset.value}
-                    type="button"
-                    onClick={() => setDuration(preset.value)}
-                    className={`px-2.5 py-1.5 text-xs rounded-lg border transition-colors ${
-                      duration === preset.value
-                        ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
-                        : 'bg-secondary border-border text-muted-foreground hover:text-foreground'
-                    }`}
-                  >
-                    {preset.label}
-                  </button>
-                ))}
-                <input
-                  id="alertRuleDuration"
-                  name="alertRuleDuration"
-                  type="number"
-                  min={0}
-                  max={3600}
-                  value={duration}
-                  onChange={e => setDuration(Number(e.target.value))}
-                  className="w-20 px-2 py-1.5 text-xs rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                />
-                <span className="text-xs text-muted-foreground">{t('alerts.durationHint')}</span>
-              </div>
-            </div>
-
-            {/* Cluster Filter */}
-            {availableClusters.length > 1 && (
-              <div>
-                <label className="block text-xs text-muted-foreground mb-2">
-                  Clusters (leave empty for all)
-                </label>
-                <div className="flex flex-wrap gap-2">
-                  {availableClusters.map(cluster => (
-                    <button
-                      key={cluster.name}
-                      onClick={() => toggleCluster(cluster.name)}
-                      className={`px-2 py-1 text-xs rounded-lg flex items-center gap-1 transition-colors ${
-                        selectedClusters.includes(cluster.name)
-                          ? 'bg-purple-500/20 border border-purple-500/50 text-purple-400'
-                          : 'bg-secondary border border-border text-muted-foreground hover:text-foreground'
-                      }`}
-                      aria-label={`${selectedClusters.includes(cluster.name) ? 'Deselect' : 'Select'} cluster ${cluster.name}`}
-                      aria-pressed={selectedClusters.includes(cluster.name)}
-                    >
-                      <Server className="w-3 h-3" aria-hidden="true" />
-                      {cluster.name}
-                    </button>
-                  ))}
-                </div>
-              </div>
-            )}
-          </div>
-
-          {/* Notification Channels */}
-          <div className="space-y-4">
-            {/* Issue 9254 — warn when no enabled channel is present so users
-                don't save rules that fire silently. */}
-            {errors.channels && (
-              <div className="p-2 rounded bg-red-500/10 border border-red-500/30 text-xs text-red-400">
-                {errors.channels}
-              </div>
-            )}
-            <div className="flex items-center justify-between">
-              <h4 className="text-sm font-medium text-foreground">{t('alerts.notificationChannels')}</h4>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => addChannel('browser')}
-                  className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
-                  aria-label="Add browser notification channel"
-                >
-                  <Bell className="w-3 h-3" aria-hidden="true" />
-                  {t('alerts.browser')}
-                </button>
-                <button
-                  onClick={() => addChannel('slack')}
-                  className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
-                  aria-label="Add Slack notification channel"
-                >
-                  <Slack className="w-3 h-3" aria-hidden="true" />
-                  {t('alerts.slack')}
-                </button>
-                <button
-                  onClick={() => addChannel('webhook')}
-                  className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
-                  aria-label="Add webhook notification channel"
-                >
-                  <Webhook className="w-3 h-3" aria-hidden="true" />
-                  {t('alerts.webhook')}
-                </button>
-                <button
-                  onClick={() => addChannel('pagerduty')}
-                  className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
-                  aria-label="Add PagerDuty notification channel"
-                >
-                  <Siren className="w-3 h-3" aria-hidden="true" />
-                  PagerDuty
-                </button>
-                <button
-                  onClick={() => addChannel('opsgenie')}
-                  className="px-2 py-1 text-xs rounded bg-secondary hover:bg-secondary/80 text-foreground transition-colors flex items-center gap-1"
-                  aria-label="Add OpsGenie notification channel"
-                >
-                  <ShieldAlert className="w-3 h-3" aria-hidden="true" />
-                  OpsGenie
-                </button>
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              {channels.map((channel, index) => (
-                <div
-                  key={index}
-                  className="p-3 rounded-lg bg-secondary/30 border border-border/50"
-                >
-                  <div className="flex items-center justify-between mb-2">
-                    <div className="flex items-center gap-2">
-                      {channel.type === 'browser' && <Bell className="w-4 h-4" aria-hidden="true" />}
-                      {channel.type === 'slack' && <Slack className="w-4 h-4" aria-hidden="true" />}
-                      {channel.type === 'webhook' && <Webhook className="w-4 h-4" aria-hidden="true" />}
-                      {channel.type === 'pagerduty' && <Siren className="w-4 h-4" aria-hidden="true" />}
-                      {channel.type === 'opsgenie' && <ShieldAlert className="w-4 h-4" aria-hidden="true" />}
-                      <span className="text-sm font-medium text-foreground capitalize">
-                        {channel.type}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-2">
-                      <button
-                        onClick={() =>
-                          updateChannel(index, { enabled: !channel.enabled })
-                        }
-                        className={`px-2 py-1 text-xs rounded transition-colors ${
-                          channel.enabled
-                            ? 'bg-green-500/20 text-green-400'
-                            : 'bg-secondary text-muted-foreground'
-                        }`}
-                        aria-label={`${channel.enabled ? 'Disable' : 'Enable'} ${channel.type} channel`}
-                      >
-                        {channel.enabled ? 'On' : 'Off'}
-                      </button>
-                      {channels.length > 1 && (
-                        <button
-                          onClick={() => removeChannel(index)}
-                          className="p-1 rounded hover:bg-red-500/20 text-muted-foreground hover:text-red-400 transition-colors"
-                          aria-label={`Remove ${channel.type} channel`}
-                        >
-                          <Trash2 className="w-4 h-4" aria-hidden="true" />
-                        </button>
-                      )}
-                    </div>
-                  </div>
-
-                  {channel.type === 'slack' && (
-                    <div className="space-y-2">
-                      <label htmlFor={`alertRuleSlackWebhookUrl-${index}`} className="sr-only">
-                        {t('alerts.slackWebhookUrl')}
-                      </label>
-                      <input
-                        id={`alertRuleSlackWebhookUrl-${index}`}
-                        name={`alertRuleSlackWebhookUrl-${index}`}
-                        type="text"
-                        placeholder={t('alerts.slackWebhookUrlPlaceholder')}
-                        value={channel.config.slackWebhookUrl || ''}
-                        onChange={e =>
-                          updateChannel(index, {
-                            config: { ...channel.config, slackWebhookUrl: e.target.value },
-                          })
-                        }
-                        className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                      />
-                      <label htmlFor={`alertRuleSlackChannel-${index}`} className="sr-only">
-                        {t('alerts.slackChannel')}
-                      </label>
-                      <input
-                        id={`alertRuleSlackChannel-${index}`}
-                        name={`alertRuleSlackChannel-${index}`}
-                        type="text"
-                        placeholder={t('alerts.slackChannelPlaceholder')}
-                        value={channel.config.slackChannel || ''}
-                        onChange={e =>
-                          updateChannel(index, {
-                            config: { ...channel.config, slackChannel: e.target.value },
-                          })
-                        }
-                        className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                      />
-                    </div>
-                  )}
-
-                  {channel.type === 'webhook' && (
-                    <>
-                      <label htmlFor={`alertRuleWebhookUrl-${index}`} className="sr-only">
-                        {t('alerts.webhookUrl')}
-                      </label>
-                      <input
-                        id={`alertRuleWebhookUrl-${index}`}
-                        name={`alertRuleWebhookUrl-${index}`}
-                        type="text"
-                        placeholder={t('alerts.webhookUrlPlaceholder')}
-                        value={channel.config.webhookUrl || ''}
-                        onChange={e =>
-                          updateChannel(index, {
-                            config: { ...channel.config, webhookUrl: e.target.value },
-                          })
-                        }
-                        className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                      />
-                    </>
-                  )}
-
-                  {channel.type === 'pagerduty' && (
-                    <>
-                      <label htmlFor={`alertRulePagerdutyRoutingKey-${index}`} className="sr-only">
-                        {t('alerts.pagerdutyRoutingKey')}
-                      </label>
-                      <input
-                        id={`alertRulePagerdutyRoutingKey-${index}`}
-                        name={`alertRulePagerdutyRoutingKey-${index}`}
-                        type="password"
-                        placeholder={t('alerts.pagerdutyRoutingKeyPlaceholder')}
-                        value={channel.config.pagerdutyRoutingKey || ''}
-                        onChange={e =>
-                          updateChannel(index, {
-                            config: { ...channel.config, pagerdutyRoutingKey: e.target.value },
-                          })
-                        }
-                        className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                      />
-                    </>
-                  )}
-
-                  {channel.type === 'opsgenie' && (
-                    <>
-                      <label htmlFor={`alertRuleOpsgenieApiKey-${index}`} className="sr-only">
-                        {t('alerts.opsgenieApiKey')}
-                      </label>
-                      <input
-                        id={`alertRuleOpsgenieApiKey-${index}`}
-                        name={`alertRuleOpsgenieApiKey-${index}`}
-                        type="password"
-                        placeholder={t('alerts.opsgenieApiKeyPlaceholder')}
-                        value={channel.config.opsgenieApiKey || ''}
-                        onChange={e =>
-                          updateChannel(index, {
-                            config: { ...channel.config, opsgenieApiKey: e.target.value },
-                          })
-                        }
-                        className="w-full px-3 py-1.5 text-sm rounded bg-secondary border border-border text-foreground placeholder:text-muted-foreground focus:outline-hidden focus:ring-2 focus:ring-purple-500"
-                      />
-                    </>
-                  )}
-                </div>
-              ))}
-            </div>
-          </div>
+          <AlertRuleChannels
+            channels={channels}
+            onAddChannel={addChannel}
+            onRemoveChannel={removeChannel}
+            onUpdateChannel={updateChannel}
+            errors={errors}
+          />
 
           {/* AI Diagnosis */}
           <div className="space-y-2">


### PR DESCRIPTION
Fixes #21609

## What

Splits the 800-line `AlertRuleEditor.tsx` (which carried a `/* eslint-disable max-lines */` suppression) into four focused files:

| File | Responsibility | Lines |
|---|---|---|
| `AlertRuleEditor.tsx` | State, validation, save/close logic, modal shell | ~230 |
| `AlertRuleBasicInfo.tsx` | Name, description, severity picker, enabled toggle | ~110 |
| `AlertRuleCondition.tsx` | Condition type grid, threshold/weather/duration/cluster inputs | ~230 |
| `AlertRuleChannels.tsx` | Channel add-buttons, per-channel config forms | ~220 |

## How

- Each sub-component owns its own `useTranslation('common')` call — no `t` prop threading.
- The parent `AlertRuleEditor` passes plain callbacks and values; no shared context needed.
- The `eslint-disable max-lines` comment is removed from the main file.
- Public API (`AlertRuleEditor` export, props interface) is unchanged — existing consumers and the existing test suite are unaffected.

## Testing

All existing tests in `AlertRuleEditor.test.tsx` continue to import from `./AlertRuleEditor` and exercise the full component tree (including the new sub-components) via normal React rendering — no test changes needed.