### PR TITLE
[scanner] fix: resolve Auto-QA UI resilience and consistency issues

### DIFF
--- a/web/src/components/cards/ACMMFeedbackLoops.tsx
+++ b/web/src/components/cards/ACMMFeedbackLoops.tsx
@@ -311,7 +311,7 @@ export function ACMMFeedbackLoops() {
             type="button"
             onClick={() => scan.forceRefetch()}
             disabled={scan.isLoading || scan.isRefreshing}
-            className="p-1 rounded hover:bg-muted/50 text-muted-foreground transition-colors disabled:opacity-50"
+            className="p-1 min-h-11 min-w-11 flex items-center justify-center rounded hover:bg-muted/50 text-muted-foreground transition-colors disabled:opacity-50"
             title="Re-scan current repo (bypasses server cache)"
           >
             <RefreshCw

--- a/web/src/components/cards/lima_status/useLimaStatus.ts
+++ b/web/src/components/cards/lima_status/useLimaStatus.ts
@@ -3,6 +3,7 @@ import { useCardLoadingState } from '../CardDataContext'
 import { LIMA_DEMO_DATA, type LimaDemoData, type LimaInstance } from './demoData'
 import { authFetch } from '../../../lib/api'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants/network'
+import { HTTP_SERVICE_UNAVAILABLE } from '../../../lib/constants/http'
 
 export interface LimaStatus {
   instances: LimaInstance[]
@@ -27,8 +28,6 @@ const INITIAL_DATA: LimaStatus = {
   totalMemoryGB: 0,
   lastCheckTime: new Date().toISOString(),
 }
-
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 interface LimaListResponse {
   limaInstances: LimaInstance[]
@@ -89,7 +88,7 @@ async function fetchLimaStatus(): Promise<LimaStatus> {
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
-  if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+  if (res.status === HTTP_SERVICE_UNAVAILABLE) {
     throw new Error('Service unavailable')
   }
 

--- a/web/src/components/dashboard/PostConnectBanner.tsx
+++ b/web/src/components/dashboard/PostConnectBanner.tsx
@@ -17,6 +17,7 @@ import {
   STORAGE_KEY_HINTS_SUPPRESSED,
 } from '../../lib/constants/storage'
 import { emitPostConnectShown, emitPostConnectActioned } from '../../lib/analytics'
+import { Button } from '../ui/Button'
 
 interface PostConnectBannerProps {
   onRunHealthCheck: () => void
@@ -118,13 +119,14 @@ export function PostConnectBanner({
             </p>
           </div>
         </div>
-        <button
+        <Button
+          variant="ghost"
+          size="sm"
           onClick={handleDismiss}
-          className="p-1.5 rounded-md hover:bg-secondary/80 text-muted-foreground hover:text-foreground transition-colors duration-150 shrink-0 flex items-center justify-center"
+          className="min-h-11 min-w-11 shrink-0"
           aria-label="Dismiss"
-        >
-          <X className="w-3.5 h-3.5" />
-        </button>
+          icon={<X className="w-3.5 h-3.5" />}
+        />
       </div>
 
       <div className="grid grid-cols-1 sm:grid-cols-3 gap-2">

--- a/web/src/components/dashboard/StatBlockFactoryModal.tsx
+++ b/web/src/components/dashboard/StatBlockFactoryModal.tsx
@@ -17,6 +17,7 @@ import { InlineAIAssist } from './InlineAIAssist'
 import { STAT_BLOCK_SYSTEM_PROMPT, STAT_INLINE_ASSIST_PROMPT } from '../../lib/ai/prompts'
 import { useAIMode } from '../../hooks/useAIMode'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Button } from '../ui/Button'
 import type { StatBlockFactoryModalProps, Tab, BlockEditorItem, StatAssistResult, AiStatBlockResult } from './statBlockFactoryModal.types'
 import {
   AVAILABLE_COLORS,
@@ -232,13 +233,15 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
                   <label className="text-xs text-muted-foreground font-medium">
                     {t('dashboard.statFactory.statBlocks', { count: blocks.length })}
                   </label>
-                  <button
+                  <Button
+                    variant="secondary"
+                    size="sm"
                     onClick={addBlock}
-                    className="flex items-center gap-1 text-xs px-2 py-1 rounded-lg bg-secondary text-muted-foreground hover:text-foreground transition-colors"
+                    className="min-h-11"
+                    icon={<Plus className="w-3 h-3" />}
                   >
-                    <Plus className="w-3 h-3" />
                     {t('dashboard.statFactory.addBlock')}
-                  </button>
+                  </Button>
                 </div>
 
                 <div className="space-y-2 max-h-[35vh] overflow-y-auto">
@@ -256,7 +259,7 @@ export function StatBlockFactoryModal({ isOpen, onClose, onStatsCreated, embedde
                             <button
                               onClick={() => moveBlock(idx, 'up')}
                               disabled={idx === 0}
-                              className="p-0.5 text-muted-foreground hover:text-foreground disabled:opacity-20"
+                              className="p-0.5 min-h-11 min-w-11 flex items-center justify-center text-muted-foreground hover:text-foreground disabled:opacity-20"
                               title={t('dashboard.statFactory.moveBlockUp')}
                               aria-label={t('dashboard.statFactory.moveBlockUp')}
                             >

--- a/web/src/components/namespaces/GrantAccessModal.tsx
+++ b/web/src/components/namespaces/GrantAccessModal.tsx
@@ -247,7 +247,7 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
                       role="option"
                       aria-selected={activeSuggestionIndex === index}
                       onClick={() => selectSubject(name)}
-                      className={`w-full px-3 py-2 text-left text-sm text-white hover:bg-secondary/50 transition-colors ${activeSuggestionIndex === index ? 'bg-secondary/50' : ''}`}
+                      className={`flex w-full items-center min-h-11 px-3 py-2 text-left text-sm text-white hover:bg-secondary/50 transition-colors ${activeSuggestionIndex === index ? 'bg-secondary/50' : ''}`}
                     >
                       {name}
                     </button>
@@ -258,7 +258,7 @@ export function GrantAccessModal({ namespace, existingAccess, onClose, onGranted
                       role="option"
                       aria-selected={activeSuggestionIndex === filteredSubjects.length}
                       onClick={() => selectSubject(subjectName)}
-                      className={`w-full px-3 py-2 text-left text-sm text-blue-400 hover:bg-secondary/50 transition-colors border-t border-border ${activeSuggestionIndex === filteredSubjects.length ? 'bg-secondary/50' : ''}`}
+                      className={`flex w-full items-center min-h-11 px-3 py-2 text-left text-sm text-blue-400 hover:bg-secondary/50 transition-colors border-t border-border ${activeSuggestionIndex === filteredSubjects.length ? 'bg-secondary/50' : ''}`}
                     >
                       Use &quot;{subjectName}&quot;
                     </button>

--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -11,6 +11,7 @@ import { useClusters } from './useMCP'
 import { getStoredAuthTokenSync } from '../lib/authToken'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
@@ -26,9 +27,6 @@ const FAILURE_THRESHOLD = 3
 
 /** localStorage key for webhooks cache */
 const CACHE_KEY = 'kc-admission-webhooks-cache'
-
-/** HTTP status code returned when the backend has no k8s client */
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 // ============================================================================
 // Types
@@ -175,7 +173,7 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
         signal: signal ?? AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
-      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+      if (res.status === HTTP_SERVICE_UNAVAILABLE) {
         throw new Error('Service unavailable')
       }
 

--- a/web/src/hooks/useBenchmarkData.ts
+++ b/web/src/hooks/useBenchmarkData.ts
@@ -19,6 +19,7 @@ import {
 } from '../lib/llmd/benchmarkMockData'
 import { getStoredAuthTokenSync } from '../lib/authToken'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 function authHeaders(): Record<string, string> {
   const token = getStoredAuthTokenSync()
@@ -26,7 +27,6 @@ function authHeaders(): Record<string, string> {
 }
 
 const DEMO_REPORTS = generateBenchmarkReports()
-const HTTP_SERVICE_UNAVAILABLE = 503
 
 // ---------------------------------------------------------------------------
 // Module-level SSE singleton — shared across all card hook instances

--- a/web/src/hooks/useCRDs.ts
+++ b/web/src/hooks/useCRDs.ts
@@ -13,13 +13,13 @@ import { useClusters } from './useMCP'
 import { getStoredAuthTokenSync } from '../lib/authToken'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { createCachedHook } from '../lib/cache'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
 // ============================================================================
 
 const CRD_CACHE_KEY = 'crds'
-const STATUS_SERVICE_UNAVAILABLE = 503
 const DEFAULT_DEMO_CLUSTERS = ['us-east-1', 'us-west-2', 'eu-central-1'] as const
 
 // ============================================================================
@@ -99,7 +99,7 @@ async function fetchCRDs(): Promise<CRDData[]> {
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
-  if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+  if (res.status === HTTP_SERVICE_UNAVAILABLE) {
     throw new Error('Service unavailable')
   }
 

--- a/web/src/hooks/useCachedBackstage.ts
+++ b/web/src/hooks/useCachedBackstage.ts
@@ -26,6 +26,7 @@ import {
   type BackstageScaffolderTemplate,
   type BackstageStatusData,
 } from '../lib/demo/backstage'
+import { HTTP_NOT_FOUND } from '../lib/constants/http'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -44,8 +45,6 @@ const DEFAULT_DESIRED_REPLICAS = 0
 // Backstage install against a real SCM provider.
 const STALE_CATALOG_WINDOW_HOURS = 6
 const STALE_CATALOG_WINDOW_MS = STALE_CATALOG_WINDOW_HOURS * BACKSTAGE_MS_PER_HOUR
-
-const NOT_FOUND_STATUS = 404
 
 const EMPTY_CATALOG: BackstageCatalogCounts = {
   Component: 0,
@@ -209,7 +208,7 @@ async function fetchBackstageStatus(): Promise<BackstageStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === NOT_FOUND_STATUS) {
+    if (resp.status === HTTP_NOT_FOUND) {
       // Endpoint not yet wired — surface "not-installed" so the cache layer
       // will fall back to demo data instead of flagging a hard failure.
       return buildBackstageStatus({})

--- a/web/src/hooks/useCachedCloudCustodian.ts
+++ b/web/src/hooks/useCachedCloudCustodian.ts
@@ -23,6 +23,7 @@ import {
   type CustodianSeverityCounts,
   type CustodianTopResource,
 } from '../lib/demo/cloud-custodian'
+import { HTTP_NOT_FOUND } from '../lib/constants/http'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -31,8 +32,6 @@ import {
 const CACHE_KEY_CLOUD_CUSTODIAN = 'cloud-custodian-status'
 const CLOUD_CUSTODIAN_STATUS_ENDPOINT = '/api/cloud-custodian/status'
 const DEFAULT_CUSTODIAN_VERSION = 'unknown'
-
-const NOT_FOUND_STATUS = 404
 
 const EMPTY_SEVERITY_COUNTS: CustodianSeverityCounts = {
   critical: 0,
@@ -140,7 +139,7 @@ async function fetchCloudCustodianStatus(): Promise<CloudCustodianStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === NOT_FOUND_STATUS) {
+    if (resp.status === HTTP_NOT_FOUND) {
       // Endpoint not yet wired — surface "not-installed" so the cache layer
       // will fall back to demo data instead of flagging a hard failure.
       return buildCloudCustodianStatus(

--- a/web/src/hooks/useCachedCortex.ts
+++ b/web/src/hooks/useCachedCortex.ts
@@ -22,6 +22,7 @@ import {
   type CortexStatusData,
   type CortexSummary,
 } from '../lib/demo/cortex'
+import { HTTP_NOT_FOUND } from '../lib/constants/http'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -30,7 +31,6 @@ import {
 const CACHE_KEY = 'cortex-status'
 const CORTEX_STATUS_ENDPOINT = '/api/cortex/status'
 const DEFAULT_VERSION = 'unknown'
-const NOT_FOUND_STATUS = 404
 
 const EMPTY_METRICS: CortexIngestionMetrics = {
   activeSeries: 0,
@@ -125,7 +125,7 @@ async function fetchJson<T>(
     })
 
     if (!resp.ok) {
-      if (options?.treat404AsEmpty && resp.status === NOT_FOUND_STATUS) {
+      if (options?.treat404AsEmpty && resp.status === HTTP_NOT_FOUND) {
         return { data: null, failed: false }
       }
       return { data: null, failed: true }

--- a/web/src/hooks/useCachedLonghorn.ts
+++ b/web/src/hooks/useCachedLonghorn.ts
@@ -28,6 +28,7 @@ import {
   type LonghornVolumeRobustness,
   type LonghornVolumeState,
 } from '../lib/demo/longhorn'
+import { HTTP_NOT_FOUND } from '../lib/constants/http'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,9 +36,6 @@ import {
 
 const CACHE_KEY_LONGHORN = 'longhorn-status'
 const LONGHORN_STATUS_ENDPOINT = '/api/longhorn/status'
-
-// HTTP status sentinels
-const HTTP_NOT_FOUND = 404
 
 const INITIAL_DATA: LonghornStatusData = {
   health: 'not-installed',

--- a/web/src/hooks/useCachedSpire.ts
+++ b/web/src/hooks/useCachedSpire.ts
@@ -24,6 +24,7 @@ import {
   type SpireStatusData,
   type SpireSummary,
 } from '../lib/demo/spire'
+import { HTTP_NOT_FOUND } from '../lib/constants/http'
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -33,8 +34,6 @@ const CACHE_KEY_SPIRE = 'spire-status'
 const SPIRE_STATUS_ENDPOINT = '/api/spire/status'
 const DEFAULT_VERSION = 'unknown'
 const DEFAULT_TRUST_DOMAIN = ''
-
-const NOT_FOUND_STATUS = 404
 
 const INITIAL_SUMMARY: SpireSummary = {
   registrationEntries: 0,
@@ -152,7 +151,7 @@ async function fetchSpireStatus(): Promise<SpireStatusData> {
   })
 
   if (!resp.ok) {
-    if (resp.status === NOT_FOUND_STATUS) {
+    if (resp.status === HTTP_NOT_FOUND) {
       // Endpoint not yet wired — surface "not-installed" so the cache layer
       // will fall back to demo data instead of flagging a hard failure.
       return buildSpireStatus(DEFAULT_VERSION, DEFAULT_TRUST_DOMAIN, [], null, {})

--- a/web/src/hooks/useConsoleCRs.ts
+++ b/web/src/hooks/useConsoleCRs.ts
@@ -3,8 +3,7 @@ import { usePersistence } from './usePersistence'
 import { agentFetch } from './mcp/shared'
 import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../lib/constants/network'
 import { logger } from '@/lib/logger'
-
-const HTTP_NO_CONTENT = 204
+import { HTTP_NO_CONTENT } from '../lib/constants/http'
 
 // =============================================================================
 // Types

--- a/web/src/hooks/useDeployMissions.types.ts
+++ b/web/src/hooks/useDeployMissions.types.ts
@@ -2,8 +2,7 @@ import { getStoredAuthTokenSync } from '../lib/authToken'
 import { MS_PER_MINUTE } from '../lib/constants/time'
 
 /** HTTP status codes that indicate authentication/authorization failure */
-export const HTTP_UNAUTHORIZED = 401
-export const HTTP_FORBIDDEN = 403
+export { HTTP_UNAUTHORIZED, HTTP_FORBIDDEN } from '../lib/constants/http'
 
 export type DeployMissionStatus = 'launching' | 'deploying' | 'orbit' | 'abort' | 'partial'
 

--- a/web/src/hooks/useGatewayStatus.ts
+++ b/web/src/hooks/useGatewayStatus.ts
@@ -18,6 +18,7 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { registerRefetch } from '../lib/modeTransition'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
@@ -33,9 +34,6 @@ const FAILURE_THRESHOLD = 3
 
 /** localStorage key for Gateway status cache */
 const CACHE_KEY = 'kc-gateway-status-cache'
-
-/** HTTP status code returned when the backend has no k8s client */
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 // ============================================================================
 // Types
@@ -119,7 +117,6 @@ function saveToCache(data: Gateway[], isDemoData: boolean): void {
 // ============================================================================
 // Demo Data Generator
 // ============================================================================
-
 
 function getDemoGateways(clusterNames: string[]): Gateway[] {
   const gateways: Gateway[] = []
@@ -247,7 +244,7 @@ export function useGatewayStatus(): UseGatewayStatusResult {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
-      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+      if (res.status === HTTP_SERVICE_UNAVAILABLE) {
         throw new Error('Service unavailable')
       }
 

--- a/web/src/hooks/useLocalAgent.ts
+++ b/web/src/hooks/useLocalAgent.ts
@@ -7,6 +7,7 @@ import { safeGetItem, safeSetItem } from '../lib/utils/localStorage'
 import { STORAGE_KEY_FIRST_AGENT_CONNECT } from '../lib/constants/storage'
 import { triggerAllRefetches } from '../lib/modeTransition'
 import { agentFetch } from './mcp/shared'
+import { HTTP_UNAUTHORIZED, HTTP_FORBIDDEN } from '../lib/constants/http'
 
 export interface ProviderSummary {
   name: string
@@ -61,11 +62,9 @@ const FAILURE_THRESHOLD = 2 // Require 2 consecutive failures before disconnecti
 // Using the default 10s timeout causes false failures when the browser's
 // HTTP/1.1 connection pool (6 per origin) is saturated by concurrent requests.
 const AGENT_HEALTH_TIMEOUT_MS = 1_500 // Reduced for faster disconnect detection (#14192)
-const HTTP_UNAUTHORIZED_STATUS = 401
-const HTTP_FORBIDDEN_STATUS = 403
 const AUTH_ERROR_STATUS_CODES = new Set([
-  HTTP_UNAUTHORIZED_STATUS,
-  HTTP_FORBIDDEN_STATUS,
+  HTTP_UNAUTHORIZED,
+  HTTP_FORBIDDEN,
 ])
 const SUCCESS_THRESHOLD = 2 // Require 2 consecutive successes before reconnecting (prevents flicker)
 const AGGRESSIVE_POLL_INTERVAL = 1_000 // 1 second during aggressive detection burst
@@ -357,7 +356,7 @@ class AgentManager {
       }
 
       if (AUTH_ERROR_STATUS_CODES.has(authResponse.status)) {
-        const isUnauthorized = authResponse.status === HTTP_UNAUTHORIZED_STATUS
+        const isUnauthorized = authResponse.status === HTTP_UNAUTHORIZED
         const authErrorMessage = isUnauthorized
           ? 'Local agent reachable, but authentication failed'
           : 'Local agent reachable, but access is forbidden'

--- a/web/src/hooks/useResultHistogram.ts
+++ b/web/src/hooks/useResultHistogram.ts
@@ -4,6 +4,7 @@ import { useCache } from '../lib/cache'
 import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import { isQuantumForcedToDemo } from '../lib/demoMode'
 import { subscribeToPatternChanges } from '../lib/quantum/patternChangeEmitter'
+import { HTTP_TOO_MANY_REQUESTS } from '../lib/constants/http'
 
 export type HistogramSort = 'count' | 'pattern'
 
@@ -44,7 +45,6 @@ interface UseResultHistogramResult {
 const HISTOGRAM_ENDPOINT = '/api/result/histogram'
 const DEFAULT_SORT: HistogramSort = 'count'
 const DEFAULT_POLL_MS = 5000
-const RATE_LIMIT_STATUS = 429
 const RATE_LIMIT_BACKOFF_BASE_MS = 100 // Base delay for exponential backoff (100ms, 200ms, 400ms...)
 
 const EMPTY_HISTOGRAM_DATA: HistogramData = {
@@ -131,14 +131,14 @@ async function fetchHistogramWithRetry(
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
-  if (response.status === RATE_LIMIT_STATUS) {
+  if (response.status === HTTP_TOO_MANY_REQUESTS) {
     if (attempt < maxAttempts - 1) {
       // Exponential backoff: 100ms, 200ms, 400ms
       const delayMs = RATE_LIMIT_BACKOFF_BASE_MS * Math.pow(2, attempt)
       await new Promise(resolve => setTimeout(resolve, delayMs))
       return fetchHistogramWithRetry(sortBy, attempt + 1, maxAttempts)
     }
-    throw new Error(`Failed to fetch histogram (${RATE_LIMIT_STATUS})`)
+    throw new Error(`Failed to fetch histogram (${HTTP_TOO_MANY_REQUESTS})`)
   }
 
   if (!response.ok) {

--- a/web/src/hooks/useServiceExports.ts
+++ b/web/src/hooks/useServiceExports.ts
@@ -18,6 +18,7 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceExport } from '../types/mcs'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
@@ -33,9 +34,6 @@ const FAILURE_THRESHOLD = 3
 
 /** localStorage key for ServiceExport cache */
 const CACHE_KEY = 'kc-service-exports-cache'
-
-/** HTTP status code returned when the backend has no k8s client */
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 // ============================================================================
 // Types
@@ -97,7 +95,6 @@ function saveToCache(data: ServiceExport[], isDemoData: boolean): void {
 // ============================================================================
 // Demo Data Generator
 // ============================================================================
-
 
 function getDemoServiceExports(clusterNames: string[]): ServiceExport[] {
   const exports: ServiceExport[] = []
@@ -180,7 +177,7 @@ export function useServiceExports(): UseServiceExportsResult {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
-      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+      if (res.status === HTTP_SERVICE_UNAVAILABLE) {
         throw new Error('Service unavailable')
       }
 

--- a/web/src/hooks/useServiceImportsCard.ts
+++ b/web/src/hooks/useServiceImportsCard.ts
@@ -18,6 +18,7 @@ import { FETCH_DEFAULT_TIMEOUT_MS } from '../lib/constants/network'
 import type { ServiceImport, ServiceImportList } from '../types/mcs'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { MS_PER_DAY, MS_PER_HOUR } from '../lib/constants/time'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
@@ -33,9 +34,6 @@ const FAILURE_THRESHOLD = 3
 
 /** localStorage key for ServiceImports cache */
 const CACHE_KEY = 'kc-service-imports-cache'
-
-/** HTTP status code returned when the backend has no k8s client */
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 // ============================================================================
 // Types
@@ -92,7 +90,6 @@ function saveToCache(data: ServiceImport[], isDemoData: boolean): void {
 // ============================================================================
 // Demo Data Generator
 // ============================================================================
-
 
 function getDemoServiceImports(clusterNames: string[]): ServiceImport[] {
   const imports: ServiceImport[] = []
@@ -181,7 +178,7 @@ export function useServiceImportsCard(): UseServiceImportsCardResult {
         signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
       })
 
-      if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+      if (res.status === HTTP_SERVICE_UNAVAILABLE) {
         throw new Error('Service unavailable')
       }
 

--- a/web/src/hooks/useTopology.ts
+++ b/web/src/hooks/useTopology.ts
@@ -25,6 +25,7 @@ import type {
   TopologyNode,
   TopologyEdge,
 } from '../types/topology'
+import { HTTP_SERVICE_UNAVAILABLE } from '../lib/constants/http'
 
 // ============================================================================
 // Constants
@@ -37,9 +38,6 @@ const CACHE_EXPIRY_MS = 300_000
 
 /** localStorage key for topology cache */
 const TOPOLOGY_CACHE_KEY = 'kc-topology-cache'
-
-/** HTTP status code returned when the backend has no k8s client */
-const STATUS_SERVICE_UNAVAILABLE = 503
 
 // ============================================================================
 // Demo fallback data
@@ -186,7 +184,7 @@ async function fetchTopology(): Promise<TopologyData> {
     signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
   })
 
-  if (res.status === STATUS_SERVICE_UNAVAILABLE) {
+  if (res.status === HTTP_SERVICE_UNAVAILABLE) {
     console.warn('[useTopology] Backend returned 503, using demo data')
     return normalizeTopologyData(DEMO_RESPONSE, true)
   }

--- a/web/src/hooks/version/useAutoUpdate.ts
+++ b/web/src/hooks/version/useAutoUpdate.ts
@@ -1,6 +1,7 @@
 import type { AutoUpdateStatus, UpdateChannel } from '../../types/updates'
 import { authFetch } from '../../lib/api'
 import { FETCH_DEFAULT_TIMEOUT_MS, isLocalAgentSuppressed } from '../../lib/constants/network'
+import { HTTP_CONFLICT, HTTP_NOT_FOUND } from '../../lib/constants/http'
 import {
   CANCEL_UPDATE_TIMEOUT_MS,
   safeJsonParse,
@@ -87,7 +88,7 @@ export async function triggerUpdate(channel: UpdateChannel): Promise<AutoUpdateM
 
     return {
       success: false,
-      error: response.status === 404
+      error: response.status === HTTP_NOT_FOUND
         ? 'kc-agent does not support auto-update yet — restart with latest code'
         : `kc-agent returned ${response.status}`,
     }
@@ -112,13 +113,13 @@ export async function cancelUpdate(): Promise<AutoUpdateMutationResult> {
       return { success: true }
     }
 
-    if (response.status === 409) {
+    if (response.status === HTTP_CONFLICT) {
       return { success: false, error: 'No update in progress' }
     }
 
     return {
       success: false,
-      error: response.status === 404
+      error: response.status === HTTP_NOT_FOUND
         ? 'kc-agent does not support cancel yet — restart with latest code'
         : `kc-agent returned ${response.status}`,
     }

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -11,6 +11,7 @@ import { clearClusterCacheOnLogout } from '../hooks/mcp/shared'
 import { clearAgentToken, setAgentToken } from '../hooks/mcp/agentFetch'
 import { DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_HAS_SESSION, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE } from './constants'
 import { isLocalAgentSuppressed } from './constants/network'
+import { HTTP_UNAUTHORIZED, HTTP_FORBIDDEN } from './constants/http'
 import { safeGet, safeRemove, safeSet, safeSetJSON } from './safeLocalStorage'
 import { AUTH_TOKEN_SYNC_KEY, clearStoredAuthToken, getStoredAuthToken, getStoredAuthTokenSync, parseAuthTokenSyncEvent, setStoredAuthToken } from './authToken'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession, emitSessionRefreshFailure } from './analytics'
@@ -377,8 +378,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             // #6930 — A 401/403 from /auth/refresh is a definitive signal that
             // the server session has expired. Clear the session hint so future
             // page loads don't keep hitting /auth/refresh in a loop.
-            const HTTP_UNAUTHORIZED = 401
-            const HTTP_FORBIDDEN = 403
             if (refreshResponse.status === HTTP_UNAUTHORIZED || refreshResponse.status === HTTP_FORBIDDEN) {
               localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
             }
@@ -668,8 +667,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           } else {
             // #6930 — A definitive auth failure from the banner refresh
             // should also clear the session hint to prevent stale loops.
-            const HTTP_UNAUTHORIZED = 401
-            const HTTP_FORBIDDEN = 403
             if (response.status === HTTP_UNAUTHORIZED || response.status === HTTP_FORBIDDEN) {
               localStorage.removeItem(STORAGE_KEY_HAS_SESSION)
             }

--- a/web/src/lib/constants/http.ts
+++ b/web/src/lib/constants/http.ts
@@ -1,0 +1,39 @@
+/**
+ * HTTP Status Constants
+ *
+ * Centralizes HTTP status codes that were previously re-declared as file-local
+ * magic numbers across 20+ hooks and libraries (`const NOT_FOUND_STATUS = 404`,
+ * `const STATUS_SERVICE_UNAVAILABLE = 503`, ...).
+ *
+ * Import from here instead of introducing a new local constant.
+ */
+
+/** 200 — request succeeded. */
+export const HTTP_OK = 200
+
+/** 204 — request succeeded with an intentionally empty body. */
+export const HTTP_NO_CONTENT = 204
+
+/** 400 — malformed request; retrying without changes will fail again. */
+export const HTTP_BAD_REQUEST = 400
+
+/** 401 — missing/expired credentials; the caller should re-authenticate. */
+export const HTTP_UNAUTHORIZED = 401
+
+/** 403 — authenticated but not permitted (commonly RBAC denials). */
+export const HTTP_FORBIDDEN = 403
+
+/** 404 — resource absent. Often treated as "feature not installed" / empty. */
+export const HTTP_NOT_FOUND = 404
+
+/** 409 — conflicting concurrent write; the caller should refetch and retry. */
+export const HTTP_CONFLICT = 409
+
+/** 429 — client is rate limited; back off before retrying. */
+export const HTTP_TOO_MANY_REQUESTS = 429
+
+/** 500 — unexpected server-side failure. */
+export const HTTP_INTERNAL_SERVER_ERROR = 500
+
+/** 503 — backend reachable but dependency (agent/cluster) is unavailable. */
+export const HTTP_SERVICE_UNAVAILABLE = 503

--- a/web/src/lib/constants/index.ts
+++ b/web/src/lib/constants/index.ts
@@ -1,6 +1,7 @@
 /**
  * Constants barrel export
  */
+export * from './http'
 export * from './network'
 export * from './storage'
 export {


### PR DESCRIPTION
Fixes #21710
Fixes #21712
Fixes #21713
Fixes #21714

Auto-QA UI resilience and consistency pass. Behavior-safe: no data-flow, API, or control-flow changes — only constant extraction, class additions, and shared-component substitution.

## #21710 — Hardcoded thresholds and magic numbers / #21714 — Centralization

The scan surfaced HTTP status codes re-declared as file-local magic numbers across the codebase under four different names (`NOT_FOUND_STATUS`, `HTTP_NOT_FOUND`, `STATUS_SERVICE_UNAVAILABLE`, `HTTP_SERVICE_UNAVAILABLE`, `RATE_LIMIT_STATUS`, `HTTP_UNAUTHORIZED_STATUS`, ...), including two copies declared *inside function bodies* in `lib/auth.tsx`.

- New `web/src/lib/constants/http.ts` with documented status constants, exported from the `lib/constants` barrel.
- Migrated 19 files off their local redeclarations.
- Replaced the remaining raw `404` / `409` literals in `hooks/version/useAutoUpdate.ts`.
- `useDeployMissions.types.ts` now re-exports `HTTP_UNAUTHORIZED` / `HTTP_FORBIDDEN` from the shared module so its existing consumers are unaffected.

Note on the other #21714 suggestions: a shared `useModal` hook **already exists** (`src/hooks/useModal.ts` → `lib/modals/useModalNavigation.ts:390`), so that item was already done.

## #21712 — Touch targets

Most reported lines were already fixed in earlier passes (`NamespaceResources.tsx`, `InstallCTAFlow.tsx`, `ResourceBadges.tsx`, `TeamAccessGrants.tsx` all already carry `min-h-11`/`min-w-11`). The four genuinely-remaining sub-44px targets are fixed here:

- `StatBlockFactoryModal.tsx` — reorder handle was `p-0.5` (~20px).
- `PostConnectBanner.tsx` — dismiss button was `p-1.5` (~26px).
- `GrantAccessModal.tsx` — subject suggestion listbox options were `py-2` (~36px).
- `ACMMFeedbackLoops.tsx` — re-scan icon button was `p-1` (~22px).

## #21713 — Inconsistent component patterns

Replaced raw `<button>` elements with the shared `ui/Button` component in `PostConnectBanner.tsx` (dismiss) and `StatBlockFactoryModal.tsx` (add block), which also gives them the standard focus/disabled/aria handling for free.

## #21711 — closed as not planned

Audited separately; every non-test file in that report already has loading/error handling (or does no fetching at all). Evidence table posted at https://github.com/kubestellar/console/issues/21711#issuecomment-5106523780.

<sub>Co-authored-by: Copilot &lt;223556219+Copilot@users.noreply.github.com&gt;</sub>