### PR TITLE
[scanner] fix: split GPU and cluster component modules

### DIFF
--- a/web/src/components/clusters/Clusters.tsx
+++ b/web/src/components/clusters/Clusters.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useMemo } from 'react'
 import { useSearchParams, useLocation, useNavigate } from 'react-router-dom'
 import { AlertCircle, AlertTriangle, CheckCircle, ChevronRight, ChevronDown, Server, Scissors } from 'lucide-react'
 import { useClusters, useGPUNodes, useNVIDIAOperators, refreshSingleCluster } from '../../hooks/useMCP'
-import { agentFetch } from '../../hooks/mcp/shared'
 import { ClusterDetailModal } from './ClusterDetailModal'
 import { AddClusterDialog } from './AddClusterDialog'
 import { EmptyClusterState } from './EmptyClusterState'
@@ -11,16 +10,13 @@ import {
   RemoveClusterDialog,
   FilterTabs,
   ClusterGrid,
-  GPUDetailModal,
-  type ClusterLayoutMode } from './components'
+  GPUDetailModal } from './components'
 import { useMissions } from '../../hooks/useMissions'
 import { useApiKeyCheck, ApiKeyPromptModal } from '../cards/console-missions/shared'
 import { loadMissionPrompt } from '../cards/multi-tenancy/missionLoader'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { useLocalAgent, wasAgentEverConnected } from '../../hooks/useLocalAgent'
-import { emitClusterStatsDrillDown } from '../../lib/analytics'
-import { ROUTES } from '../../config/routes'
 import { isInClusterMode } from '../../hooks/useBackendHealth'
 import { useDemoMode } from '../../hooks/useDemoMode'
 import { useGlobalFilters } from '../../hooks/useGlobalFilters'
@@ -28,16 +24,16 @@ import { usePermissions } from '../../hooks/usePermissions'
 import { ClusterCardSkeleton } from '../ui/ClusterCardSkeleton'
 import { useIsModeSwitching } from '../../lib/unified/demo'
 import { useTranslation } from 'react-i18next'
-import { LOCAL_AGENT_HTTP_URL, STORAGE_KEY_CLUSTER_LAYOUT, STORAGE_KEY_CLUSTER_ORDER, FETCH_DEFAULT_TIMEOUT_MS, isLocalAgentSuppressed } from '../../lib/constants'
-import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import { isLocalAgentSuppressed } from '../../lib/constants'
 import { useModalState } from '../../lib/modals'
-import { useToast } from '../ui/Toast'
 import type { StatBlockValue } from '../ui/StatsOverview'
-import { formatMemoryStat } from '../../lib/formatStats'
 import { RotatingTip } from '../ui/RotatingTip'
 import { StatusBadge } from '../ui/StatusBadge'
 import { useClusterFiltering } from './useClusterFiltering'
 import { useClusterStats } from './useClusterStats'
+import { useClusterViewState } from './useClusterViewState'
+import { useClusterMutations } from './useClusterMutations'
+import { getClusterDashboardStatValue } from './clusterStatValues'
 import { ClusterGroupsSection } from './ClusterGroupsSection'
 
 // Storage key for cluster page cards
@@ -64,7 +60,6 @@ export function Clusters() {
   const { startMission, openSidebar } = useMissions()
   const { showKeyPrompt: pruneShowKeyPrompt, checkKeyAndRun: pruneCheckKeyAndRun, goToSettings: pruneGoToSettings, dismissPrompt: pruneDismissPrompt } = useApiKeyCheck()
   const { showKeyPrompt: createShowKeyPrompt, checkKeyAndRun: createCheckKeyAndRun, goToSettings: createGoToSettings, dismissPrompt: createDismissPrompt } = useApiKeyCheck()
-  const { showToast } = useToast()
 
   // When demo mode is OFF and agent is not connected, force skeleton display
   // Also show skeleton during mode switching for smooth transitions
@@ -81,67 +76,24 @@ export function Clusters() {
     selectClusterGroup,
     selectedDistributions,
     isAllDistributionsSelected } = useGlobalFilters()
-  const [searchParams, setSearchParams] = useSearchParams()
+  const searchParamsTuple = useSearchParams()
   const location = useLocation()
   const navigate = useNavigate()
   const [selectedCluster, setSelectedCluster] = useState<string | null>(null)
 
-  // Read filter from URL, default to 'all'
-  const urlStatus = searchParams.get('status')
-  const validFilter = (urlStatus === 'healthy' || urlStatus === 'unhealthy' || urlStatus === 'unreachable') ? urlStatus : 'all'
-  const [filter, setFilterState] = useState<'all' | 'healthy' | 'unhealthy' | 'unreachable'>(validFilter)
+  const {
+    filter,
+    setFilter,
+    sortBy,
+    setSortBy,
+    sortAsc,
+    setSortAsc,
+    customOrder,
+    layoutMode,
+    setLayoutMode,
+    handleReorder,
+  } = useClusterViewState(searchParamsTuple)
 
-  // Sync filter state with URL changes (e.g., when navigating from sidebar)
-  useEffect(() => {
-    const newFilter = (urlStatus === 'healthy' || urlStatus === 'unhealthy' || urlStatus === 'unreachable') ? urlStatus : 'all'
-    if (newFilter !== filter) {
-      setFilterState(newFilter)
-    }
-  }, [urlStatus, filter])
-
-  // Update URL when filter changes programmatically
-  const setFilter = (newFilter: 'all' | 'healthy' | 'unhealthy' | 'unreachable') => {
-    setFilterState(newFilter)
-    if (newFilter === 'all') {
-      searchParams.delete('status')
-    } else {
-      searchParams.set('status', newFilter)
-    }
-    setSearchParams(searchParams, { replace: true })
-  }
-  const [sortState, setSortState] = useState<{ by: 'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom'; customOrder: string[] }>(() => {
-    try {
-      const savedOrder = safeGetItem(STORAGE_KEY_CLUSTER_ORDER)
-      return {
-        by: savedOrder ? 'custom' : 'name',
-        customOrder: savedOrder ? JSON.parse(savedOrder) : [] }
-    } catch {
-      return { by: 'name', customOrder: [] }
-    }
-  })
-  const [sortAsc, setSortAsc] = useState(true)
-
-  // Notify user if saved cluster sort configuration was corrupt and had to be reset
-  useEffect(() => {
-    const savedOrder = safeGetItem(STORAGE_KEY_CLUSTER_ORDER)
-    if (savedOrder) {
-      try {
-        JSON.parse(savedOrder)
-      } catch {
-        showToast(t('cluster.sortPreferencesCorrupted'), 'warning')
-      }
-    }
-  }, []) // eslint-disable-line react-hooks/exhaustive-deps
-
-  // Convenience aliases so downstream code stays unchanged
-  const sortBy = sortState.by
-  const customOrder = sortState.customOrder
-  const setSortBy = (by: 'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom') =>
-      setSortState(prev => ({ ...prev, by }))
-  const [layoutMode, setLayoutMode] = useState<ClusterLayoutMode>(() => {
-    const stored = safeGetItem(STORAGE_KEY_CLUSTER_LAYOUT)
-    return (stored as ClusterLayoutMode) || 'grid'
-  })
   const [renamingCluster, setRenamingCluster] = useState<string | null>(null)
   const [removingCluster, setRemovingCluster] = useState<string | null>(null)
 
@@ -155,67 +107,7 @@ export function Clusters() {
     refetch()
   }, [location.key]) // eslint-disable-line react-hooks/exhaustive-deps
 
-  const handleRenameContext = async (oldName: string, newName: string) => {
-    if (!isConnected) throw new Error(t('cluster.renameNoAgent'))
-    // Use agentFetch so the Authorization: Bearer <KC_AGENT_TOKEN> header
-    // is injected — plain fetch() is rejected with 401 when the agent has
-    // a token configured (#6133).
-    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rename-context`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ oldName, newName }),
-      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-    if (!response.ok) {
-      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
-      // Fall back to HTTP status so users see e.g. "HTTP 401: Unauthorized"
-      // instead of a silent generic error when the body has no message.
-      const fallback = `HTTP ${response.status}: ${response.statusText || 'Failed to rename context'}`
-      throw new Error(data.error || data.message || fallback)
-    }
-    refetch()
-  }
-
-  /**
-   * Remove an offline cluster's kubeconfig context (#5901).
-   * Backend: `RemoveContext` in pkg/k8s/client.go (added in #5658). The agent
-   * exposes it at POST /kubeconfig/remove on the localhost-only HTTP server.
-   *
-   * Uses agentFetch() to inject the KC_AGENT_TOKEN Authorization header;
-   * without this the kc-agent rejects the request with 401 Unauthorized
-   * whenever a token is configured, which manifested as a silent "Failed
-   * to remove cluster from kubeconfig" in the UI (#6133).
-   */
-  const handleRemoveCluster = async (contextName: string) => {
-    if (!isConnected) throw new Error(t('cluster.removeClusterNoAgent'))
-    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/remove`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ context: contextName }),
-      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-    if (!response.ok) {
-      // #6293: check for the 404-means-stale-agent case BEFORE attempting
-      // to parse the body. An old kc-agent returns a plain-text Go
-      // default 404 ("404 page not found") which is not JSON — reading
-      // it first would be a wasted round-trip. Same reason #6288 added
-      // the status-specific branch in the first place.
-      if (response.status === 404) {
-        throw new Error(t('cluster.removeClusterAgentTooOld'))
-      }
-      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
-      // Always surface the HTTP status if the body has no structured error,
-      // so the user sees "HTTP 401: Unauthorized" instead of the generic
-      // fallback — this was the root cause of #6133 being unactionable.
-      const fallback = `HTTP ${response.status}: ${response.statusText || t('cluster.removeClusterError')}`
-      throw new Error(data.error || data.message || fallback)
-    }
-    showToast(t('cluster.removeClusterSuccess', { name: contextName }), 'success')
-    refetch()
-  }
-
-  const handleReorder = (newOrder: string[]) => {
-    setSortState({ by: 'custom', customOrder: newOrder })
-    safeSetItem(STORAGE_KEY_CLUSTER_ORDER, JSON.stringify(newOrder))
-  }
+  const { handleRenameContext, handleRemoveCluster } = useClusterMutations({ isConnected, refetch })
 
   const { filteredClusters, globalFilteredClusters } = useClusterFiltering({
     clusters,
@@ -272,93 +164,16 @@ export function Clusters() {
   const showSkeletonContent = (isLoading && (clusters || []).length === 0) || forceSkeletonForOffline || isModeSwitching
 
   // Stats value getter for DashboardPage's configurable StatsOverview
-  const getDashboardStatValue = (blockId: string): StatBlockValue => {
-    const hasData = stats.hasResourceData || stats.total > 0
-    switch (blockId) {
-      case 'clusters':
-        return {
-          value: stats.total,
-          groundtruthField: 'clusters-total',
-          sublabel: 'total clusters',
-          onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('all'); setShowClusterGrid(true) },
-          isClickable: stats.total > 0 }
-      case 'healthy':
-        return {
-          value: stats.healthy,
-          groundtruthField: 'clusters-healthy',
-          sublabel: 'healthy',
-          max: clusterStatusProgressMax,
-          onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('healthy'); setShowClusterGrid(true) },
-          isClickable: stats.healthy > 0 }
-      case 'unhealthy':
-        return {
-          value: stats.unhealthy,
-          sublabel: 'unhealthy',
-          max: clusterStatusProgressMax,
-          onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('unhealthy'); setShowClusterGrid(true) },
-          isClickable: stats.unhealthy > 0 }
-      case 'unreachable':
-        return {
-          value: stats.unreachable,
-          sublabel: 'offline',
-          max: clusterStatusProgressMax,
-          onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('unreachable'); setShowClusterGrid(true) },
-          isClickable: stats.unreachable > 0 }
-      case 'nodes':
-        return {
-          value: hasData ? stats.totalNodes : '-',
-          groundtruthFields: {
-            'nodes-total': hasData ? stats.totalNodes : '-',
-            'nodes-ready': stats.healthyNodes,
-          },
-          progressValue: stats.healthyNodes,
-          max: stats.totalNodes,
-          sublabel: 'total nodes',
-          onClick: () => { emitClusterStatsDrillDown('nodes'); navigate(ROUTES.COMPUTE) },
-          isClickable: hasData }
-      case 'cpus':
-        return {
-          value: hasData ? stats.totalCPUs : '-',
-          sublabel: 'cores allocatable',
-          onClick: () => { emitClusterStatsDrillDown('cpu'); navigate(ROUTES.COMPUTE) },
-          isClickable: hasData }
-      case 'memory':
-        return {
-          value: hasData ? formatMemoryStat(stats.totalMemoryGB) : '-',
-          sublabel: 'allocatable',
-          onClick: () => { emitClusterStatsDrillDown('memory'); navigate(ROUTES.COMPUTE) },
-          isClickable: hasData }
-      case 'storage':
-        return {
-          value: hasData ? formatMemoryStat(stats.totalStorageGB) : '-',
-          sublabel: 'storage',
-          onClick: () => { emitClusterStatsDrillDown('storage'); navigate(ROUTES.STORAGE) },
-          isClickable: hasData }
-      case 'gpus':
-        return {
-          value: hasData ? stats.totalGPUs : '-',
-          sublabel: 'total GPUs',
-          onClick: () => { emitClusterStatsDrillDown('gpu'); openGPUModal() },
-          isClickable: hasData && stats.totalGPUs > 0 }
-      case 'pods':
-        return {
-          value: hasData ? stats.totalPods : '-',
-          groundtruthFields: {
-            'pods-total': hasData ? stats.totalPods : '-',
-            'pods-running': hasData ? stats.totalPods : '-',
-            'pods-pending': 0,
-            'pods-crashloop': 0,
-          },
-          sublabel: 'running pods',
-          onClick: () => { emitClusterStatsDrillDown('pods'); navigate(ROUTES.WORKLOADS) },
-          isClickable: hasData }
-      default:
-        return { value: '-', sublabel: '' }
-    }
-  }
-
-  const getStatValue = getDashboardStatValue
   const clusterStatusProgressMax = Math.max(stats.total, MIN_CLUSTER_PROGRESS_TOTAL)
+  const getStatValue = (blockId: string): StatBlockValue =>
+    getClusterDashboardStatValue(
+      blockId,
+      stats,
+      stats.hasResourceData || stats.total > 0,
+      clusterStatusProgressMax,
+      { navigate, setFilter, setShowClusterGrid, openGPUModal },
+    )
+
   const clusterGroundtruthFields: Record<string, number> = {
     'clusters-total': stats.total,
     'clusters-healthy': stats.healthy,
@@ -448,10 +263,7 @@ export function Clusters() {
                 sortAsc={sortAsc}
                 onSortAscChange={setSortAsc}
                 layoutMode={layoutMode}
-                onLayoutModeChange={(mode) => {
-                  setLayoutMode(mode)
-                  safeSetItem(STORAGE_KEY_CLUSTER_LAYOUT, mode)
-                }}
+                onLayoutModeChange={setLayoutMode}
                 onAddCluster={() => setShowAddCluster(true)}
                 onCreateClusterWithAI={() => {
                   createCheckKeyAndRun(async () => {

--- a/web/src/components/clusters/__tests__/clusterStatValues.test.ts
+++ b/web/src/components/clusters/__tests__/clusterStatValues.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import type { NavigateFunction } from 'react-router-dom'
+import type { ClusterStats } from '../useClusterStats'
+
+const { mockEmit } = vi.hoisted(() => ({
+  mockEmit: vi.fn(),
+}))
+
+vi.mock('../../../lib/analytics', () => ({
+  emitClusterStatsDrillDown: mockEmit,
+}))
+
+import { getClusterDashboardStatValue } from '../clusterStatValues'
+import { ROUTES } from '../../../config/routes'
+
+function makeStats(overrides: Partial<ClusterStats> = {}): ClusterStats {
+  return {
+    total: 5,
+    loading: 0,
+    healthy: 3,
+    unhealthy: 1,
+    unreachable: 1,
+    staleContexts: 0,
+    healthyNodes: 8,
+    totalNodes: 10,
+    totalCPUs: 64,
+    totalMemoryGB: 512,
+    totalStorageGB: 2048,
+    totalPods: 120,
+    totalGPUs: 4,
+    allocatedGPUs: 2,
+    hasResourceData: true,
+    ...overrides,
+  }
+}
+
+describe('getClusterDashboardStatValue', () => {
+  let navigate: NavigateFunction
+  let setFilter: ReturnType<typeof vi.fn>
+  let setShowClusterGrid: ReturnType<typeof vi.fn>
+  let openGPUModal: ReturnType<typeof vi.fn>
+
+  beforeEach(() => {
+    mockEmit.mockClear()
+    navigate = vi.fn() as unknown as NavigateFunction
+    setFilter = vi.fn()
+    setShowClusterGrid = vi.fn()
+    openGPUModal = vi.fn()
+  })
+
+  const callbacks = () => ({ navigate, setFilter, setShowClusterGrid, openGPUModal })
+
+  it('clusters: reports total count and is clickable when >0', () => {
+    const result = getClusterDashboardStatValue('clusters', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(5)
+    expect(result.isClickable).toBe(true)
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('cluster_health_status')
+    expect(setFilter).toHaveBeenCalledWith('all')
+    expect(setShowClusterGrid).toHaveBeenCalledWith(true)
+  })
+
+  it('healthy: reports healthy count and progress max', () => {
+    const result = getClusterDashboardStatValue('healthy', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(3)
+    expect(result.max).toBe(10)
+    result.onClick?.()
+    expect(setFilter).toHaveBeenCalledWith('healthy')
+  })
+
+  it('unhealthy: reports unhealthy count', () => {
+    const result = getClusterDashboardStatValue('unhealthy', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(1)
+    result.onClick?.()
+    expect(setFilter).toHaveBeenCalledWith('unhealthy')
+  })
+
+  it('unreachable: reports unreachable count', () => {
+    const result = getClusterDashboardStatValue('unreachable', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(1)
+    result.onClick?.()
+    expect(setFilter).toHaveBeenCalledWith('unreachable')
+  })
+
+  it('nodes: shows totalNodes and healthyNodes when hasData', () => {
+    const result = getClusterDashboardStatValue('nodes', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(10)
+    expect(result.progressValue).toBe(8)
+    expect(result.max).toBe(10)
+    expect(result.isClickable).toBe(true)
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('nodes')
+    expect(navigate).toHaveBeenCalledWith(ROUTES.COMPUTE)
+  })
+
+  it('nodes: shows dash and is not clickable when hasData is false', () => {
+    const result = getClusterDashboardStatValue('nodes', makeStats(), false, 10, callbacks())
+    expect(result.value).toBe('-')
+    expect(result.isClickable).toBe(false)
+  })
+
+  it('cpus: shows totalCPUs and navigates to compute', () => {
+    const result = getClusterDashboardStatValue('cpus', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(64)
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('cpu')
+    expect(navigate).toHaveBeenCalledWith(ROUTES.COMPUTE)
+  })
+
+  it('cpus: shows dash when hasData is false', () => {
+    const result = getClusterDashboardStatValue('cpus', makeStats(), false, 10, callbacks())
+    expect(result.value).toBe('-')
+  })
+
+  it('memory: formats totalMemoryGB via formatMemoryStat', () => {
+    const result = getClusterDashboardStatValue('memory', makeStats({ totalMemoryGB: 512 }), true, 10, callbacks())
+    expect(result.value).toBe('512 GB')
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('memory')
+    expect(navigate).toHaveBeenCalledWith(ROUTES.COMPUTE)
+  })
+
+  it('storage: formats totalStorageGB and navigates to storage route', () => {
+    const result = getClusterDashboardStatValue('storage', makeStats({ totalStorageGB: 2048 }), true, 10, callbacks())
+    expect(result.value).toBe('2.0 TB')
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('storage')
+    expect(navigate).toHaveBeenCalledWith(ROUTES.STORAGE)
+  })
+
+  it('gpus: is clickable only when hasData and totalGPUs > 0', () => {
+    const withGpus = getClusterDashboardStatValue('gpus', makeStats({ totalGPUs: 4 }), true, 10, callbacks())
+    expect(withGpus.isClickable).toBe(true)
+    withGpus.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('gpu')
+    expect(openGPUModal).toHaveBeenCalled()
+
+    const noGpus = getClusterDashboardStatValue('gpus', makeStats({ totalGPUs: 0 }), true, 10, callbacks())
+    expect(noGpus.isClickable).toBe(false)
+  })
+
+  it('pods: shows totalPods and navigates to workloads', () => {
+    const result = getClusterDashboardStatValue('pods', makeStats(), true, 10, callbacks())
+    expect(result.value).toBe(120)
+    result.onClick?.()
+    expect(mockEmit).toHaveBeenCalledWith('pods')
+    expect(navigate).toHaveBeenCalledWith(ROUTES.WORKLOADS)
+  })
+
+  it('pods: shows dash when hasData is false', () => {
+    const result = getClusterDashboardStatValue('pods', makeStats(), false, 10, callbacks())
+    expect(result.value).toBe('-')
+  })
+
+  it('returns a dash placeholder for an unrecognized blockId', () => {
+    const result = getClusterDashboardStatValue('unknown-block', makeStats(), true, 10, callbacks())
+    expect(result).toEqual({ value: '-', sublabel: '' })
+  })
+})

--- a/web/src/components/clusters/clusterStatValues.ts
+++ b/web/src/components/clusters/clusterStatValues.ts
@@ -1,0 +1,110 @@
+import type { NavigateFunction } from 'react-router-dom'
+import { emitClusterStatsDrillDown } from '../../lib/analytics'
+import { ROUTES } from '../../config/routes'
+import { formatMemoryStat } from '../../lib/formatStats'
+import type { StatBlockValue } from '../ui/StatsOverview'
+import type { ClusterHealthFilter } from './useClusterViewState'
+import type { useClusterStats } from './useClusterStats'
+
+export interface ClusterStatValueCallbacks {
+  navigate: NavigateFunction
+  setFilter: (filter: ClusterHealthFilter) => void
+  setShowClusterGrid: (show: boolean) => void
+  openGPUModal: () => void
+}
+
+/**
+ * Pure mapping from a StatsOverview block id to its display value/click
+ * handler for the Clusters page. Extracted from Clusters.tsx (#21617) as a
+ * plain function (not a hook) since it has no hook dependencies of its own,
+ * reducing the component's hook count and line count.
+ */
+export function getClusterDashboardStatValue(
+  blockId: string,
+  stats: ReturnType<typeof useClusterStats>,
+  hasData: boolean,
+  clusterStatusProgressMax: number,
+  { navigate, setFilter, setShowClusterGrid, openGPUModal }: ClusterStatValueCallbacks,
+): StatBlockValue {
+  switch (blockId) {
+    case 'clusters':
+      return {
+        value: stats.total,
+        groundtruthField: 'clusters-total',
+        sublabel: 'total clusters',
+        onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('all'); setShowClusterGrid(true) },
+        isClickable: stats.total > 0 }
+    case 'healthy':
+      return {
+        value: stats.healthy,
+        groundtruthField: 'clusters-healthy',
+        sublabel: 'healthy',
+        max: clusterStatusProgressMax,
+        onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('healthy'); setShowClusterGrid(true) },
+        isClickable: stats.healthy > 0 }
+    case 'unhealthy':
+      return {
+        value: stats.unhealthy,
+        sublabel: 'unhealthy',
+        max: clusterStatusProgressMax,
+        onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('unhealthy'); setShowClusterGrid(true) },
+        isClickable: stats.unhealthy > 0 }
+    case 'unreachable':
+      return {
+        value: stats.unreachable,
+        sublabel: 'offline',
+        max: clusterStatusProgressMax,
+        onClick: () => { emitClusterStatsDrillDown('cluster_health_status'); setFilter('unreachable'); setShowClusterGrid(true) },
+        isClickable: stats.unreachable > 0 }
+    case 'nodes':
+      return {
+        value: hasData ? stats.totalNodes : '-',
+        groundtruthFields: {
+          'nodes-total': hasData ? stats.totalNodes : '-',
+          'nodes-ready': stats.healthyNodes,
+        },
+        progressValue: stats.healthyNodes,
+        max: stats.totalNodes,
+        sublabel: 'total nodes',
+        onClick: () => { emitClusterStatsDrillDown('nodes'); navigate(ROUTES.COMPUTE) },
+        isClickable: hasData }
+    case 'cpus':
+      return {
+        value: hasData ? stats.totalCPUs : '-',
+        sublabel: 'cores allocatable',
+        onClick: () => { emitClusterStatsDrillDown('cpu'); navigate(ROUTES.COMPUTE) },
+        isClickable: hasData }
+    case 'memory':
+      return {
+        value: hasData ? formatMemoryStat(stats.totalMemoryGB) : '-',
+        sublabel: 'allocatable',
+        onClick: () => { emitClusterStatsDrillDown('memory'); navigate(ROUTES.COMPUTE) },
+        isClickable: hasData }
+    case 'storage':
+      return {
+        value: hasData ? formatMemoryStat(stats.totalStorageGB) : '-',
+        sublabel: 'storage',
+        onClick: () => { emitClusterStatsDrillDown('storage'); navigate(ROUTES.STORAGE) },
+        isClickable: hasData }
+    case 'gpus':
+      return {
+        value: hasData ? stats.totalGPUs : '-',
+        sublabel: 'total GPUs',
+        onClick: () => { emitClusterStatsDrillDown('gpu'); openGPUModal() },
+        isClickable: hasData && stats.totalGPUs > 0 }
+    case 'pods':
+      return {
+        value: hasData ? stats.totalPods : '-',
+        groundtruthFields: {
+          'pods-total': hasData ? stats.totalPods : '-',
+          'pods-running': hasData ? stats.totalPods : '-',
+          'pods-pending': 0,
+          'pods-crashloop': 0,
+        },
+        sublabel: 'running pods',
+        onClick: () => { emitClusterStatsDrillDown('pods'); navigate(ROUTES.WORKLOADS) },
+        isClickable: hasData }
+    default:
+      return { value: '-', sublabel: '' }
+  }
+}

--- a/web/src/components/clusters/components/GPUDetailModal.tsx
+++ b/web/src/components/clusters/components/GPUDetailModal.tsx
@@ -1,10 +1,19 @@
 import { useMemo } from 'react'
-import { Zap, Server, Layers, RefreshCw, Cpu, AlertCircle, HardDrive, CircuitBoard, Settings } from 'lucide-react'
+import { Zap, Server, Layers, RefreshCw, Cpu, AlertCircle, CircuitBoard, Settings } from 'lucide-react'
 import { GPUNode, NVIDIAOperatorStatus } from '../../../hooks/useMCP'
 import { BaseModal } from '../../../lib/modals'
 import { useTranslation } from 'react-i18next'
-import { StatusBadge } from '../../ui/StatusBadge'
-import { wrapAbbreviations } from '../../shared/TechnicalAcronym'
+import {
+  computeGpuTypeInfo,
+  computeClusterInfo,
+  computeGpuTotals,
+  computeManufacturerBreakdown,
+  computeGpuSpecs,
+  getUtilizationColor,
+} from './gpuDetailUtils'
+import { GPUSpecsPanel, NvidiaOperatorStatusPanel } from './GPUSpecsPanel'
+import { GPUTypeUtilizationList, GPUClusterUtilizationList } from './GPUUtilizationList'
+import { GPUNodesTable } from './GPUNodesTable'
 
 interface GPUDetailModalProps {
   gpuNodes: GPUNode[]
@@ -15,165 +24,21 @@ interface GPUDetailModalProps {
   operatorStatus?: NVIDIAOperatorStatus[]
 }
 
-interface GPUTypeInfo {
-  type: string
-  manufacturer: string
-  totalGPUs: number
-  allocatedGPUs: number
-  availableGPUs: number
-  nodeCount: number
-  clusters: string[]
-}
-
-interface ClusterGPUInfo {
-  cluster: string
-  totalGPUs: number
-  allocatedGPUs: number
-  availableGPUs: number
-  nodeCount: number
-  gpuTypes: string[]
-}
-
-function extractManufacturer(gpuType: string): string {
-  const lower = gpuType.toLowerCase()
-  if (lower.includes('nvidia')) return 'NVIDIA'
-  if (lower.includes('amd') || lower.includes('radeon')) return 'AMD'
-  if (lower.includes('intel')) return 'Intel'
-  return 'Unknown'
-}
-
-const GPU_UTIL_HIGH = 90 // Utilization % threshold for critical (red) status
-const GPU_UTIL_WARN = 70 // Utilization % threshold for warning (yellow) status
-
-function getUtilizationColor(percentage: number): string {
-  if (percentage >= GPU_UTIL_HIGH) return 'text-red-400'
-  if (percentage >= GPU_UTIL_WARN) return 'text-yellow-400'
-  return 'text-green-400'
-}
-
 interface GPUDetailModalInternalProps extends GPUDetailModalProps {
   isOpen?: boolean
 }
 
 export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRefresh, onClose, operatorStatus }: GPUDetailModalInternalProps) {
-
   const { t } = useTranslation()
-  // Calculate GPU type breakdown
-  const gpuTypeInfo = useMemo(() => {
-    const typeMap = new Map<string, GPUTypeInfo>()
 
-    gpuNodes.forEach(node => {
-      const existing = typeMap.get(node.gpuType)
-      if (existing) {
-        existing.totalGPUs += node.gpuCount
-        existing.allocatedGPUs += node.gpuAllocated
-        existing.availableGPUs += (node.gpuCount - node.gpuAllocated)
-        existing.nodeCount += 1
-        if (!existing.clusters.includes(node.cluster)) {
-          existing.clusters.push(node.cluster)
-        }
-      } else {
-        typeMap.set(node.gpuType, {
-          type: node.gpuType,
-          manufacturer: extractManufacturer(node.gpuType),
-          totalGPUs: node.gpuCount,
-          allocatedGPUs: node.gpuAllocated,
-          availableGPUs: node.gpuCount - node.gpuAllocated,
-          nodeCount: 1,
-          clusters: [node.cluster] })
-      }
-    })
+  const gpuTypeInfo = useMemo(() => computeGpuTypeInfo(gpuNodes), [gpuNodes])
+  const clusterInfo = useMemo(() => computeClusterInfo(gpuNodes), [gpuNodes])
+  const gpuSpecs = useMemo(() => computeGpuSpecs(gpuNodes), [gpuNodes])
+  const totals = computeGpuTotals(gpuNodes)
+  const manufacturerBreakdown = computeManufacturerBreakdown(gpuTypeInfo)
 
-    return Array.from(typeMap.values()).sort((a, b) => b.totalGPUs - a.totalGPUs)
-  }, [gpuNodes])
-
-  // Calculate cluster breakdown
-  const clusterInfo = useMemo(() => {
-    const clusterMap = new Map<string, ClusterGPUInfo>()
-
-    gpuNodes.forEach(node => {
-      const existing = clusterMap.get(node.cluster)
-      if (existing) {
-        existing.totalGPUs += node.gpuCount
-        existing.allocatedGPUs += node.gpuAllocated
-        existing.availableGPUs += (node.gpuCount - node.gpuAllocated)
-        existing.nodeCount += 1
-        if (!existing.gpuTypes.includes(node.gpuType)) {
-          existing.gpuTypes.push(node.gpuType)
-        }
-      } else {
-        clusterMap.set(node.cluster, {
-          cluster: node.cluster,
-          totalGPUs: node.gpuCount,
-          allocatedGPUs: node.gpuAllocated,
-          availableGPUs: node.gpuCount - node.gpuAllocated,
-          nodeCount: 1,
-          gpuTypes: [node.gpuType] })
-      }
-    })
-
-    return Array.from(clusterMap.values()).sort((a, b) => b.totalGPUs - a.totalGPUs)
-  }, [gpuNodes])
-
-  // Calculate totals
-  const totals = (() => {
-    let total = 0
-    let allocated = 0
-    gpuNodes.forEach(node => {
-      total += node.gpuCount
-      allocated += node.gpuAllocated
-    })
-    return {
-      total,
-      allocated,
-      available: total - allocated,
-      utilizationPercent: total > 0 ? Math.round((allocated / total) * 100) : 0 }
-  })()
-
-  // Get manufacturer breakdown
-  const manufacturerBreakdown = (() => {
-    const mfgMap = new Map<string, number>()
-    gpuTypeInfo.forEach(info => {
-      const existing = mfgMap.get(info.manufacturer) || 0
-      mfgMap.set(info.manufacturer, existing + info.totalGPUs)
-    })
-    return Array.from(mfgMap.entries()).sort((a, b) => b[1] - a[1])
-  })()
-
-  // Get GPU specifications from nodes (memory, family, CUDA version)
-  const gpuSpecs = useMemo(() => {
-    const specs = {
-      totalMemoryGB: 0,
-      families: new Set<string>(),
-      cudaDriverVersions: new Set<string>(),
-      cudaRuntimeVersions: new Set<string>(),
-      migCapableCount: 0 }
-
-    gpuNodes.forEach(node => {
-      if (node.gpuMemoryMB) {
-        specs.totalMemoryGB += (node.gpuMemoryMB / 1024) * node.gpuCount
-      }
-      if (node.gpuFamily) {
-        specs.families.add(node.gpuFamily)
-      }
-      if (node.cudaDriverVersion) {
-        specs.cudaDriverVersions.add(node.cudaDriverVersion)
-      }
-      if (node.cudaRuntimeVersion) {
-        specs.cudaRuntimeVersions.add(node.cudaRuntimeVersion)
-      }
-      if (node.migCapable) {
-        specs.migCapableCount += node.gpuCount
-      }
-    })
-
-    return {
-      totalMemoryGB: Math.round(specs.totalMemoryGB),
-      families: Array.from(specs.families),
-      cudaDriverVersions: Array.from(specs.cudaDriverVersions),
-      cudaRuntimeVersions: Array.from(specs.cudaRuntimeVersions),
-      migCapableCount: specs.migCapableCount }
-  }, [gpuNodes])
+  const hasOperatorStatus = operatorStatus && operatorStatus.length > 0 && operatorStatus.some(s => s.gpuOperator || s.networkOperator)
+  const hasSpecs = gpuSpecs.totalMemoryGB > 0 || gpuSpecs.families.length > 0 || gpuSpecs.cudaDriverVersions.length > 0
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} size="lg">
@@ -230,92 +95,24 @@ export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRe
           </div>
 
           {/* GPU Specifications */}
-          {(gpuSpecs.totalMemoryGB > 0 || gpuSpecs.families.length > 0 || gpuSpecs.cudaDriverVersions.length > 0) && (
+          {hasSpecs && (
             <div>
               <h4 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
                 <CircuitBoard className="w-4 h-4" />
                 GPU Specifications
               </h4>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                {gpuSpecs.totalMemoryGB > 0 && (
-                  <div className="glass p-3 rounded-lg">
-                    <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                      <HardDrive className="w-3 h-3" />
-                      {wrapAbbreviations('Total VRAM')}
-                    </div>
-                    <div className="text-lg font-bold text-foreground">{gpuSpecs.totalMemoryGB} GB</div>
-                  </div>
-                )}
-                {gpuSpecs.families.length > 0 && (
-                  <div className="glass p-3 rounded-lg">
-                    <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                      <Cpu className="w-3 h-3" />
-                      Architecture
-                    </div>
-                    <div className="text-sm font-medium text-foreground capitalize">
-                      {(gpuSpecs.families || []).join(', ')}
-                    </div>
-                  </div>
-                )}
-                {gpuSpecs.cudaDriverVersions.length > 0 && (
-                  <div className="glass p-3 rounded-lg">
-                    <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                      <Settings className="w-3 h-3" />
-                      {wrapAbbreviations('CUDA Driver')}
-                    </div>
-                    <div className="text-sm font-medium text-foreground">
-                      {(gpuSpecs.cudaDriverVersions || []).join(', ')}
-                    </div>
-                  </div>
-                )}
-                {gpuSpecs.migCapableCount > 0 && (
-                  <div className="glass p-3 rounded-lg">
-                    <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
-                      <Layers className="w-3 h-3" />
-                      {wrapAbbreviations('MIG Capable')}
-                    </div>
-                    <div className="text-lg font-bold text-purple-400">{gpuSpecs.migCapableCount}</div>
-                  </div>
-                )}
-              </div>
+              <GPUSpecsPanel gpuSpecs={gpuSpecs} />
             </div>
           )}
 
           {/* NVIDIA Operator Status */}
-          {operatorStatus && operatorStatus.length > 0 && operatorStatus.some(s => s.gpuOperator || s.networkOperator) && (
+          {hasOperatorStatus && (
             <div>
               <h4 className="text-sm font-medium text-muted-foreground mb-3 flex items-center gap-2">
                 <Settings className="w-4 h-4" />
                 NVIDIA Operators
               </h4>
-              <div className="space-y-2">
-                {operatorStatus.map(status => (
-                  <div key={status.cluster} className="glass p-3 rounded-lg">
-                    <div className="text-sm font-medium text-foreground mb-2">{status.cluster}</div>
-                    <div className="flex flex-wrap gap-2">
-                      {status.gpuOperator && (
-                        <span className={`px-2 py-1 rounded text-xs ${
-                          status.gpuOperator.ready
-                            ? 'bg-green-500/20 text-green-400'
-                            : 'bg-yellow-500/20 text-yellow-400'
-                        }`}>
-                          GPU Operator: {status.gpuOperator.state || (status.gpuOperator.ready ? 'Ready' : 'Not Ready')}
-                          {status.gpuOperator.driverVersion && ` (${status.gpuOperator.driverVersion})`}
-                        </span>
-                      )}
-                      {status.networkOperator && (
-                        <span className={`px-2 py-1 rounded text-xs ${
-                          status.networkOperator.ready
-                            ? 'bg-green-500/20 text-green-400'
-                            : 'bg-yellow-500/20 text-yellow-400'
-                        }`}>
-                          Network Operator: {status.networkOperator.state || (status.networkOperator.ready ? 'Ready' : 'Not Ready')}
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <NvidiaOperatorStatusPanel operatorStatus={operatorStatus!} />
             </div>
           )}
 
@@ -351,35 +148,7 @@ export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRe
                 <Zap className="w-4 h-4" />
                 GPU Types
               </h4>
-              <div className="space-y-2">
-                {gpuTypeInfo.map(info => {
-                  const utilPercent = info.totalGPUs > 0 ? Math.round((info.allocatedGPUs / info.totalGPUs) * 100) : 0
-                  return (
-                    <div key={info.type} className="glass p-3 rounded-lg">
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="font-medium text-foreground">{info.type}</span>
-                        <span className={`text-sm ${getUtilizationColor(utilPercent)}`}>
-                          {info.allocatedGPUs}/{info.totalGPUs} ({utilPercent}%)
-                        </span>
-                      </div>
-                      <div className="h-2 bg-secondary rounded-full overflow-hidden">
-                        <div
-                          className={`h-full transition-all ${
-                            utilPercent >= GPU_UTIL_HIGH ? 'bg-red-400' :
-                            utilPercent >= GPU_UTIL_WARN ? 'bg-yellow-400' :
-                            'bg-green-400'
-                          }`}
-                          style={{ width: `${utilPercent}%` }}
-                        />
-                      </div>
-                      <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
-                        <span>{info.nodeCount} node{info.nodeCount !== 1 ? 's' : ''}</span>
-                        <span>{info.clusters.length} cluster{info.clusters.length !== 1 ? 's' : ''}: {info.clusters.join(', ')}</span>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
+              <GPUTypeUtilizationList gpuTypeInfo={gpuTypeInfo} />
             </div>
           )}
 
@@ -390,35 +159,7 @@ export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRe
                 <Layers className="w-4 h-4" />
                 By Cluster
               </h4>
-              <div className="space-y-2">
-                {clusterInfo.map(info => {
-                  const utilPercent = info.totalGPUs > 0 ? Math.round((info.allocatedGPUs / info.totalGPUs) * 100) : 0
-                  return (
-                    <div key={info.cluster} className="glass p-3 rounded-lg">
-                      <div className="flex items-center justify-between mb-2">
-                        <span className="font-medium text-foreground">{info.cluster}</span>
-                        <span className={`text-sm ${getUtilizationColor(utilPercent)}`}>
-                          {info.allocatedGPUs}/{info.totalGPUs} allocated
-                        </span>
-                      </div>
-                      <div className="h-2 bg-secondary rounded-full overflow-hidden">
-                        <div
-                          className={`h-full transition-all ${
-                            utilPercent >= GPU_UTIL_HIGH ? 'bg-red-400' :
-                            utilPercent >= GPU_UTIL_WARN ? 'bg-yellow-400' :
-                            'bg-green-400'
-                          }`}
-                          style={{ width: `${utilPercent}%` }}
-                        />
-                      </div>
-                      <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
-                        <span>{info.nodeCount} GPU node{info.nodeCount !== 1 ? 's' : ''}</span>
-                        <span>{(info.gpuTypes || []).join(', ')}</span>
-                      </div>
-                    </div>
-                  )
-                })}
-              </div>
+              <GPUClusterUtilizationList clusterInfo={clusterInfo} />
             </div>
           )}
 
@@ -429,57 +170,7 @@ export function GPUDetailModal({ isOpen = true, gpuNodes, isLoading, error, onRe
                 <Server className="w-4 h-4" />
                 GPU Nodes ({gpuNodes.length})
               </h4>
-              <div className="overflow-x-auto">
-                <table className="w-full text-sm">
-                  <thead>
-                    <tr className="border-b border-border">
-                      <th className="text-left py-2 px-3 text-muted-foreground font-medium">{t('common.node')}</th>
-                      <th className="text-left py-2 px-3 text-muted-foreground font-medium">{t('common.cluster')}</th>
-                      <th className="text-left py-2 px-3 text-muted-foreground font-medium">GPU Type</th>
-                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.memory')}</th>
-                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.used')}</th>
-                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.available')}</th>
-                      <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.total')}</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {gpuNodes.map(node => {
-                      const available = node.gpuCount - node.gpuAllocated
-                      const utilPercent = node.gpuCount > 0 ? Math.round((node.gpuAllocated / node.gpuCount) * 100) : 0
-                      const memoryGB = node.gpuMemoryMB ? Math.round(node.gpuMemoryMB / 1024) : null
-                      return (
-                        <tr key={`${node.cluster}-${node.name}`} className="border-b border-border/50 hover:bg-secondary/30">
-                          <td className="py-2 px-3 font-mono text-xs text-foreground">
-                            <div className="flex items-center gap-1">
-                              {node.name}
-                              {node.migCapable && (
-                                <StatusBadge color="purple" size="xs">MIG</StatusBadge>
-                              )}
-                            </div>
-                          </td>
-                          <td className="py-2 px-3 text-muted-foreground">{node.cluster}</td>
-                          <td className="py-2 px-3 text-muted-foreground">
-                            <div>
-                              {node.gpuType}
-                              {node.gpuFamily && (
-                                <span className="text-xs text-muted-foreground/70 ml-1 capitalize">({node.gpuFamily})</span>
-                              )}
-                            </div>
-                          </td>
-                          <td className="py-2 px-3 text-center text-muted-foreground">
-                            {memoryGB ? `${memoryGB}GB` : '-'}
-                          </td>
-                          <td className={`py-2 px-3 text-center ${getUtilizationColor(utilPercent)}`}>
-                            {node.gpuAllocated}
-                          </td>
-                          <td className="py-2 px-3 text-center text-green-400">{available}</td>
-                          <td className="py-2 px-3 text-center text-foreground">{node.gpuCount}</td>
-                        </tr>
-                      )
-                    })}
-                  </tbody>
-                </table>
-              </div>
+              <GPUNodesTable gpuNodes={gpuNodes} />
             </div>
           )}
 

--- a/web/src/components/clusters/components/GPUNodesTable.tsx
+++ b/web/src/components/clusters/components/GPUNodesTable.tsx
@@ -1,0 +1,71 @@
+import type { GPUNode } from '../../../hooks/useMCP'
+import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { getUtilizationColor } from './gpuDetailUtils'
+
+const MB_PER_GB = 1024
+
+interface GPUNodesTableProps {
+  gpuNodes: GPUNode[]
+}
+
+/**
+ * Renders the per-node GPU details table. Extracted from
+ * GPUDetailModal.tsx (#21613) to reduce the parent component's line count.
+ */
+export function GPUNodesTable({ gpuNodes }: GPUNodesTableProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b border-border">
+            <th className="text-left py-2 px-3 text-muted-foreground font-medium">{t('common.node')}</th>
+            <th className="text-left py-2 px-3 text-muted-foreground font-medium">{t('common.cluster')}</th>
+            <th className="text-left py-2 px-3 text-muted-foreground font-medium">GPU Type</th>
+            <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.memory')}</th>
+            <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.used')}</th>
+            <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.available')}</th>
+            <th className="text-center py-2 px-3 text-muted-foreground font-medium">{t('common.total')}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {gpuNodes.map(node => {
+            const available = node.gpuCount - node.gpuAllocated
+            const utilPercent = node.gpuCount > 0 ? Math.round((node.gpuAllocated / node.gpuCount) * 100) : 0
+            const memoryGB = node.gpuMemoryMB ? Math.round(node.gpuMemoryMB / MB_PER_GB) : null
+            return (
+              <tr key={`${node.cluster}-${node.name}`} className="border-b border-border/50 hover:bg-secondary/30">
+                <td className="py-2 px-3 font-mono text-xs text-foreground">
+                  <div className="flex items-center gap-1">
+                    {node.name}
+                    {node.migCapable && (
+                      <StatusBadge color="purple" size="xs">MIG</StatusBadge>
+                    )}
+                  </div>
+                </td>
+                <td className="py-2 px-3 text-muted-foreground">{node.cluster}</td>
+                <td className="py-2 px-3 text-muted-foreground">
+                  <div>
+                    {node.gpuType}
+                    {node.gpuFamily && (
+                      <span className="text-xs text-muted-foreground/70 ml-1 capitalize">({node.gpuFamily})</span>
+                    )}
+                  </div>
+                </td>
+                <td className="py-2 px-3 text-center text-muted-foreground">
+                  {memoryGB ? `${memoryGB}GB` : '-'}
+                </td>
+                <td className={`py-2 px-3 text-center ${getUtilizationColor(utilPercent)}`}>
+                  {node.gpuAllocated}
+                </td>
+                <td className="py-2 px-3 text-center text-green-400">{available}</td>
+                <td className="py-2 px-3 text-center text-foreground">{node.gpuCount}</td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/web/src/components/clusters/components/GPUSpecsPanel.tsx
+++ b/web/src/components/clusters/components/GPUSpecsPanel.tsx
@@ -1,0 +1,101 @@
+import { Cpu, HardDrive, Settings, Layers } from 'lucide-react'
+import type { NVIDIAOperatorStatus } from '../../../hooks/useMCP'
+import { wrapAbbreviations } from '../../shared/TechnicalAcronym'
+import type { GPUSpecs } from './gpuDetailUtils'
+
+interface GPUSpecsPanelProps {
+  gpuSpecs: GPUSpecs
+}
+
+/**
+ * Renders the "GPU Specifications" card grid (VRAM, architecture, CUDA
+ * driver version, MIG support). Extracted from GPUDetailModal.tsx
+ * (#21613) to reduce the parent component's line count.
+ */
+export function GPUSpecsPanel({ gpuSpecs }: GPUSpecsPanelProps) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+      {gpuSpecs.totalMemoryGB > 0 && (
+        <div className="glass p-3 rounded-lg">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
+            <HardDrive className="w-3 h-3" />
+            {wrapAbbreviations('Total VRAM')}
+          </div>
+          <div className="text-lg font-bold text-foreground">{gpuSpecs.totalMemoryGB} GB</div>
+        </div>
+      )}
+      {gpuSpecs.families.length > 0 && (
+        <div className="glass p-3 rounded-lg">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
+            <Cpu className="w-3 h-3" />
+            Architecture
+          </div>
+          <div className="text-sm font-medium text-foreground capitalize">
+            {(gpuSpecs.families || []).join(', ')}
+          </div>
+        </div>
+      )}
+      {gpuSpecs.cudaDriverVersions.length > 0 && (
+        <div className="glass p-3 rounded-lg">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
+            <Settings className="w-3 h-3" />
+            {wrapAbbreviations('CUDA Driver')}
+          </div>
+          <div className="text-sm font-medium text-foreground">
+            {(gpuSpecs.cudaDriverVersions || []).join(', ')}
+          </div>
+        </div>
+      )}
+      {gpuSpecs.migCapableCount > 0 && (
+        <div className="glass p-3 rounded-lg">
+          <div className="flex items-center gap-2 text-muted-foreground text-xs mb-1">
+            <Layers className="w-3 h-3" />
+            {wrapAbbreviations('MIG Capable')}
+          </div>
+          <div className="text-lg font-bold text-purple-400">{gpuSpecs.migCapableCount}</div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface NvidiaOperatorStatusPanelProps {
+  operatorStatus: NVIDIAOperatorStatus[]
+}
+
+/**
+ * Renders the "NVIDIA Operators" status section. Extracted from
+ * GPUDetailModal.tsx (#21613) to reduce the parent component's line count.
+ */
+export function NvidiaOperatorStatusPanel({ operatorStatus }: NvidiaOperatorStatusPanelProps) {
+  return (
+    <div className="space-y-2">
+      {operatorStatus.map(status => (
+        <div key={status.cluster} className="glass p-3 rounded-lg">
+          <div className="text-sm font-medium text-foreground mb-2">{status.cluster}</div>
+          <div className="flex flex-wrap gap-2">
+            {status.gpuOperator && (
+              <span className={`px-2 py-1 rounded text-xs ${
+                status.gpuOperator.ready
+                  ? 'bg-green-500/20 text-green-400'
+                  : 'bg-yellow-500/20 text-yellow-400'
+              }`}>
+                GPU Operator: {status.gpuOperator.state || (status.gpuOperator.ready ? 'Ready' : 'Not Ready')}
+                {status.gpuOperator.driverVersion && ` (${status.gpuOperator.driverVersion})`}
+              </span>
+            )}
+            {status.networkOperator && (
+              <span className={`px-2 py-1 rounded text-xs ${
+                status.networkOperator.ready
+                  ? 'bg-green-500/20 text-green-400'
+                  : 'bg-yellow-500/20 text-yellow-400'
+              }`}>
+                Network Operator: {status.networkOperator.state || (status.networkOperator.ready ? 'Ready' : 'Not Ready')}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/clusters/components/GPUUtilizationList.tsx
+++ b/web/src/components/clusters/components/GPUUtilizationList.tsx
@@ -1,0 +1,94 @@
+import { getUtilizationColor, GPU_UTIL_HIGH, GPU_UTIL_WARN } from './gpuDetailUtils'
+
+interface GPUUtilizationBarProps {
+  /** e.g. GPU type name or cluster name */
+  title: string
+  allocatedGPUs: number
+  totalGPUs: number
+  /** Text shown to the right of the utilization percentage, e.g. "(80%)" */
+  suffix?: string
+  footerLeft: string
+  footerRight: string
+}
+
+/**
+ * A single utilization row with a progress bar, shared by the "GPU Types"
+ * and "By Cluster" breakdown sections. Extracted from GPUDetailModal.tsx
+ * (#21613) to remove duplicated markup between the two sections.
+ */
+function GPUUtilizationBar({ title, allocatedGPUs, totalGPUs, suffix, footerLeft, footerRight }: GPUUtilizationBarProps) {
+  const utilPercent = totalGPUs > 0 ? Math.round((allocatedGPUs / totalGPUs) * 100) : 0
+  return (
+    <div className="glass p-3 rounded-lg">
+      <div className="flex items-center justify-between mb-2">
+        <span className="font-medium text-foreground">{title}</span>
+        <span className={`text-sm ${getUtilizationColor(utilPercent)}`}>
+          {allocatedGPUs}/{totalGPUs}{suffix ?? ''}
+        </span>
+      </div>
+      <div className="h-2 bg-secondary rounded-full overflow-hidden">
+        <div
+          className={`h-full transition-all ${
+            utilPercent >= GPU_UTIL_HIGH ? 'bg-red-400' :
+            utilPercent >= GPU_UTIL_WARN ? 'bg-yellow-400' :
+            'bg-green-400'
+          }`}
+          style={{ width: `${utilPercent}%` }}
+        />
+      </div>
+      <div className="flex items-center justify-between mt-2 text-xs text-muted-foreground">
+        <span>{footerLeft}</span>
+        <span>{footerRight}</span>
+      </div>
+    </div>
+  )
+}
+
+interface GPUTypeUtilizationListProps {
+  gpuTypeInfo: Array<{ type: string; allocatedGPUs: number; totalGPUs: number; nodeCount: number; clusters: string[] }>
+}
+
+/** Renders the "GPU Types" utilization breakdown section. */
+export function GPUTypeUtilizationList({ gpuTypeInfo }: GPUTypeUtilizationListProps) {
+  return (
+    <div className="space-y-2">
+      {gpuTypeInfo.map(info => {
+        const utilPercent = info.totalGPUs > 0 ? Math.round((info.allocatedGPUs / info.totalGPUs) * 100) : 0
+        return (
+          <GPUUtilizationBar
+            key={info.type}
+            title={info.type}
+            allocatedGPUs={info.allocatedGPUs}
+            totalGPUs={info.totalGPUs}
+            suffix={` (${utilPercent}%)`}
+            footerLeft={`${info.nodeCount} node${info.nodeCount !== 1 ? 's' : ''}`}
+            footerRight={`${info.clusters.length} cluster${info.clusters.length !== 1 ? 's' : ''}: ${info.clusters.join(', ')}`}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+interface GPUClusterUtilizationListProps {
+  clusterInfo: Array<{ cluster: string; allocatedGPUs: number; totalGPUs: number; nodeCount: number; gpuTypes: string[] }>
+}
+
+/** Renders the "By Cluster" utilization breakdown section. */
+export function GPUClusterUtilizationList({ clusterInfo }: GPUClusterUtilizationListProps) {
+  return (
+    <div className="space-y-2">
+      {clusterInfo.map(info => (
+        <GPUUtilizationBar
+          key={info.cluster}
+          title={info.cluster}
+          allocatedGPUs={info.allocatedGPUs}
+          totalGPUs={info.totalGPUs}
+          suffix=" allocated"
+          footerLeft={`${info.nodeCount} GPU node${info.nodeCount !== 1 ? 's' : ''}`}
+          footerRight={(info.gpuTypes || []).join(', ')}
+        />
+      ))}
+    </div>
+  )
+}

--- a/web/src/components/clusters/components/NamespaceResources.tsx
+++ b/web/src/components/clusters/components/NamespaceResources.tsx
@@ -4,24 +4,31 @@ import { usePods, useDeployments, useServices, useJobs, useHPAs, useConfigMaps, 
 import { useCachedPVCs } from '../../../hooks/useCachedData'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
-import { StatusBadge } from '../../ui/StatusBadge'
 import { RefreshIndicator } from '../../ui/RefreshIndicator'
-import {
-  LB_PROVISIONING_LABEL,
-  LB_STATUS_PROVISIONING,
-} from '../../../lib/constants/network'
 import { TechnicalAcronym } from '../../shared/TechnicalAcronym'
-
-/** Service type string emitted by the backend for LoadBalancer services.
- * Defined as a constant to avoid magic strings. */
-const SERVICE_TYPE_LOAD_BALANCER = 'LoadBalancer'
-
-type ResourceKind = 'Pod' | 'Deployment' | 'Service' | 'Job' | 'HPA' | 'ConfigMap' | 'Secret' | 'ServiceAccount' | 'PVC'
+import { ResourceTypeAccordion } from './ResourceTypeAccordion'
+import { SimpleResourceRow } from './SimpleResourceRow'
+import { buildAllResources, getStatusBgColor, type ResourceKind } from './namespaceResourceUtils'
 
 interface NamespaceResourcesProps {
   clusterName: string
   namespace: string
   onClose?: () => void
+}
+
+/** Resource kind icon mapping for the list view. */
+function getKindIcon(kind: ResourceKind) {
+  switch (kind) {
+    case 'Pod': return <Box className="w-3.5 h-3.5 text-blue-400" />
+    case 'Deployment': return <Layers className="w-3.5 h-3.5 text-purple-400" />
+    case 'Service': return <Network className="w-3.5 h-3.5 text-cyan-400" />
+    case 'Job': return <Briefcase className="w-3.5 h-3.5 text-yellow-400" />
+    case 'HPA': return <Activity className="w-3.5 h-3.5 text-purple-400" />
+    case 'ConfigMap': return <Settings className="w-3.5 h-3.5 text-orange-400" />
+    case 'Secret': return <Lock className="w-3.5 h-3.5 text-purple-400" />
+    case 'ServiceAccount': return <User className="w-3.5 h-3.5 text-cyan-400" />
+    case 'PVC': return <HardDrive className="w-3.5 h-3.5 text-green-400" />
+  }
 }
 
 export function NamespaceResources({ clusterName, namespace, onClose }: NamespaceResourcesProps) {
@@ -103,156 +110,10 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
   })()
 
   // Build flat list of all resources for list view
-  const allResources = useMemo(() => {
-    const resources: Array<{
-      kind: ResourceKind
-      name: string
-      namespace?: string
-      status?: string
-      statusColor: string
-      detail?: string
-      data?: Record<string, unknown>
-    }> = []
-
-    deployments.forEach(dep => resources.push({
-      kind: 'Deployment',
-      name: dep.name,
-      namespace: dep.namespace,
-      status: dep.status,
-      statusColor: dep.status === 'running' ? 'green' : dep.status === 'deploying' ? 'blue' : 'red',
-      detail: `${dep.readyReplicas}/${dep.replicas}`,
-      data: { replicas: dep.replicas, readyReplicas: dep.readyReplicas, image: dep.image, status: dep.status, age: dep.age }
-    }))
-
-    pods.forEach(pod => resources.push({
-      kind: 'Pod',
-      name: pod.name,
-      namespace: pod.namespace,
-      status: pod.status,
-      statusColor: pod.status === 'Running' ? 'green' : pod.status === 'Pending' ? 'yellow' : 'red',
-      detail: pod.ready,
-      data: { status: pod.status, ready: pod.ready, restarts: pod.restarts, node: pod.node, age: pod.age }
-    }))
-
-    services.forEach(svc => {
-      // Issue #6153: for LoadBalancer services with no ingress IP/
-      // hostname assigned yet, display 'Provisioning' instead of an
-      // empty string. We treat either the explicit lbStatus flag from
-      // the backend OR a LoadBalancer type with a missing externalIP
-      // (for older backends that do not set lbStatus) as provisioning.
-      const isPendingLB =
-        svc.type === SERVICE_TYPE_LOAD_BALANCER &&
-        (svc.lbStatus === LB_STATUS_PROVISIONING || !svc.externalIP)
-      const externalIPDisplay = isPendingLB
-        ? LB_PROVISIONING_LABEL
-        : svc.externalIP
-      resources.push({
-        kind: 'Service',
-        name: svc.name,
-        namespace: svc.namespace,
-        status: svc.type,
-        statusColor: 'cyan',
-        detail: (svc.ports ?? []).slice(0, 2).join(', '),
-        data: {
-          type: svc.type,
-          clusterIP: svc.clusterIP,
-          externalIP: externalIPDisplay,
-          endpoints: svc.endpoints,
-          lbStatus: svc.lbStatus,
-          ports: svc.ports,
-          age: svc.age,
-        },
-      })
-    })
-
-    jobs.forEach(job => resources.push({
-      kind: 'Job',
-      name: job.name,
-      namespace: job.namespace,
-      status: job.status,
-      statusColor: job.status === 'Complete' ? 'green' : job.status === 'Running' ? 'green' : 'red',
-      detail: job.completions,
-      data: { status: job.status, completions: job.completions, duration: job.duration, age: job.age }
-    }))
-
-    hpas.forEach(hpa => resources.push({
-      kind: 'HPA',
-      name: hpa.name,
-      namespace: hpa.namespace,
-      status: `${hpa.currentReplicas}/${hpa.minReplicas}-${hpa.maxReplicas}`,
-      statusColor: 'purple',
-      detail: hpa.reference,
-      data: { reference: hpa.reference, minReplicas: hpa.minReplicas, maxReplicas: hpa.maxReplicas, currentReplicas: hpa.currentReplicas, targetCPU: hpa.targetCPU, currentCPU: hpa.currentCPU, age: hpa.age }
-    }))
-
-    configmaps.forEach(cm => resources.push({
-      kind: 'ConfigMap',
-      name: cm.name,
-      namespace: cm.namespace,
-      status: `${cm.dataCount} keys`,
-      statusColor: 'orange',
-      data: { dataCount: cm.dataCount, age: cm.age }
-    }))
-
-    secrets.forEach(secret => resources.push({
-      kind: 'Secret',
-      name: secret.name,
-      namespace: secret.namespace,
-      status: secret.type,
-      statusColor: 'purple',
-      detail: `${secret.dataCount} keys`,
-      data: { type: secret.type, dataCount: secret.dataCount, age: secret.age }
-    }))
-
-    serviceAccounts.forEach(sa => resources.push({
-      kind: 'ServiceAccount',
-      name: sa.name,
-      namespace: sa.namespace,
-      status: `${sa.secrets?.length || 0} secrets`,
-      statusColor: 'cyan',
-      data: { secrets: sa.secrets, imagePullSecrets: sa.imagePullSecrets, age: sa.age }
-    }))
-
-    pvcs.forEach(pvc => resources.push({
-      kind: 'PVC',
-      name: pvc.name,
-      namespace: pvc.namespace,
-      status: pvc.status,
-      statusColor: pvc.status === 'Bound' ? 'green' : pvc.status === 'Pending' ? 'yellow' : 'red',
-      detail: pvc.capacity,
-      data: { status: pvc.status, storageClass: pvc.storageClass, capacity: pvc.capacity, accessModes: pvc.accessModes, volumeName: pvc.volumeName, age: pvc.age }
-    }))
-
-    return resources
-  }, [deployments, pods, services, jobs, hpas, configmaps, secrets, serviceAccounts, pvcs])
-
-  // Resource kind icon mapping
-  const getKindIcon = (kind: ResourceKind) => {
-    switch (kind) {
-      case 'Pod': return <Box className="w-3.5 h-3.5 text-blue-400" />
-      case 'Deployment': return <Layers className="w-3.5 h-3.5 text-purple-400" />
-      case 'Service': return <Network className="w-3.5 h-3.5 text-cyan-400" />
-      case 'Job': return <Briefcase className="w-3.5 h-3.5 text-yellow-400" />
-      case 'HPA': return <Activity className="w-3.5 h-3.5 text-purple-400" />
-      case 'ConfigMap': return <Settings className="w-3.5 h-3.5 text-orange-400" />
-      case 'Secret': return <Lock className="w-3.5 h-3.5 text-purple-400" />
-      case 'ServiceAccount': return <User className="w-3.5 h-3.5 text-cyan-400" />
-      case 'PVC': return <HardDrive className="w-3.5 h-3.5 text-green-400" />
-    }
-  }
-
-  const getStatusBgColor = (color: string) => {
-    switch (color) {
-      case 'green': return 'bg-green-500/20 text-green-400'
-      case 'blue': return 'bg-blue-500/20 text-blue-400'
-      case 'yellow': return 'bg-yellow-500/20 text-yellow-400'
-      case 'red': return 'bg-red-500/20 text-red-400'
-      case 'cyan': return 'bg-cyan-500/20 text-cyan-400'
-      case 'purple': return 'bg-purple-500/20 text-purple-400'
-      case 'orange': return 'bg-orange-500/20 text-orange-400'
-      default: return 'bg-gray-500/20 text-muted-foreground dark:bg-gray-400/20'
-    }
-  }
+  const allResources = useMemo(
+    () => buildAllResources({ deployments, pods, services, jobs, hpas, configmaps, secrets, serviceAccounts, pvcs }),
+    [deployments, pods, services, jobs, hpas, configmaps, secrets, serviceAccounts, pvcs],
+  )
 
   const handleResourceClick = (kind: ResourceKind, name: string, ns: string, data?: Record<string, unknown>) => {
     switch (kind) {
@@ -377,274 +238,246 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
         <div className="font-mono text-xs max-h-[300px] overflow-y-auto">
           <div className="border-l border-border/50 pl-2">
             {deployments.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('deployments')} disabled={deploymentsLoading} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11 disabled:opacity-50 disabled:cursor-not-allowed">
-                  {expandedTypes.has('deployments') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="purple" icon={<Layers className="w-3 h-3" />}>Deploy</StatusBadge>
-                  <span className="text-muted-foreground">({deployments.length})</span>
-                </button>
-                {expandedTypes.has('deployments') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {deployments.map((dep) => {
-                      const depPods = podsByDeployment.byDeployment[dep.name] || []
-                      const isExpanded = expandedItems.has(`dep-${dep.name}`)
-                      return (
-                        <div key={dep.name} className="mb-0.5">
-                          <div className="flex items-center gap-2 min-h-11 px-1 rounded hover:bg-card/30">
-                            <button onClick={() => depPods.length > 0 && toggleItem(`dep-${dep.name}`)} className="min-h-11 min-w-[44px] flex items-center justify-center">
-                              {depPods.length > 0 ? (isExpanded ? <ChevronDown className="w-3 h-3 text-muted-foreground" /> : <ChevronRight className="w-3 h-3 text-muted-foreground" />) : <span className="w-3" />}
-                            </button>
-                            <button
-                              onClick={() => handleResourceClick('Deployment', dep.name, dep.namespace, { replicas: dep.replicas, readyReplicas: dep.readyReplicas, status: dep.status })}
-                              className="flex items-center gap-2 flex-1 min-h-11"
-                            >
-                              <span className="text-foreground">{dep.name}</span>
-                              <span className={`text-xs ${dep.readyReplicas === dep.replicas ? 'text-green-400' : 'text-orange-400'}`}>{dep.readyReplicas}/{dep.replicas}</span>
-                              {depPods.length > 0 && <span className="text-xs text-muted-foreground">({depPods.length} pods)</span>}
-                              <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                            </button>
-                          </div>
-                          {isExpanded && depPods.length > 0 && (
-                            <div className="ml-4 border-l border-border/30 pl-2">
-                              {depPods.slice(0, 10).map(pod => (
-                                <div
-                                  key={pod.name}
-                                  className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                                  onClick={() => handleResourceClick('Pod', pod.name, pod.namespace, { status: pod.status, restarts: pod.restarts })}
-                                >
-                                  <Box className="w-3 h-3 text-blue-400" />
-                                  <span className="text-foreground truncate max-w-[200px]" title={pod.name}>{pod.name}</span>
-                                  <span className={pod.status === 'Running' ? 'text-green-400' : pod.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}>{pod.status}</span>
-                                  <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                                </div>
-                              ))}
-                              {depPods.length > 10 && <div className="text-xs text-muted-foreground pl-5">+{depPods.length - 10} more</div>}
-                            </div>
-                          )}
+              <ResourceTypeAccordion
+                typeKey="deployments"
+                isExpanded={expandedTypes.has('deployments')}
+                onToggle={toggleType}
+                disabled={deploymentsLoading}
+                badgeColor="purple"
+                badgeIcon={<Layers className="w-3 h-3" />}
+                label="Deploy"
+                countLabel={`(${deployments.length})`}
+              >
+                {deployments.map((dep) => {
+                  const depPods = podsByDeployment.byDeployment[dep.name] || []
+                  const isExpanded = expandedItems.has(`dep-${dep.name}`)
+                  return (
+                    <div key={dep.name} className="mb-0.5">
+                      <div className="flex items-center gap-2 min-h-11 px-1 rounded hover:bg-card/30">
+                        <button onClick={() => depPods.length > 0 && toggleItem(`dep-${dep.name}`)} className="min-h-11 min-w-[44px] flex items-center justify-center">
+                          {depPods.length > 0 ? (isExpanded ? <ChevronDown className="w-3 h-3 text-muted-foreground" /> : <ChevronRight className="w-3 h-3 text-muted-foreground" />) : <span className="w-3" />}
+                        </button>
+                        <button
+                          onClick={() => handleResourceClick('Deployment', dep.name, dep.namespace, { replicas: dep.replicas, readyReplicas: dep.readyReplicas, status: dep.status })}
+                          className="flex items-center gap-2 flex-1 min-h-11"
+                        >
+                          <span className="text-foreground">{dep.name}</span>
+                          <span className={`text-xs ${dep.readyReplicas === dep.replicas ? 'text-green-400' : 'text-orange-400'}`}>{dep.readyReplicas}/{dep.replicas}</span>
+                          {depPods.length > 0 && <span className="text-xs text-muted-foreground">({depPods.length} pods)</span>}
+                          <ChevronRight className="w-3 h-3 text-primary ml-auto" />
+                        </button>
+                      </div>
+                      {isExpanded && depPods.length > 0 && (
+                        <div className="ml-4 border-l border-border/30 pl-2">
+                          {depPods.slice(0, 10).map(pod => (
+                            <SimpleResourceRow
+                              key={pod.name}
+                              icon={<Box className="w-3 h-3 text-blue-400" />}
+                              name={pod.name}
+                              primaryText={pod.status}
+                              primaryClassName={pod.status === 'Running' ? 'text-green-400' : pod.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}
+                              onClick={() => handleResourceClick('Pod', pod.name, pod.namespace, { status: pod.status, restarts: pod.restarts })}
+                            />
+                          ))}
+                          {depPods.length > 10 && <div className="text-xs text-muted-foreground pl-5">+{depPods.length - 10} more</div>}
                         </div>
-                      )
-                    })}
-                  </div>
-                )}
-              </div>
+                      )}
+                    </div>
+                  )
+                })}
+              </ResourceTypeAccordion>
             )}
 
             {podsByDeployment.standalone.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('pods')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('pods') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="blue" icon={<Box className="w-3 h-3" />}>{t('common.pod')}</StatusBadge>
-                  <span className="text-muted-foreground">Standalone ({podsByDeployment.standalone.length})</span>
-                </button>
-                {expandedTypes.has('pods') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {podsByDeployment.standalone.slice(0, 20).map(pod => (
-                      <div
-                        key={pod.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('Pod', pod.name, pod.namespace, { status: pod.status, restarts: pod.restarts })}
-                      >
-                        <Box className="w-3 h-3 text-blue-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={pod.name}>{pod.name}</span>
-                        <span className={pod.status === 'Running' ? 'text-green-400' : pod.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}>{pod.status}</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                    {podsByDeployment.standalone.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{podsByDeployment.standalone.length - 20} more</div>}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="pods"
+                isExpanded={expandedTypes.has('pods')}
+                onToggle={toggleType}
+                badgeColor="blue"
+                badgeIcon={<Box className="w-3 h-3" />}
+                label={t('common.pod')}
+                countLabel={`Standalone (${podsByDeployment.standalone.length})`}
+              >
+                {podsByDeployment.standalone.slice(0, 20).map(pod => (
+                  <SimpleResourceRow
+                    key={pod.name}
+                    icon={<Box className="w-3 h-3 text-blue-400" />}
+                    name={pod.name}
+                    primaryText={pod.status}
+                    primaryClassName={pod.status === 'Running' ? 'text-green-400' : pod.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}
+                    onClick={() => handleResourceClick('Pod', pod.name, pod.namespace, { status: pod.status, restarts: pod.restarts })}
+                  />
+                ))}
+                {podsByDeployment.standalone.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{podsByDeployment.standalone.length - 20} more</div>}
+              </ResourceTypeAccordion>
             )}
 
             {services.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('services')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('services') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="cyan" icon={<Network className="w-3 h-3" />}>Svc</StatusBadge>
-                  <span className="text-muted-foreground">({services.length})</span>
-                </button>
-                {expandedTypes.has('services') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {services.map(svc => (
-                      <div
-                        key={svc.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('Service', svc.name, svc.namespace, { type: svc.type, clusterIP: svc.clusterIP, ports: svc.ports })}
-                      >
-                        <Network className="w-3 h-3 text-cyan-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={svc.name}>{svc.name}</span>
-                        <span className="text-cyan-400">{svc.type}</span>
-                        {svc.ports && svc.ports.length > 0 && <span className="text-muted-foreground">{svc.ports[0]}</span>}
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="services"
+                isExpanded={expandedTypes.has('services')}
+                onToggle={toggleType}
+                badgeColor="cyan"
+                badgeIcon={<Network className="w-3 h-3" />}
+                label="Svc"
+                countLabel={`(${services.length})`}
+              >
+                {services.map(svc => (
+                  <SimpleResourceRow
+                    key={svc.name}
+                    icon={<Network className="w-3 h-3 text-cyan-400" />}
+                    name={svc.name}
+                    primaryText={svc.type}
+                    primaryClassName="text-cyan-400"
+                    secondaryText={svc.ports && svc.ports.length > 0 ? svc.ports[0] : undefined}
+                    onClick={() => handleResourceClick('Service', svc.name, svc.namespace, { type: svc.type, clusterIP: svc.clusterIP, ports: svc.ports })}
+                  />
+                ))}
+              </ResourceTypeAccordion>
             )}
 
             {jobs.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('jobs')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('jobs') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="yellow" icon={<Briefcase className="w-3 h-3" />}>Job</StatusBadge>
-                  <span className="text-muted-foreground">({jobs.length})</span>
-                </button>
-                {expandedTypes.has('jobs') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {jobs.map(job => (
-                      <div
-                        key={job.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('Job', job.name, job.namespace, { status: job.status, completions: job.completions })}
-                      >
-                        <Briefcase className="w-3 h-3 text-yellow-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={job.name}>{job.name}</span>
-                        <span className={job.status === 'Complete' ? 'text-green-400' : job.status === 'Running' ? 'text-green-400' : 'text-red-400'}>{job.status}</span>
-                        <span className="text-muted-foreground">{job.completions}</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="jobs"
+                isExpanded={expandedTypes.has('jobs')}
+                onToggle={toggleType}
+                badgeColor="yellow"
+                badgeIcon={<Briefcase className="w-3 h-3" />}
+                label="Job"
+                countLabel={`(${jobs.length})`}
+              >
+                {jobs.map(job => (
+                  <SimpleResourceRow
+                    key={job.name}
+                    icon={<Briefcase className="w-3 h-3 text-yellow-400" />}
+                    name={job.name}
+                    primaryText={job.status}
+                    primaryClassName={job.status === 'Complete' ? 'text-green-400' : job.status === 'Running' ? 'text-green-400' : 'text-red-400'}
+                    secondaryText={job.completions}
+                    onClick={() => handleResourceClick('Job', job.name, job.namespace, { status: job.status, completions: job.completions })}
+                  />
+                ))}
+              </ResourceTypeAccordion>
             )}
 
             {hpas.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('hpas')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('hpas') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="purple" icon={<Activity className="w-3 h-3" />}><TechnicalAcronym term="HPA">HPA</TechnicalAcronym></StatusBadge>
-                  <span className="text-muted-foreground">({hpas.length})</span>
-                </button>
-                {expandedTypes.has('hpas') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {hpas.map(hpa => (
-                      <div
-                        key={hpa.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('HPA', hpa.name, hpa.namespace, { reference: hpa.reference, minReplicas: hpa.minReplicas, maxReplicas: hpa.maxReplicas })}
-                      >
-                        <Activity className="w-3 h-3 text-purple-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={hpa.name}>{hpa.name}</span>
-                        <span className="text-purple-400">{hpa.currentReplicas}/{hpa.minReplicas}-{hpa.maxReplicas}</span>
-                        <span className="text-muted-foreground">→ {hpa.reference}</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="hpas"
+                isExpanded={expandedTypes.has('hpas')}
+                onToggle={toggleType}
+                badgeColor="purple"
+                badgeIcon={<Activity className="w-3 h-3" />}
+                label={<TechnicalAcronym term="HPA">HPA</TechnicalAcronym>}
+                countLabel={`(${hpas.length})`}
+              >
+                {hpas.map(hpa => (
+                  <SimpleResourceRow
+                    key={hpa.name}
+                    icon={<Activity className="w-3 h-3 text-purple-400" />}
+                    name={hpa.name}
+                    primaryText={`${hpa.currentReplicas}/${hpa.minReplicas}-${hpa.maxReplicas}`}
+                    primaryClassName="text-purple-400"
+                    secondaryText={`→ ${hpa.reference}`}
+                    onClick={() => handleResourceClick('HPA', hpa.name, hpa.namespace, { reference: hpa.reference, minReplicas: hpa.minReplicas, maxReplicas: hpa.maxReplicas })}
+                  />
+                ))}
+              </ResourceTypeAccordion>
             )}
 
             {serviceAccounts.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('serviceaccounts')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('serviceaccounts') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="cyan" icon={<User className="w-3 h-3" />}>SA</StatusBadge>
-                  <span className="text-muted-foreground">({serviceAccounts.length})</span>
-                </button>
-                {expandedTypes.has('serviceaccounts') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {serviceAccounts.slice(0, 20).map(sa => (
-                      <div
-                        key={sa.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('ServiceAccount', sa.name, sa.namespace, { secrets: sa.secrets, imagePullSecrets: sa.imagePullSecrets })}
-                      >
-                        <User className="w-3 h-3 text-cyan-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={sa.name}>{sa.name}</span>
-                        <span className="text-muted-foreground">{sa.secrets?.length || 0} secrets</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                    {serviceAccounts.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{serviceAccounts.length - 20} more</div>}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="serviceaccounts"
+                isExpanded={expandedTypes.has('serviceaccounts')}
+                onToggle={toggleType}
+                badgeColor="cyan"
+                badgeIcon={<User className="w-3 h-3" />}
+                label="SA"
+                countLabel={`(${serviceAccounts.length})`}
+              >
+                {serviceAccounts.slice(0, 20).map(sa => (
+                  <SimpleResourceRow
+                    key={sa.name}
+                    icon={<User className="w-3 h-3 text-cyan-400" />}
+                    name={sa.name}
+                    secondaryText={`${sa.secrets?.length || 0} secrets`}
+                    onClick={() => handleResourceClick('ServiceAccount', sa.name, sa.namespace, { secrets: sa.secrets, imagePullSecrets: sa.imagePullSecrets })}
+                  />
+                ))}
+                {serviceAccounts.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{serviceAccounts.length - 20} more</div>}
+              </ResourceTypeAccordion>
             )}
 
             {pvcs.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('pvcs')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('pvcs') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="green" icon={<HardDrive className="w-3 h-3" />}><TechnicalAcronym term="PVC">PVC</TechnicalAcronym></StatusBadge>
-                  <span className="text-muted-foreground">({pvcs.length})</span>
-                </button>
-                {expandedTypes.has('pvcs') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {pvcs.slice(0, 20).map(pvc => (
-                      <div
-                        key={pvc.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('PVC', pvc.name, pvc.namespace, { status: pvc.status, storageClass: pvc.storageClass, capacity: pvc.capacity })}
-                      >
-                        <HardDrive className="w-3 h-3 text-green-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={pvc.name}>{pvc.name}</span>
-                        <span className={pvc.status === 'Bound' ? 'text-green-400' : pvc.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}>{pvc.status}</span>
-                        {pvc.capacity && <span className="text-muted-foreground">{pvc.capacity}</span>}
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                    {pvcs.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{pvcs.length - 20} more</div>}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="pvcs"
+                isExpanded={expandedTypes.has('pvcs')}
+                onToggle={toggleType}
+                badgeColor="green"
+                badgeIcon={<HardDrive className="w-3 h-3" />}
+                label={<TechnicalAcronym term="PVC">PVC</TechnicalAcronym>}
+                countLabel={`(${pvcs.length})`}
+              >
+                {pvcs.slice(0, 20).map(pvc => (
+                  <SimpleResourceRow
+                    key={pvc.name}
+                    icon={<HardDrive className="w-3 h-3 text-green-400" />}
+                    name={pvc.name}
+                    primaryText={pvc.status}
+                    primaryClassName={pvc.status === 'Bound' ? 'text-green-400' : pvc.status === 'Pending' ? 'text-yellow-400' : 'text-red-400'}
+                    secondaryText={pvc.capacity}
+                    onClick={() => handleResourceClick('PVC', pvc.name, pvc.namespace, { status: pvc.status, storageClass: pvc.storageClass, capacity: pvc.capacity })}
+                  />
+                ))}
+                {pvcs.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{pvcs.length - 20} more</div>}
+              </ResourceTypeAccordion>
             )}
 
             {configmaps.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('configmaps')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('configmaps') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="orange" icon={<Settings className="w-3 h-3" />}>CM</StatusBadge>
-                  <span className="text-muted-foreground">({configmaps.length})</span>
-                </button>
-                {expandedTypes.has('configmaps') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {configmaps.slice(0, 20).map(cm => (
-                      <div
-                        key={cm.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('ConfigMap', cm.name, cm.namespace, { dataCount: cm.dataCount })}
-                      >
-                        <Settings className="w-3 h-3 text-orange-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={cm.name}>{cm.name}</span>
-                        <span className="text-muted-foreground">{cm.dataCount} keys</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                    {configmaps.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{configmaps.length - 20} more</div>}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="configmaps"
+                isExpanded={expandedTypes.has('configmaps')}
+                onToggle={toggleType}
+                badgeColor="orange"
+                badgeIcon={<Settings className="w-3 h-3" />}
+                label="CM"
+                countLabel={`(${configmaps.length})`}
+              >
+                {configmaps.slice(0, 20).map(cm => (
+                  <SimpleResourceRow
+                    key={cm.name}
+                    icon={<Settings className="w-3 h-3 text-orange-400" />}
+                    name={cm.name}
+                    secondaryText={`${cm.dataCount} keys`}
+                    onClick={() => handleResourceClick('ConfigMap', cm.name, cm.namespace, { dataCount: cm.dataCount })}
+                  />
+                ))}
+                {configmaps.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{configmaps.length - 20} more</div>}
+              </ResourceTypeAccordion>
             )}
 
             {secrets.length > 0 && (
-              <div className="mb-1">
-                <button onClick={() => toggleType('secrets')} className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11">
-                  {expandedTypes.has('secrets') ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
-                  <StatusBadge color="purple" icon={<Lock className="w-3 h-3" />}>Secret</StatusBadge>
-                  <span className="text-muted-foreground">({secrets.length})</span>
-                </button>
-                {expandedTypes.has('secrets') && (
-                  <div className="ml-4 border-l border-border/30 pl-2">
-                    {secrets.slice(0, 20).map(secret => (
-                      <div
-                        key={secret.name}
-                        className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
-                        onClick={() => handleResourceClick('Secret', secret.name, secret.namespace, { type: secret.type, dataCount: secret.dataCount })}
-                      >
-                        <Lock className="w-3 h-3 text-purple-400" />
-                        <span className="text-foreground truncate max-w-[200px]" title={secret.name}>{secret.name}</span>
-                        <span className="text-purple-400">{secret.type}</span>
-                        <span className="text-muted-foreground">{secret.dataCount} keys</span>
-                        <ChevronRight className="w-3 h-3 text-primary ml-auto" />
-                      </div>
-                    ))}
-                    {secrets.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{secrets.length - 20} more</div>}
-                  </div>
-                )}
-              </div>
+              <ResourceTypeAccordion
+                typeKey="secrets"
+                isExpanded={expandedTypes.has('secrets')}
+                onToggle={toggleType}
+                badgeColor="purple"
+                badgeIcon={<Lock className="w-3 h-3" />}
+                label="Secret"
+                countLabel={`(${secrets.length})`}
+              >
+                {secrets.slice(0, 20).map(secret => (
+                  <SimpleResourceRow
+                    key={secret.name}
+                    icon={<Lock className="w-3 h-3 text-purple-400" />}
+                    name={secret.name}
+                    primaryText={secret.type}
+                    primaryClassName="text-purple-400"
+                    secondaryText={`${secret.dataCount} keys`}
+                    onClick={() => handleResourceClick('Secret', secret.name, secret.namespace, { type: secret.type, dataCount: secret.dataCount })}
+                  />
+                ))}
+                {secrets.length > 20 && <div className="text-xs text-muted-foreground pl-5">+{secrets.length - 20} more</div>}
+              </ResourceTypeAccordion>
             )}
           </div>
         </div>
@@ -658,3 +491,4 @@ export function NamespaceResources({ clusterName, namespace, onClose }: Namespac
     </div>
   )
 }
+

--- a/web/src/components/clusters/components/ResourceTypeAccordion.tsx
+++ b/web/src/components/clusters/components/ResourceTypeAccordion.tsx
@@ -1,0 +1,55 @@
+import type { ReactNode } from 'react'
+import { ChevronRight, ChevronDown } from 'lucide-react'
+import { StatusBadge, type BadgeColor } from '../../ui/StatusBadge'
+
+interface ResourceTypeAccordionProps {
+  /** e.g. 'services', 'jobs' — key used to track expand/collapse state */
+  typeKey: string
+  isExpanded: boolean
+  onToggle: (typeKey: string) => void
+  badgeColor: BadgeColor
+  badgeIcon: ReactNode
+  /** Short label shown inside the badge, e.g. "Svc", "Job" */
+  label: ReactNode
+  /** Text shown after the badge, e.g. "(3)" or "Standalone (2)" */
+  countLabel: string
+  disabled?: boolean
+  children: ReactNode
+}
+
+/**
+ * Generic collapsible section for a single resource type (Services, Jobs,
+ * HPAs, ServiceAccounts, PVCs, ConfigMaps, Secrets, …) in the namespace
+ * resources tree view. Extracted from NamespaceResources.tsx (#21617) to
+ * remove eight near-identical accordion blocks.
+ */
+export function ResourceTypeAccordion({
+  typeKey,
+  isExpanded,
+  onToggle,
+  badgeColor,
+  badgeIcon,
+  label,
+  countLabel,
+  disabled,
+  children,
+}: ResourceTypeAccordionProps) {
+  return (
+    <div className="mb-1">
+      <button
+        onClick={() => onToggle(typeKey)}
+        disabled={disabled}
+        className="flex min-w-11 items-center gap-1.5 p-3 hover:bg-card/30 rounded w-full text-left min-h-11 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {isExpanded ? <ChevronDown className="w-3.5 h-3.5 text-muted-foreground" /> : <ChevronRight className="w-3.5 h-3.5 text-muted-foreground" />}
+        <StatusBadge color={badgeColor} icon={badgeIcon}>{label}</StatusBadge>
+        <span className="text-muted-foreground">{countLabel}</span>
+      </button>
+      {isExpanded && (
+        <div className="ml-4 border-l border-border/30 pl-2">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/clusters/components/SimpleResourceRow.tsx
+++ b/web/src/components/clusters/components/SimpleResourceRow.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from 'react'
+import { ChevronRight } from 'lucide-react'
+
+interface SimpleResourceRowProps {
+  icon: ReactNode
+  name: string
+  /** Colored primary status text, e.g. service type or job status */
+  primaryText?: ReactNode
+  primaryClassName?: string
+  /** Additional muted text shown after the primary text */
+  secondaryText?: ReactNode
+  onClick: () => void
+}
+
+/**
+ * A single leaf row in the namespace resources tree view (used for
+ * Services, Jobs, HPAs, ServiceAccounts, PVCs, ConfigMaps, Secrets).
+ * Extracted from NamespaceResources.tsx (#21617) to remove seven
+ * near-identical row blocks.
+ */
+export function SimpleResourceRow({ icon, name, primaryText, primaryClassName, secondaryText, onClick }: SimpleResourceRowProps) {
+  return (
+    <div
+      className="flex items-center gap-2 min-h-11 px-1 text-xs cursor-pointer hover:bg-card/30 rounded"
+      onClick={onClick}
+    >
+      {icon}
+      <span className="text-foreground truncate max-w-[200px]" title={name}>{name}</span>
+      {primaryText !== undefined && <span className={primaryClassName}>{primaryText}</span>}
+      {secondaryText !== undefined && <span className="text-muted-foreground">{secondaryText}</span>}
+      <ChevronRight className="w-3 h-3 text-primary ml-auto" />
+    </div>
+  )
+}

--- a/web/src/components/clusters/components/__tests__/gpuDetailUtils.test.ts
+++ b/web/src/components/clusters/components/__tests__/gpuDetailUtils.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from 'vitest'
+import {
+  extractManufacturer,
+  getUtilizationColor,
+  computeGpuTypeInfo,
+  computeClusterInfo,
+  computeGpuTotals,
+  computeManufacturerBreakdown,
+  computeGpuSpecs,
+  GPU_UTIL_HIGH,
+  GPU_UTIL_WARN,
+} from '../gpuDetailUtils'
+import type { GPUNode } from '../../../../hooks/mcp/types.gpu'
+
+function makeNode(overrides: Partial<GPUNode> = {}): GPUNode {
+  return {
+    name: 'node-1',
+    cluster: 'cluster-a',
+    gpuType: 'NVIDIA A100',
+    gpuCount: 4,
+    gpuAllocated: 2,
+    ...overrides,
+  }
+}
+
+describe('extractManufacturer', () => {
+  it('detects nvidia', () => {
+    expect(extractManufacturer('NVIDIA A100')).toBe('NVIDIA')
+  })
+
+  it('detects amd', () => {
+    expect(extractManufacturer('AMD MI250')).toBe('AMD')
+  })
+
+  it('detects radeon as amd', () => {
+    expect(extractManufacturer('Radeon Pro W7900')).toBe('AMD')
+  })
+
+  it('detects intel', () => {
+    expect(extractManufacturer('Intel Gaudi2')).toBe('Intel')
+  })
+
+  it('returns Unknown for unrecognized types', () => {
+    expect(extractManufacturer('IBM AIU')).toBe('Unknown')
+  })
+
+  it('is case-insensitive', () => {
+    expect(extractManufacturer('nvidia a100')).toBe('NVIDIA')
+    expect(extractManufacturer('AmD Instinct')).toBe('AMD')
+  })
+})
+
+describe('getUtilizationColor', () => {
+  it('returns green below the warn threshold', () => {
+    expect(getUtilizationColor(GPU_UTIL_WARN - 1)).toBe('text-green-400')
+  })
+
+  it('returns yellow at the warn threshold', () => {
+    expect(getUtilizationColor(GPU_UTIL_WARN)).toBe('text-yellow-400')
+  })
+
+  it('returns yellow between warn and high thresholds', () => {
+    expect(getUtilizationColor(GPU_UTIL_HIGH - 1)).toBe('text-yellow-400')
+  })
+
+  it('returns red at the high threshold', () => {
+    expect(getUtilizationColor(GPU_UTIL_HIGH)).toBe('text-red-400')
+  })
+
+  it('returns red above the high threshold', () => {
+    expect(getUtilizationColor(100)).toBe('text-red-400')
+  })
+})
+
+describe('computeGpuTypeInfo', () => {
+  it('returns an empty array for no nodes', () => {
+    expect(computeGpuTypeInfo([])).toEqual([])
+  })
+
+  it('aggregates a single type across multiple nodes', () => {
+    const nodes = [
+      makeNode({ name: 'n1', cluster: 'a', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 2 }),
+      makeNode({ name: 'n2', cluster: 'a', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4 }),
+    ]
+    const result = computeGpuTypeInfo(nodes)
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({
+      type: 'NVIDIA A100',
+      manufacturer: 'NVIDIA',
+      totalGPUs: 12,
+      allocatedGPUs: 6,
+      availableGPUs: 6,
+      nodeCount: 2,
+      clusters: ['a'],
+    })
+  })
+
+  it('sorts multiple types by totalGPUs descending', () => {
+    const nodes = [
+      makeNode({ name: 'n1', gpuType: 'AMD MI250', gpuCount: 2, gpuAllocated: 0 }),
+      makeNode({ name: 'n2', gpuType: 'NVIDIA A100', gpuCount: 10, gpuAllocated: 5 }),
+    ]
+    const result = computeGpuTypeInfo(nodes)
+    expect(result.map(r => r.type)).toEqual(['NVIDIA A100', 'AMD MI250'])
+  })
+
+  it('deduplicates clusters for the same type', () => {
+    const nodes = [
+      makeNode({ name: 'n1', cluster: 'a', gpuType: 'NVIDIA A100' }),
+      makeNode({ name: 'n2', cluster: 'a', gpuType: 'NVIDIA A100' }),
+      makeNode({ name: 'n3', cluster: 'b', gpuType: 'NVIDIA A100' }),
+    ]
+    const result = computeGpuTypeInfo(nodes)
+    expect(result[0].clusters).toEqual(['a', 'b'])
+  })
+})
+
+describe('computeClusterInfo', () => {
+  it('returns an empty array for no nodes', () => {
+    expect(computeClusterInfo([])).toEqual([])
+  })
+
+  it('aggregates per cluster and dedups gpuTypes', () => {
+    const nodes = [
+      makeNode({ name: 'n1', cluster: 'a', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 1 }),
+      makeNode({ name: 'n2', cluster: 'a', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 1 }),
+      makeNode({ name: 'n3', cluster: 'b', gpuType: 'AMD MI250', gpuCount: 2, gpuAllocated: 2 }),
+    ]
+    const result = computeClusterInfo(nodes)
+    expect(result).toHaveLength(2)
+    const clusterA = result.find(c => c.cluster === 'a')
+    expect(clusterA).toMatchObject({ totalGPUs: 8, allocatedGPUs: 2, availableGPUs: 6, nodeCount: 2, gpuTypes: ['NVIDIA A100'] })
+  })
+
+  it('sorts clusters by totalGPUs descending', () => {
+    const nodes = [
+      makeNode({ name: 'n1', cluster: 'small', gpuCount: 1, gpuAllocated: 0 }),
+      makeNode({ name: 'n2', cluster: 'big', gpuCount: 20, gpuAllocated: 0 }),
+    ]
+    const result = computeClusterInfo(nodes)
+    expect(result.map(r => r.cluster)).toEqual(['big', 'small'])
+  })
+})
+
+describe('computeGpuTotals', () => {
+  it('returns zeros with no NaN utilization when there are no GPUs', () => {
+    expect(computeGpuTotals([])).toEqual({ total: 0, allocated: 0, available: 0, utilizationPercent: 0 })
+  })
+
+  it('sums totals and rounds utilization percent', () => {
+    const nodes = [
+      makeNode({ name: 'n1', gpuCount: 3, gpuAllocated: 1 }),
+      makeNode({ name: 'n2', gpuCount: 4, gpuAllocated: 2 }),
+    ]
+    // total = 7, allocated = 3 -> 42.857...% rounds to 43
+    expect(computeGpuTotals(nodes)).toEqual({ total: 7, allocated: 3, available: 4, utilizationPercent: 43 })
+  })
+
+  it('reports 100% utilization when fully allocated', () => {
+    const nodes = [makeNode({ gpuCount: 8, gpuAllocated: 8 })]
+    expect(computeGpuTotals(nodes)).toEqual({ total: 8, allocated: 8, available: 0, utilizationPercent: 100 })
+  })
+})
+
+describe('computeManufacturerBreakdown', () => {
+  it('returns an empty array for no type info', () => {
+    expect(computeManufacturerBreakdown([])).toEqual([])
+  })
+
+  it('aggregates totalGPUs per manufacturer sorted descending', () => {
+    const typeInfo = computeGpuTypeInfo([
+      makeNode({ name: 'n1', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 0 }),
+      makeNode({ name: 'n2', gpuType: 'NVIDIA H100', gpuCount: 8, gpuAllocated: 0 }),
+      makeNode({ name: 'n3', gpuType: 'AMD MI250', gpuCount: 2, gpuAllocated: 0 }),
+    ])
+    expect(computeManufacturerBreakdown(typeInfo)).toEqual([
+      ['NVIDIA', 12],
+      ['AMD', 2],
+    ])
+  })
+})
+
+describe('computeGpuSpecs', () => {
+  it('returns empty/zero defaults for no nodes', () => {
+    expect(computeGpuSpecs([])).toEqual({
+      totalMemoryGB: 0,
+      families: [],
+      cudaDriverVersions: [],
+      cudaRuntimeVersions: [],
+      migCapableCount: 0,
+    })
+  })
+
+  it('sums memory using MB/1024*gpuCount and rounds the total', () => {
+    const nodes = [makeNode({ gpuMemoryMB: 40960, gpuCount: 2 })] // 40GB * 2 = 80GB
+    expect(computeGpuSpecs(nodes).totalMemoryGB).toBe(80)
+  })
+
+  it('dedups families and CUDA versions via a Set', () => {
+    const nodes = [
+      makeNode({ name: 'n1', gpuFamily: 'Ampere', cudaDriverVersion: '535.1', cudaRuntimeVersion: '12.2' }),
+      makeNode({ name: 'n2', gpuFamily: 'Ampere', cudaDriverVersion: '535.1', cudaRuntimeVersion: '12.2' }),
+      makeNode({ name: 'n3', gpuFamily: 'Hopper', cudaDriverVersion: '550.0', cudaRuntimeVersion: '12.4' }),
+    ]
+    const specs = computeGpuSpecs(nodes)
+    expect(specs.families).toEqual(['Ampere', 'Hopper'])
+    expect(specs.cudaDriverVersions).toEqual(['535.1', '550.0'])
+    expect(specs.cudaRuntimeVersions).toEqual(['12.2', '12.4'])
+  })
+
+  it('accumulates migCapableCount by gpuCount for MIG-capable nodes only', () => {
+    const nodes = [
+      makeNode({ name: 'n1', gpuCount: 4, migCapable: true }),
+      makeNode({ name: 'n2', gpuCount: 8, migCapable: false }),
+    ]
+    expect(computeGpuSpecs(nodes).migCapableCount).toBe(4)
+  })
+})

--- a/web/src/components/clusters/components/__tests__/namespaceResourceUtils.test.ts
+++ b/web/src/components/clusters/components/__tests__/namespaceResourceUtils.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest'
+import { buildAllResources, getStatusBgColor } from '../namespaceResourceUtils'
+import type { BuildAllResourcesParams } from '../namespaceResourceUtils'
+
+const emptyParams: BuildAllResourcesParams = {
+  deployments: [],
+  pods: [],
+  services: [],
+  jobs: [],
+  hpas: [],
+  configmaps: [],
+  secrets: [],
+  serviceAccounts: [],
+  pvcs: [],
+}
+
+describe('buildAllResources', () => {
+  it('returns an empty list when every input is empty', () => {
+    expect(buildAllResources(emptyParams)).toEqual([])
+  })
+
+  it('includes deployments with the correct kind and detail', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      deployments: [{ name: 'api', namespace: 'default', status: 'running', replicas: 3, readyReplicas: 3, updatedReplicas: 3, availableReplicas: 3, progress: 100 }],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ kind: 'Deployment', name: 'api', statusColor: 'green', detail: '3/3' })
+  })
+
+  it('includes pods', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      pods: [{ name: 'pod-1', namespace: 'default', status: 'Running', ready: '1/1', restarts: 0, age: '1d' }],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0]).toMatchObject({ kind: 'Pod', name: 'pod-1', statusColor: 'green', detail: '1/1' })
+  })
+
+  it('includes services and marks a LoadBalancer with no externalIP as provisioning', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      services: [{ name: 'svc-1', namespace: 'default', type: 'LoadBalancer' }],
+    })
+    expect(result).toHaveLength(1)
+    expect(result[0].kind).toBe('Service')
+    expect(result[0].data?.externalIP).toBe('Provisioning')
+  })
+
+  it('shows the actual externalIP for a provisioned LoadBalancer service', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      services: [{ name: 'svc-1', namespace: 'default', type: 'LoadBalancer', externalIP: '1.2.3.4' }],
+    })
+    expect(result[0].data?.externalIP).toBe('1.2.3.4')
+  })
+
+  it('does not mark non-LoadBalancer services as provisioning', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      services: [{ name: 'svc-1', namespace: 'default', type: 'ClusterIP' }],
+    })
+    expect(result[0].data?.externalIP).toBeUndefined()
+  })
+
+  it('includes jobs', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      jobs: [{ name: 'job-1', namespace: 'default', status: 'Complete', completions: '1/1' }],
+    })
+    expect(result[0]).toMatchObject({ kind: 'Job', statusColor: 'green', detail: '1/1' })
+  })
+
+  it('includes HPAs, ConfigMaps, Secrets, ServiceAccounts, and PVCs', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      hpas: [{ name: 'hpa-1', namespace: 'default', reference: 'deploy/api', minReplicas: 1, maxReplicas: 5, currentReplicas: 2 }],
+      configmaps: [{ name: 'cm-1', namespace: 'default', dataCount: 3 }],
+      secrets: [{ name: 'secret-1', namespace: 'default', type: 'Opaque', dataCount: 2 }],
+      serviceAccounts: [{ name: 'sa-1', namespace: 'default', secrets: ['s1'] }],
+      pvcs: [{ name: 'pvc-1', namespace: 'default', status: 'Bound', capacity: '10Gi' }],
+    })
+    const kinds = result.map(r => r.kind)
+    expect(kinds).toEqual(['HPA', 'ConfigMap', 'Secret', 'ServiceAccount', 'PVC'])
+    expect(result.find(r => r.kind === 'PVC')).toMatchObject({ statusColor: 'green', detail: '10Gi' })
+  })
+
+  it('handles a serviceAccount with no secrets gracefully', () => {
+    const result = buildAllResources({
+      ...emptyParams,
+      serviceAccounts: [{ name: 'sa-1', namespace: 'default' }],
+    })
+    expect(result[0].status).toBe('0 secrets')
+  })
+})
+
+describe('getStatusBgColor', () => {
+  it.each([
+    ['green', 'bg-green-500/20 text-green-400'],
+    ['blue', 'bg-blue-500/20 text-blue-400'],
+    ['yellow', 'bg-yellow-500/20 text-yellow-400'],
+    ['red', 'bg-red-500/20 text-red-400'],
+    ['cyan', 'bg-cyan-500/20 text-cyan-400'],
+    ['purple', 'bg-purple-500/20 text-purple-400'],
+    ['orange', 'bg-orange-500/20 text-orange-400'],
+  ])('maps %s to the expected classes', (color, expected) => {
+    expect(getStatusBgColor(color)).toBe(expected)
+  })
+
+  it('falls back to the default gray classes for unknown colors', () => {
+    expect(getStatusBgColor('not-a-color')).toBe('bg-gray-500/20 text-muted-foreground dark:bg-gray-400/20')
+  })
+})

--- a/web/src/components/clusters/components/gpuDetailUtils.ts
+++ b/web/src/components/clusters/components/gpuDetailUtils.ts
@@ -1,0 +1,180 @@
+import type { GPUNode } from '../../../hooks/useMCP'
+
+export interface GPUTypeInfo {
+  type: string
+  manufacturer: string
+  totalGPUs: number
+  allocatedGPUs: number
+  availableGPUs: number
+  nodeCount: number
+  clusters: string[]
+}
+
+export interface ClusterGPUInfo {
+  cluster: string
+  totalGPUs: number
+  allocatedGPUs: number
+  availableGPUs: number
+  nodeCount: number
+  gpuTypes: string[]
+}
+
+export interface GPUTotals {
+  total: number
+  allocated: number
+  available: number
+  utilizationPercent: number
+}
+
+export interface GPUSpecs {
+  totalMemoryGB: number
+  families: string[]
+  cudaDriverVersions: string[]
+  cudaRuntimeVersions: string[]
+  migCapableCount: number
+}
+
+/** GPU utilization % threshold for critical (red) status. */
+export const GPU_UTIL_HIGH = 90
+/** GPU utilization % threshold for warning (yellow) status. */
+export const GPU_UTIL_WARN = 70
+
+export function extractManufacturer(gpuType: string): string {
+  const lower = gpuType.toLowerCase()
+  if (lower.includes('nvidia')) return 'NVIDIA'
+  if (lower.includes('amd') || lower.includes('radeon')) return 'AMD'
+  if (lower.includes('intel')) return 'Intel'
+  return 'Unknown'
+}
+
+export function getUtilizationColor(percentage: number): string {
+  if (percentage >= GPU_UTIL_HIGH) return 'text-red-400'
+  if (percentage >= GPU_UTIL_WARN) return 'text-yellow-400'
+  return 'text-green-400'
+}
+
+/**
+ * Calculates the GPU type breakdown (total/allocated/available GPUs per
+ * GPU type, across clusters). Extracted from GPUDetailModal.tsx (#21613)
+ * as a pure function to reduce the component's line count.
+ */
+export function computeGpuTypeInfo(gpuNodes: GPUNode[]): GPUTypeInfo[] {
+  const typeMap = new Map<string, GPUTypeInfo>()
+
+  gpuNodes.forEach(node => {
+    const existing = typeMap.get(node.gpuType)
+    if (existing) {
+      existing.totalGPUs += node.gpuCount
+      existing.allocatedGPUs += node.gpuAllocated
+      existing.availableGPUs += (node.gpuCount - node.gpuAllocated)
+      existing.nodeCount += 1
+      if (!existing.clusters.includes(node.cluster)) {
+        existing.clusters.push(node.cluster)
+      }
+    } else {
+      typeMap.set(node.gpuType, {
+        type: node.gpuType,
+        manufacturer: extractManufacturer(node.gpuType),
+        totalGPUs: node.gpuCount,
+        allocatedGPUs: node.gpuAllocated,
+        availableGPUs: node.gpuCount - node.gpuAllocated,
+        nodeCount: 1,
+        clusters: [node.cluster] })
+    }
+  })
+
+  return Array.from(typeMap.values()).sort((a, b) => b.totalGPUs - a.totalGPUs)
+}
+
+/**
+ * Calculates the per-cluster GPU breakdown. Extracted from
+ * GPUDetailModal.tsx (#21613) as a pure function.
+ */
+export function computeClusterInfo(gpuNodes: GPUNode[]): ClusterGPUInfo[] {
+  const clusterMap = new Map<string, ClusterGPUInfo>()
+
+  gpuNodes.forEach(node => {
+    const existing = clusterMap.get(node.cluster)
+    if (existing) {
+      existing.totalGPUs += node.gpuCount
+      existing.allocatedGPUs += node.gpuAllocated
+      existing.availableGPUs += (node.gpuCount - node.gpuAllocated)
+      existing.nodeCount += 1
+      if (!existing.gpuTypes.includes(node.gpuType)) {
+        existing.gpuTypes.push(node.gpuType)
+      }
+    } else {
+      clusterMap.set(node.cluster, {
+        cluster: node.cluster,
+        totalGPUs: node.gpuCount,
+        allocatedGPUs: node.gpuAllocated,
+        availableGPUs: node.gpuCount - node.gpuAllocated,
+        nodeCount: 1,
+        gpuTypes: [node.gpuType] })
+    }
+  })
+
+  return Array.from(clusterMap.values()).sort((a, b) => b.totalGPUs - a.totalGPUs)
+}
+
+/** Calculates aggregate total/allocated/available/utilization across all GPU nodes. */
+export function computeGpuTotals(gpuNodes: GPUNode[]): GPUTotals {
+  let total = 0
+  let allocated = 0
+  gpuNodes.forEach(node => {
+    total += node.gpuCount
+    allocated += node.gpuAllocated
+  })
+  return {
+    total,
+    allocated,
+    available: total - allocated,
+    utilizationPercent: total > 0 ? Math.round((allocated / total) * 100) : 0 }
+}
+
+/** Aggregates total GPU count by manufacturer, sorted descending. */
+export function computeManufacturerBreakdown(gpuTypeInfo: GPUTypeInfo[]): Array<[string, number]> {
+  const mfgMap = new Map<string, number>()
+  gpuTypeInfo.forEach(info => {
+    const existing = mfgMap.get(info.manufacturer) || 0
+    mfgMap.set(info.manufacturer, existing + info.totalGPUs)
+  })
+  return Array.from(mfgMap.entries()).sort((a, b) => b[1] - a[1])
+}
+
+const MB_PER_GB = 1024
+
+/** Extracts GPU specifications (VRAM, family, CUDA versions, MIG support) from nodes. */
+export function computeGpuSpecs(gpuNodes: GPUNode[]): GPUSpecs {
+  const specs = {
+    totalMemoryGB: 0,
+    families: new Set<string>(),
+    cudaDriverVersions: new Set<string>(),
+    cudaRuntimeVersions: new Set<string>(),
+    migCapableCount: 0 }
+
+  gpuNodes.forEach(node => {
+    if (node.gpuMemoryMB) {
+      specs.totalMemoryGB += (node.gpuMemoryMB / MB_PER_GB) * node.gpuCount
+    }
+    if (node.gpuFamily) {
+      specs.families.add(node.gpuFamily)
+    }
+    if (node.cudaDriverVersion) {
+      specs.cudaDriverVersions.add(node.cudaDriverVersion)
+    }
+    if (node.cudaRuntimeVersion) {
+      specs.cudaRuntimeVersions.add(node.cudaRuntimeVersion)
+    }
+    if (node.migCapable) {
+      specs.migCapableCount += node.gpuCount
+    }
+  })
+
+  return {
+    totalMemoryGB: Math.round(specs.totalMemoryGB),
+    families: Array.from(specs.families),
+    cudaDriverVersions: Array.from(specs.cudaDriverVersions),
+    cudaRuntimeVersions: Array.from(specs.cudaRuntimeVersions),
+    migCapableCount: specs.migCapableCount }
+}

--- a/web/src/components/clusters/components/namespaceResourceUtils.ts
+++ b/web/src/components/clusters/components/namespaceResourceUtils.ts
@@ -1,0 +1,184 @@
+import { LB_PROVISIONING_LABEL, LB_STATUS_PROVISIONING } from '../../../lib/constants/network'
+import type {
+  PodInfo,
+  Deployment,
+  Service,
+  Job,
+  HPA,
+  ConfigMap,
+  Secret,
+  ServiceAccount,
+  PVC,
+} from '../../../hooks/useMCP'
+
+/** Service type string emitted by the backend for LoadBalancer services.
+ * Defined as a constant to avoid magic strings. */
+export const SERVICE_TYPE_LOAD_BALANCER = 'LoadBalancer'
+
+export type ResourceKind = 'Pod' | 'Deployment' | 'Service' | 'Job' | 'HPA' | 'ConfigMap' | 'Secret' | 'ServiceAccount' | 'PVC'
+
+export interface NamespaceResourceRow {
+  kind: ResourceKind
+  name: string
+  namespace?: string
+  status?: string
+  statusColor: string
+  detail?: string
+  data?: Record<string, unknown>
+}
+
+export interface BuildAllResourcesParams {
+  deployments: Deployment[]
+  pods: PodInfo[]
+  services: Service[]
+  jobs: Job[]
+  hpas: HPA[]
+  configmaps: ConfigMap[]
+  secrets: Secret[]
+  serviceAccounts: ServiceAccount[]
+  pvcs: PVC[]
+}
+
+/**
+ * Builds the flat list of all namespace resources (used by the list view).
+ * Extracted from NamespaceResources.tsx (#21617) as a pure function to
+ * reduce the component's line count.
+ */
+export function buildAllResources({
+  deployments,
+  pods,
+  services,
+  jobs,
+  hpas,
+  configmaps,
+  secrets,
+  serviceAccounts,
+  pvcs,
+}: BuildAllResourcesParams): NamespaceResourceRow[] {
+  const resources: NamespaceResourceRow[] = []
+
+  deployments.forEach(dep => resources.push({
+    kind: 'Deployment',
+    name: dep.name,
+    namespace: dep.namespace,
+    status: dep.status,
+    statusColor: dep.status === 'running' ? 'green' : dep.status === 'deploying' ? 'blue' : 'red',
+    detail: `${dep.readyReplicas}/${dep.replicas}`,
+    data: { replicas: dep.replicas, readyReplicas: dep.readyReplicas, image: dep.image, status: dep.status, age: dep.age }
+  }))
+
+  pods.forEach(pod => resources.push({
+    kind: 'Pod',
+    name: pod.name,
+    namespace: pod.namespace,
+    status: pod.status,
+    statusColor: pod.status === 'Running' ? 'green' : pod.status === 'Pending' ? 'yellow' : 'red',
+    detail: pod.ready,
+    data: { status: pod.status, ready: pod.ready, restarts: pod.restarts, node: pod.node, age: pod.age }
+  }))
+
+  services.forEach(svc => {
+    // Issue #6153: for LoadBalancer services with no ingress IP/
+    // hostname assigned yet, display 'Provisioning' instead of an
+    // empty string. We treat either the explicit lbStatus flag from
+    // the backend OR a LoadBalancer type with a missing externalIP
+    // (for older backends that do not set lbStatus) as provisioning.
+    const isPendingLB =
+      svc.type === SERVICE_TYPE_LOAD_BALANCER &&
+      (svc.lbStatus === LB_STATUS_PROVISIONING || !svc.externalIP)
+    const externalIPDisplay = isPendingLB
+      ? LB_PROVISIONING_LABEL
+      : svc.externalIP
+    resources.push({
+      kind: 'Service',
+      name: svc.name,
+      namespace: svc.namespace,
+      status: svc.type,
+      statusColor: 'cyan',
+      detail: (svc.ports ?? []).slice(0, 2).join(', '),
+      data: {
+        type: svc.type,
+        clusterIP: svc.clusterIP,
+        externalIP: externalIPDisplay,
+        endpoints: svc.endpoints,
+        lbStatus: svc.lbStatus,
+        ports: svc.ports,
+        age: svc.age,
+      },
+    })
+  })
+
+  jobs.forEach(job => resources.push({
+    kind: 'Job',
+    name: job.name,
+    namespace: job.namespace,
+    status: job.status,
+    statusColor: job.status === 'Complete' ? 'green' : job.status === 'Running' ? 'green' : 'red',
+    detail: job.completions,
+    data: { status: job.status, completions: job.completions, duration: job.duration, age: job.age }
+  }))
+
+  hpas.forEach(hpa => resources.push({
+    kind: 'HPA',
+    name: hpa.name,
+    namespace: hpa.namespace,
+    status: `${hpa.currentReplicas}/${hpa.minReplicas}-${hpa.maxReplicas}`,
+    statusColor: 'purple',
+    detail: hpa.reference,
+    data: { reference: hpa.reference, minReplicas: hpa.minReplicas, maxReplicas: hpa.maxReplicas, currentReplicas: hpa.currentReplicas, targetCPU: hpa.targetCPU, currentCPU: hpa.currentCPU, age: hpa.age }
+  }))
+
+  configmaps.forEach(cm => resources.push({
+    kind: 'ConfigMap',
+    name: cm.name,
+    namespace: cm.namespace,
+    status: `${cm.dataCount} keys`,
+    statusColor: 'orange',
+    data: { dataCount: cm.dataCount, age: cm.age }
+  }))
+
+  secrets.forEach(secret => resources.push({
+    kind: 'Secret',
+    name: secret.name,
+    namespace: secret.namespace,
+    status: secret.type,
+    statusColor: 'purple',
+    detail: `${secret.dataCount} keys`,
+    data: { type: secret.type, dataCount: secret.dataCount, age: secret.age }
+  }))
+
+  serviceAccounts.forEach(sa => resources.push({
+    kind: 'ServiceAccount',
+    name: sa.name,
+    namespace: sa.namespace,
+    status: `${sa.secrets?.length || 0} secrets`,
+    statusColor: 'cyan',
+    data: { secrets: sa.secrets, imagePullSecrets: sa.imagePullSecrets, age: sa.age }
+  }))
+
+  pvcs.forEach(pvc => resources.push({
+    kind: 'PVC',
+    name: pvc.name,
+    namespace: pvc.namespace,
+    status: pvc.status,
+    statusColor: pvc.status === 'Bound' ? 'green' : pvc.status === 'Pending' ? 'yellow' : 'red',
+    detail: pvc.capacity,
+    data: { status: pvc.status, storageClass: pvc.storageClass, capacity: pvc.capacity, accessModes: pvc.accessModes, volumeName: pvc.volumeName, age: pvc.age }
+  }))
+
+  return resources
+}
+
+/** Maps a status "color" tag to Tailwind background/text classes. */
+export function getStatusBgColor(color: string): string {
+  switch (color) {
+    case 'green': return 'bg-green-500/20 text-green-400'
+    case 'blue': return 'bg-blue-500/20 text-blue-400'
+    case 'yellow': return 'bg-yellow-500/20 text-yellow-400'
+    case 'red': return 'bg-red-500/20 text-red-400'
+    case 'cyan': return 'bg-cyan-500/20 text-cyan-400'
+    case 'purple': return 'bg-purple-500/20 text-purple-400'
+    case 'orange': return 'bg-orange-500/20 text-orange-400'
+    default: return 'bg-gray-500/20 text-muted-foreground dark:bg-gray-400/20'
+  }
+}

--- a/web/src/components/clusters/useClusterMutations.ts
+++ b/web/src/components/clusters/useClusterMutations.ts
@@ -1,0 +1,79 @@
+import { useTranslation } from 'react-i18next'
+import { useToast } from '../ui/Toast'
+import { agentFetch } from '../../hooks/mcp/shared'
+import { LOCAL_AGENT_HTTP_URL, FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+
+export interface UseClusterMutationsParams {
+  isConnected: boolean
+  refetch: () => void
+}
+
+/**
+ * Encapsulates the network mutations triggered from the Clusters page:
+ * renaming a kubeconfig context and removing an offline cluster's context.
+ * Extracted from Clusters.tsx (#21617) to reduce the component's hook count
+ * and line count.
+ */
+export function useClusterMutations({ isConnected, refetch }: UseClusterMutationsParams) {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+
+  const handleRenameContext = async (oldName: string, newName: string) => {
+    if (!isConnected) throw new Error(t('cluster.renameNoAgent'))
+    // Use agentFetch so the Authorization: Bearer <KC_AGENT_TOKEN> header
+    // is injected — plain fetch() is rejected with 401 when the agent has
+    // a token configured (#6133).
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/rename-context`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ oldName, newName }),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+    if (!response.ok) {
+      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
+      // Fall back to HTTP status so users see e.g. "HTTP 401: Unauthorized"
+      // instead of a silent generic error when the body has no message.
+      const fallback = `HTTP ${response.status}: ${response.statusText || 'Failed to rename context'}`
+      throw new Error(data.error || data.message || fallback)
+    }
+    refetch()
+  }
+
+  /**
+   * Remove an offline cluster's kubeconfig context (#5901).
+   * Backend: `RemoveContext` in pkg/k8s/client.go (added in #5658). The agent
+   * exposes it at POST /kubeconfig/remove on the localhost-only HTTP server.
+   *
+   * Uses agentFetch() to inject the KC_AGENT_TOKEN Authorization header;
+   * without this the kc-agent rejects the request with 401 Unauthorized
+   * whenever a token is configured, which manifested as a silent "Failed
+   * to remove cluster from kubeconfig" in the UI (#6133).
+   */
+  const handleRemoveCluster = async (contextName: string) => {
+    if (!isConnected) throw new Error(t('cluster.removeClusterNoAgent'))
+    const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/kubeconfig/remove`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ context: contextName }),
+      signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+    if (!response.ok) {
+      // #6293: check for the 404-means-stale-agent case BEFORE attempting
+      // to parse the body. An old kc-agent returns a plain-text Go
+      // default 404 ("404 page not found") which is not JSON — reading
+      // it first would be a wasted round-trip. Same reason #6288 added
+      // the status-specific branch in the first place.
+      if (response.status === 404) {
+        throw new Error(t('cluster.removeClusterAgentTooOld'))
+      }
+      const data = await response.json().catch(() => ({})) as { error?: string; message?: string }
+      // Always surface the HTTP status if the body has no structured error,
+      // so the user sees "HTTP 401: Unauthorized" instead of the generic
+      // fallback — this was the root cause of #6133 being unactionable.
+      const fallback = `HTTP ${response.status}: ${response.statusText || t('cluster.removeClusterError')}`
+      throw new Error(data.error || data.message || fallback)
+    }
+    showToast(t('cluster.removeClusterSuccess', { name: contextName }), 'success')
+    refetch()
+  }
+
+  return { handleRenameContext, handleRemoveCluster }
+}

--- a/web/src/components/clusters/useClusterViewState.ts
+++ b/web/src/components/clusters/useClusterViewState.ts
@@ -1,0 +1,110 @@
+import { useState, useEffect } from 'react'
+import type { useSearchParams } from 'react-router-dom'
+import { useToast } from '../ui/Toast'
+import { useTranslation } from 'react-i18next'
+import { STORAGE_KEY_CLUSTER_LAYOUT, STORAGE_KEY_CLUSTER_ORDER } from '../../lib/constants'
+import { safeGetItem, safeSetItem } from '../../lib/utils/localStorage'
+import type { ClusterLayoutMode } from './components'
+
+export type ClusterHealthFilter = 'all' | 'healthy' | 'unhealthy' | 'unreachable'
+export type ClusterSortField = 'name' | 'nodes' | 'pods' | 'health' | 'provider' | 'custom'
+
+export interface ClusterSortState {
+  by: ClusterSortField
+  customOrder: string[]
+}
+
+type SearchParamsTuple = ReturnType<typeof useSearchParams>
+
+/**
+ * Encapsulates the Clusters page's health filter, sort, and layout-mode
+ * state, including URL sync for the filter and localStorage persistence
+ * for sort order and layout mode. Extracted from Clusters.tsx (#21617) to
+ * reduce the component's hook count.
+ */
+export function useClusterViewState(searchParamsTuple: SearchParamsTuple) {
+  const { t } = useTranslation()
+  const { showToast } = useToast()
+  const [searchParams, setSearchParams] = searchParamsTuple
+
+  // Read filter from URL, default to 'all'
+  const urlStatus = searchParams.get('status')
+  const validFilter: ClusterHealthFilter = (urlStatus === 'healthy' || urlStatus === 'unhealthy' || urlStatus === 'unreachable') ? urlStatus : 'all'
+  const [filter, setFilterState] = useState<ClusterHealthFilter>(validFilter)
+
+  // Sync filter state with URL changes (e.g., when navigating from sidebar)
+  useEffect(() => {
+    const newFilter: ClusterHealthFilter = (urlStatus === 'healthy' || urlStatus === 'unhealthy' || urlStatus === 'unreachable') ? urlStatus : 'all'
+    if (newFilter !== filter) {
+      setFilterState(newFilter)
+    }
+  }, [urlStatus, filter])
+
+  // Update URL when filter changes programmatically
+  const setFilter = (newFilter: ClusterHealthFilter) => {
+    setFilterState(newFilter)
+    if (newFilter === 'all') {
+      searchParams.delete('status')
+    } else {
+      searchParams.set('status', newFilter)
+    }
+    setSearchParams(searchParams, { replace: true })
+  }
+
+  const [sortState, setSortState] = useState<ClusterSortState>(() => {
+    try {
+      const savedOrder = safeGetItem(STORAGE_KEY_CLUSTER_ORDER)
+      return {
+        by: savedOrder ? 'custom' : 'name',
+        customOrder: savedOrder ? JSON.parse(savedOrder) : [] }
+    } catch {
+      return { by: 'name', customOrder: [] }
+    }
+  })
+  const [sortAsc, setSortAsc] = useState(true)
+
+  // Notify user if saved cluster sort configuration was corrupt and had to be reset
+  useEffect(() => {
+    const savedOrder = safeGetItem(STORAGE_KEY_CLUSTER_ORDER)
+    if (savedOrder) {
+      try {
+        JSON.parse(savedOrder)
+      } catch {
+        showToast(t('cluster.sortPreferencesCorrupted'), 'warning')
+      }
+    }
+  }, []) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Convenience aliases so downstream code stays unchanged
+  const sortBy = sortState.by
+  const customOrder = sortState.customOrder
+  const setSortBy = (by: ClusterSortField) =>
+    setSortState(prev => ({ ...prev, by }))
+
+  const [layoutMode, setLayoutModeState] = useState<ClusterLayoutMode>(() => {
+    const stored = safeGetItem(STORAGE_KEY_CLUSTER_LAYOUT)
+    return (stored as ClusterLayoutMode) || 'grid'
+  })
+  const setLayoutMode = (mode: ClusterLayoutMode) => {
+    setLayoutModeState(mode)
+    safeSetItem(STORAGE_KEY_CLUSTER_LAYOUT, mode)
+  }
+
+  const handleReorder = (newOrder: string[]) => {
+    setSortState({ by: 'custom', customOrder: newOrder })
+    safeSetItem(STORAGE_KEY_CLUSTER_ORDER, JSON.stringify(newOrder))
+  }
+
+  return {
+    filter,
+    setFilter,
+    sortBy,
+    setSortBy,
+    sortAsc,
+    setSortAsc,
+    customOrder,
+    layoutMode,
+    setLayoutMode,
+    handleReorder,
+  }
+}

--- a/web/src/components/gpu/ClusterPicker.tsx
+++ b/web/src/components/gpu/ClusterPicker.tsx
@@ -1,6 +1,7 @@
 import { Loader2 } from 'lucide-react'
-import type { TFunction } from 'i18next'
 import type { GPUClusterInfo } from './ReservationFormModal'
+
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 interface NsField {
   value: string
@@ -8,7 +9,7 @@ interface NsField {
 }
 
 interface ClusterPickerProps {
-  t: TFunction
+  t: TranslateFn
   cluster: string
   setCluster: (cluster: string) => void
   namespace: string

--- a/web/src/components/gpu/ClusterPicker.tsx
+++ b/web/src/components/gpu/ClusterPicker.tsx
@@ -1,0 +1,136 @@
+import { Loader2 } from 'lucide-react'
+import type { TFunction } from 'i18next'
+import type { GPUClusterInfo } from './ReservationFormModal'
+
+interface NsField {
+  value: string
+  isNew: boolean
+}
+
+interface ClusterPickerProps {
+  t: TFunction
+  cluster: string
+  setCluster: (cluster: string) => void
+  namespace: string
+  isNewNamespace: boolean
+  setNsField: (updater: NsField | ((prev: NsField) => NsField)) => void
+  setGpuPreferences: (prefs: string[]) => void
+  gpuClusters: GPUClusterInfo[]
+  clusterNamespaces: string[]
+  editingReservation: unknown
+  namespacesLoading: boolean
+  namespacesError: string | null
+  refetchNamespaces: () => void
+}
+
+/**
+ * Cluster and namespace selection fields for the reservation form.
+ * Extracted from ReservationFormModal.tsx (#21613) to reduce the parent
+ * component's line count.
+ */
+export function ClusterPicker({
+  t,
+  cluster,
+  setCluster,
+  namespace,
+  isNewNamespace,
+  setNsField,
+  setGpuPreferences,
+  gpuClusters,
+  clusterNamespaces,
+  editingReservation,
+  namespacesLoading,
+  namespacesError,
+  refetchNamespaces,
+}: ClusterPickerProps) {
+  return (
+    <>
+      {/* Cluster (GPU-only, with counts) */}
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.clusterLabel')}</label>
+        <select value={cluster} onChange={e => { setCluster(e.target.value); setNsField({ value: '', isNew: false }); setGpuPreferences([]) }}
+          disabled={!!editingReservation}
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50">
+          <option value="">{t('gpuReservations.form.fields.selectCluster')}</option>
+          {gpuClusters.map(c => (
+            <option key={c.name} value={c.name}>
+              {t('gpuReservations.form.fields.clusterOption', { name: c.name, available: c.availableGPUs, total: c.totalGPUs })}
+            </option>
+          ))}
+        </select>
+        {gpuClusters.length === 0 && (
+          <div className="text-xs text-yellow-400 mt-1">{t('gpuReservations.form.fields.noClustersWithGpus')}</div>
+        )}
+      </div>
+
+      {/* Namespace */}
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.namespaceLabel')}</label>
+        {!isNewNamespace ? (
+          <select
+            value={namespace}
+            onChange={e => {
+              if (e.target.value === '__new__' || e.target.value === '__new_bottom__') {
+                setNsField({ value: '', isNew: true })
+                setTimeout(() => document.getElementById('new-ns-input')?.focus(), 0)
+              } else {
+                setNsField(prev => ({ ...prev, value: e.target.value }))
+              }
+            }}
+            disabled={!!editingReservation || !cluster || (namespacesLoading && clusterNamespaces.length === 0)}
+            className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50"
+          >
+            <option value="">{t('gpuReservations.form.fields.selectNamespace')}</option>
+            <option value="__new__">{t('gpuReservations.form.fields.newNamespace')}</option>
+            {clusterNamespaces.map(ns => (
+              <option key={ns} value={ns}>{ns}</option>
+            ))}
+            {clusterNamespaces.length > 0 && (
+              <option value="__new_bottom__">{t('gpuReservations.form.fields.newNamespace')}</option>
+            )}
+          </select>
+        ) : (
+          <div className="flex gap-2">
+            <input
+              id="new-ns-input"
+              type="text"
+              value={namespace}
+              onChange={e => setNsField(prev => ({ ...prev, value: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))}
+              placeholder={t('gpuReservations.form.fields.enterNamespace')}
+              disabled={!!editingReservation}
+              className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground disabled:opacity-50"
+              autoFocus
+            />
+            <button
+              type="button"
+              onClick={() => setNsField({ value: '', isNew: false })}
+              className="px-3 py-2 rounded-lg bg-secondary border border-border text-muted-foreground hover:text-foreground"
+              title={t('gpuReservations.form.fields.backToList')}
+              aria-label={t('gpuReservations.form.fields.backToList')}
+            >
+              &times;
+            </button>
+          </div>
+        )}
+        {cluster && !isNewNamespace && namespacesLoading && (
+          <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            <span>{t('common:status.loadingNamespaces')}</span>
+          </div>
+        )}
+        {cluster && !isNewNamespace && namespacesError && !namespacesLoading && (
+          <div className="mt-2 flex items-center gap-2 text-xs text-red-400">
+            <span>{namespacesError}</span>
+            <button
+              type="button"
+              onClick={() => void refetchNamespaces()}
+              className="font-medium underline underline-offset-2 hover:text-red-300"
+            >
+              Retry
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  )
+}

--- a/web/src/components/gpu/ClusterPicker.tsx
+++ b/web/src/components/gpu/ClusterPicker.tsx
@@ -1,7 +1,7 @@
 import { Loader2 } from 'lucide-react'
 import type { GPUClusterInfo } from './ReservationFormModal'
 
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
 
 interface NsField {
   value: string

--- a/web/src/components/gpu/GPUCalendarTab.tsx
+++ b/web/src/components/gpu/GPUCalendarTab.tsx
@@ -7,6 +7,8 @@ import {
 import { cn } from '../../lib/cn'
 import type { GPUReservation } from '../../hooks/useGPUReservations'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 export interface CalendarBar {
   reservation: GPUReservation
   startCol: number // 0-6 column in this week
@@ -49,7 +51,8 @@ export function GPUCalendarTab({
   onAddReservation,
   getGPUCountForDay,
 }: GPUCalendarTabProps) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
 
   return (
     <div className="space-y-6">

--- a/web/src/components/gpu/GPUDashboardTab.tsx
+++ b/web/src/components/gpu/GPUDashboardTab.tsx
@@ -15,6 +15,8 @@ import {
 import { useClusters } from '../../hooks/useMCP'
 import { StatusIndicator } from '../charts/StatusIndicator'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 export interface GPUDashboardTabProps {
   dashboardCards: GpuDashCard[]
   dashCardIds: string[]
@@ -39,7 +41,8 @@ export function GPUDashboardTab({
   onDashCardWidthChange,
   onTriggerRefresh,
   onShowAddCardModal }: GPUDashboardTabProps) {
-  const { t } = useTranslation(['cards', 'common'])
+    const { t: tTyped } = useTranslation(['cards', 'common'])
+    const t = tTyped as unknown as TranslateFn
   const { deduplicatedClusters: clusters } = useClusters()
 
   const clusterHealth = (() => {

--- a/web/src/components/gpu/GPUInventoryTab.tsx
+++ b/web/src/components/gpu/GPUInventoryTab.tsx
@@ -16,7 +16,7 @@ import { useGPUTaintFilter, GPUTaintFilterControl } from '../cards/GPUTaintFilte
 import { useRef } from 'react'
 import { useModal } from '../../hooks/useModal'
 
-type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+type TranslateFn = (key: string, defaultValueOrOptions?: string | Record<string, unknown>, options?: Record<string, unknown>) => string
 
 export interface GPUInventoryTabProps {
   gpuClusters: GPUClusterInfo[]

--- a/web/src/components/gpu/GPUInventoryTab.tsx
+++ b/web/src/components/gpu/GPUInventoryTab.tsx
@@ -16,6 +16,8 @@ import { useGPUTaintFilter, GPUTaintFilterControl } from '../cards/GPUTaintFilte
 import { useRef } from 'react'
 import { useModal } from '../../hooks/useModal'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 export interface GPUInventoryTabProps {
   gpuClusters: GPUClusterInfo[]
   nodes: GPUNode[]
@@ -29,7 +31,8 @@ export function GPUInventoryTab({
   nodesLoading,
   effectiveDemoMode,
 }: GPUInventoryTabProps) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
   const { distinctTaints, toleratedKeys, toggle, clear, isVisible, hiddenGPUCount } = useGPUTaintFilter(nodes)
   const { isOpen: isFilterOpen, setIsOpen: setIsFilterOpen } = useModal()
   const filterRef = useRef<HTMLDivElement>(null)

--- a/web/src/components/gpu/GPUOverviewTab.tsx
+++ b/web/src/components/gpu/GPUOverviewTab.tsx
@@ -26,7 +26,7 @@ import {
   getUtilizationColor,
 } from './gpu-constants'
 
-type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+type TranslateFn = (key: string, defaultValueOrOptions?: string | Record<string, unknown>, options?: Record<string, unknown>) => string
 
 export interface GPUOverviewTabProps {
   stats: GPUOverviewStats

--- a/web/src/components/gpu/GPUOverviewTab.tsx
+++ b/web/src/components/gpu/GPUOverviewTab.tsx
@@ -26,6 +26,8 @@ import {
   getUtilizationColor,
 } from './gpu-constants'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 export interface GPUOverviewTabProps {
   stats: GPUOverviewStats
   filteredReservations: GPUReservation[]
@@ -43,7 +45,8 @@ export function GPUOverviewTab({
   showOnlyMine,
   onSelectReservation,
 }: GPUOverviewTabProps) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
   const isInteractive = Boolean(onSelectReservation)
 
   return (

--- a/web/src/components/gpu/GPUReservations.tsx
+++ b/web/src/components/gpu/GPUReservations.tsx
@@ -46,9 +46,11 @@ import { useGPUCalendarState } from './useGPUCalendarState'
 import { useGPUReservationForm } from './useGPUReservationForm'
 
 type ViewTab = 'overview' | 'calendar' | 'quotas' | 'inventory' | 'dashboard'
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
 
 export function GPUReservations() {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
   const { nodes: rawNodes, isLoading: nodesLoading, refetch: refetchGPUNodes } = useGPUNodes()
   const { refetch: refetchClusters } = useClusters()
 

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -24,7 +24,7 @@ import {
   getUtilizationColor,
 } from './gpu-constants'
 
-type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+type TranslateFn = (key: string, defaultValueOrOptions?: string | Record<string, unknown>, options?: Record<string, unknown>) => string
 
 export interface GPUReservationsTabProps {
   filteredReservations: GPUReservation[]

--- a/web/src/components/gpu/GPUReservationsTab.tsx
+++ b/web/src/components/gpu/GPUReservationsTab.tsx
@@ -24,6 +24,8 @@ import {
   getUtilizationColor,
 } from './gpu-constants'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 export interface GPUReservationsTabProps {
   filteredReservations: GPUReservation[]
   utilizations: Record<string, GPUUtilizationSnapshot[]> | null
@@ -61,7 +63,8 @@ export function GPUReservationsTab({
   onDeleteReservation,
   onCreateReservation,
 }: GPUReservationsTabProps) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
 
   return (
     <div className="space-y-6">

--- a/web/src/components/gpu/ReservationFormModal.tsx
+++ b/web/src/components/gpu/ReservationFormModal.tsx
@@ -1,88 +1,11 @@
-import { useState, useMemo } from 'react'
-import { useTranslation } from 'react-i18next'
-import {
-  Zap,
-  Calendar,
-  Plus,
-  Trash2,
-  Loader2 } from 'lucide-react'
+import { Calendar, Loader2 } from 'lucide-react'
 import { BaseModal, ConfirmDialog } from '../../lib/modals'
-import {
-  useNamespaces,
-  createOrUpdateResourceQuota,
-  deleteResourceQuota,
-  COMMON_RESOURCE_TYPES } from '../../hooks/useMCP'
 import type { GPUNode } from '../../hooks/useMCP'
 import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
-import { normalizeGpuTypes } from '../../hooks/useGPUReservations'
-import { cn } from '../../lib/cn'
-
-// GPU resource keys used to identify GPU quotas
-const GPU_KEYS = ['nvidia.com/gpu', 'amd.com/gpu', 'gpu.intel.com/i915']
-
-/** Maximum length of the sanitized title segment in a generated quota name. */
-const QUOTA_NAME_TITLE_MAX_LEN = 40
-
-/** Default reservation duration in hours when the field is left blank. */
-const DEFAULT_RESERVATION_DURATION_HOURS = 24
-
-/**
- * Normalize any accepted start-date representation to the `YYYY-MM-DD`
- * format required by `<input type="date">`. Accepts either a bare date
- * (`2024-01-15`) or a full RFC 3339 timestamp (`2024-01-15T09:00:00Z`)
- * and returns just the date portion. Empty input returns an empty string.
- */
-function toDateInputValue(value: string | undefined | null): string {
-  if (!value) return ''
-  // Both `YYYY-MM-DD` and `YYYY-MM-DDT...` share the same date prefix.
-  return value.split('T')[0]
-}
-
-/**
- * Convert a `<input type="date">` value (`YYYY-MM-DD`) to an RFC 3339
- * timestamp representing local midnight with an explicit timezone offset
- * (`YYYY-MM-DDT00:00:00±HH:MM`). If the input is already an RFC 3339
- * timestamp, it is returned as-is.
- *
- * The local-offset form (rather than `Z`) prevents an off-by-one-day
- * display in calendar views: downstream code parses `start_date` with
- * `new Date(...)` and normalizes via `setHours(0, 0, 0, 0)`, which
- * shifts a hard-coded UTC midnight back a day for any user west of UTC
- * (e.g. Jan 15 00:00 UTC → Jan 14 in PST). Encoding the user's local
- * offset keeps the calendar day stable across the wire.
- */
-function toRFC3339StartDate(value: string): string {
-  if (!value) return ''
-  if (value.includes('T')) return value
-
-  // Date.getTimezoneOffset returns minutes WEST of UTC (positive for the
-  // Americas, negative for Europe/Asia), so flip the sign to get the
-  // signed offset that goes into the RFC 3339 string.
-  const offsetMinutesWestOfUTC = new Date().getTimezoneOffset()
-  const totalOffsetMinutes = -offsetMinutesWestOfUTC
-  const offsetSign = totalOffsetMinutes >= 0 ? '+' : '-'
-  const absoluteOffsetMinutes = Math.abs(totalOffsetMinutes)
-  const minutesPerHour = 60
-  const offsetHours = String(Math.floor(absoluteOffsetMinutes / minutesPerHour)).padStart(2, '0')
-  const offsetMinutes = String(absoluteOffsetMinutes % minutesPerHour).padStart(2, '0')
-
-  return `${value}T00:00:00${offsetSign}${offsetHours}:${offsetMinutes}`
-}
-
-/**
- * Derive the Kubernetes ResourceQuota name from a reservation title.
- * Exported as a local helper so both the current-title quota name and
- * the ORIGINAL-title quota name (used for cleanup on rename) are
- * computed identically.
- */
-function deriveQuotaName(title: string): string {
-  if (!title) return ''
-  return `gpu-${title
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-|-$/g, '')
-    .slice(0, QUOTA_NAME_TITLE_MAX_LEN)}`
-}
+import { useReservationFormState } from './useReservationFormState'
+import { ClusterPicker } from './ClusterPicker'
+import { ResourceRequestFields } from './ResourceRequestFields'
+import { ScheduleSelector } from './ScheduleSelector'
 
 // GPU cluster info for dropdown
 export interface GPUClusterInfo {
@@ -130,293 +53,48 @@ export function ReservationFormModal({
   onSaved: () => void
   onError: (msg: string) => void
 }) {
-  const { t } = useTranslation(['cards', 'common'])
-  const [cluster, setCluster] = useState(editingReservation?.cluster || '')
-  // namespace value and "create new" toggle always change together → merged into
-  // a single state object so each user interaction causes only one re-render.
-  const [nsField, setNsField] = useState<{ value: string; isNew: boolean }>({
-    value: editingReservation?.namespace || '',
-    isNew: false,
-  })
-  const namespace = nsField.value
-  const isNewNamespace = nsField.isNew
-  const [title, setTitle] = useState(editingReservation?.title || '')
-  const [description, setDescription] = useState(editingReservation?.description || '')
-  const [gpuCount, setGpuCount] = useState(editingReservation ? String(editingReservation.gpu_count) : '')
-  // Multi-type preference. `gpuPreferences` holds the list of
-  // acceptable GPU types for this reservation — an empty array is
-  // "no preference" (any type is acceptable), a one-element array is
-  // the legacy single-type behaviour, and two or more entries implement
-  // the multi-type-preference feature requested by
-  // @MikeSpreitzer. Seeded from both the legacy `gpu_type` string and
-  // the new `gpu_types` array via `normalizeGpuTypes` so edits of
-  // existing pre-migration reservations keep their type.
-  const [gpuPreferences, setGpuPreferences] = useState<string[]>(() => normalizeGpuTypes(editingReservation))
-  const [startDate, setStartDate] = useState(
-    toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
-  )
-  const [durationHours, setDurationHours] = useState(editingReservation ? String(editingReservation.duration_hours) : '')
-  const [notes, setNotes] = useState(editingReservation?.notes || '')
-  const enforceQuota = true
-  const [extraResources, setExtraResources] = useState<Array<{ key: string; value: string }>>([])
-  const [isSaving, setIsSaving] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
-
-  // Snapshot of the initial form state used for dirty detection. Captured
-  // once when the modal is first rendered for this editing target so the
-  // unsaved-changes dialog compares against the ORIGINAL values (not the
-  // current values, which would always look "clean").
-  const initialSnapshot = useMemo(
-    () => ({
-      cluster: editingReservation?.cluster || '',
-      namespace: editingReservation?.namespace || '',
-      title: editingReservation?.title || '',
-      description: editingReservation?.description || '',
-      gpuCount: editingReservation ? String(editingReservation.gpu_count) : '',
-      // Snapshot the multi-type preference list so dirty
-      // detection can see a type-only edit. Sorted so order churn
-      // does not trip a false positive.
-      gpuPreferences: [...normalizeGpuTypes(editingReservation)].sort(),
-      startDate: toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
-      durationHours: editingReservation ? String(editingReservation.duration_hours) : '',
-      notes: editingReservation?.notes || '' }),
-    // Re-snapshot only when the modal is opened for a different reservation
-    // or with a different prefill date.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [editingReservation?.id, prefillDate],
-  )
-
-  const forceClose = () => {
-    setShowDiscardConfirm(false)
-    onClose()
-  }
-
-  // Returns true if ANY user-editable field has diverged from the initial
-  // snapshot. Previously this only inspected title/description, so edits
-  // to cluster, namespace, GPU count/type, dates, duration, notes, or
-  // extra resources could be discarded without confirmation.
-  const isDirty = (): boolean => {
-    if (cluster !== initialSnapshot.cluster) return true
-    if (namespace !== initialSnapshot.namespace) return true
-    if (title !== initialSnapshot.title) return true
-    if (description !== initialSnapshot.description) return true
-    if (gpuCount !== initialSnapshot.gpuCount) return true
-    // Compare the sorted multi-type list. Order is intentionally
-    // ignored because the form renders the same set regardless of
-    // toggle order — only membership matters for dirty detection.
-    const currentGpuPrefSorted = [...gpuPreferences].sort()
-    if (currentGpuPrefSorted.length !== initialSnapshot.gpuPreferences.length) return true
-    for (let i = 0; i < currentGpuPrefSorted.length; i++) {
-      if (currentGpuPrefSorted[i] !== initialSnapshot.gpuPreferences[i]) return true
-    }
-    if (startDate !== initialSnapshot.startDate) return true
-    if (durationHours !== initialSnapshot.durationHours) return true
-    if (notes !== initialSnapshot.notes) return true
-    // extraResources always starts empty for both create and edit flows —
-    // any entry means the user added a row.
-    if (extraResources.length > 0) return true
-    return false
-  }
-
-  const handleClose = () => {
-    if (isDirty()) {
-      setShowDiscardConfirm(true)
-      return
-    }
-    onClose()
-  }
-
   const {
-    namespaces: rawNamespaces,
-    isLoading: namespacesLoading,
-    error: namespacesError,
-    refetch: refetchNamespaces,
-  } = useNamespaces(cluster || undefined, forceLive)
-
-  // Union the hook result with namespaces from existing reservations on
-  // this cluster. Memoized to avoid re-allocating on every keystroke.
-  const mergedRawNamespaces = useMemo(() => {
-    const knownForCluster = (cluster && knownNamespacesByCluster?.[cluster]) || []
-    if (knownForCluster.length === 0) return rawNamespaces
-    return Array.from(new Set<string>([...rawNamespaces, ...knownForCluster])).sort()
-  }, [rawNamespaces, cluster, knownNamespacesByCluster])
-
-  // Filter out system namespaces from the dropdown
-  const FILTERED_NS_PREFIXES = ['openshift-', 'kube-']
-  const FILTERED_NS_EXACT = ['default', 'kube-system', 'kube-public', 'kube-node-lease']
-  const clusterNamespaces = mergedRawNamespaces.filter(ns =>
-      !FILTERED_NS_PREFIXES.some(prefix => ns.startsWith(prefix)) &&
-      !FILTERED_NS_EXACT.includes(ns)
-    )
-
-  // Get the selected cluster's GPU info
-  const selectedClusterInfo = gpuClusters.find(c => c.name === cluster)
-  const maxGPUs = selectedClusterInfo?.availableGPUs ?? 0
-
-  // Auto-detect GPU resource key from cluster's GPU types
-  const gpuResourceKey = (() => {
-    if (!cluster) return 'limits.nvidia.com/gpu'
-    const clusterNodes = allNodes.filter(n => n.cluster === cluster)
-    const hasAMD = clusterNodes.some(n => n.gpuType.toLowerCase().includes('amd') || n.manufacturer?.toLowerCase().includes('amd'))
-    const hasIntel = clusterNodes.some(n => n.gpuType.toLowerCase().includes('intel') || n.manufacturer?.toLowerCase().includes('intel'))
-    if (hasAMD) return 'limits.amd.com/gpu'
-    if (hasIntel) return 'gpu.intel.com/i915'
-    return 'limits.nvidia.com/gpu'
-  })()
-
-  // GPU types available on selected cluster with per-type counts
-  const clusterGPUTypes = (() => {
-    if (!cluster) return [] as Array<{ type: string; total: number; available: number }>
-    const typeMap: Record<string, { total: number; allocated: number }> = {}
-    for (const n of allNodes.filter(n => n.cluster === cluster)) {
-      if (!typeMap[n.gpuType]) typeMap[n.gpuType] = { total: 0, allocated: 0 }
-      typeMap[n.gpuType].total += n.gpuCount
-      typeMap[n.gpuType].allocated += n.gpuAllocated
-    }
-    return Object.entries(typeMap).map(([type, d]) => ({
-      type,
-      total: d.total,
-      available: d.total - d.allocated }))
-  })()
-
-  // Auto-generate quota name from title
-  const quotaName = deriveQuotaName(title)
-  // Quota name computed from the ORIGINAL title, used to clean up a
-  // stale ResourceQuota if the user renamed the reservation.
-  const originalQuotaName = deriveQuotaName(editingReservation?.title || '')
-
-  const handleSave = async () => {
-    const count = parseInt(gpuCount)
-    // For edits, capacity validation must account for the GPUs the current
-    // reservation already holds: max allowed = availableGPUs + originalCount.
-    // Without this, an edit could request more GPUs than the cluster has.
-    const originalCount = editingReservation?.gpu_count ?? 0
-    const sameClusterAsOriginal = editingReservation ? cluster === editingReservation.cluster : true
-    const capacityCeiling = editingReservation && sameClusterAsOriginal
-      ? maxGPUs + originalCount
-      : maxGPUs
-    const validationError = !cluster
-      ? t('gpuReservations.form.errors.selectCluster')
-      : !namespace
-      ? t('gpuReservations.form.errors.selectNamespace')
-      : !title
-      ? t('gpuReservations.form.errors.titleRequired')
-      : !count || count < 1
-      ? t('gpuReservations.form.errors.gpuCountMin')
-      : count > capacityCeiling
-      ? t('gpuReservations.form.errors.gpuCountMax', { max: capacityCeiling, cluster })
-      : null
-    setError(validationError)
-    if (validationError) return
-
-    setIsSaving(true)
-    try {
-      let reservationId: string | void
-      // Backend requires RFC 3339; <input type="date"> only emits YYYY-MM-DD,
-      // so normalize to midnight UTC before sending.
-      const rfc3339StartDate = toRFC3339StartDate(startDate)
-      // Canonical list of accepted GPU types. An empty list is
-      // "no preference" (server-side: any GPU acceptable). If the user
-      // left every type toggled off but the cluster only has one type,
-      // fall back to that single type so the back-compat path with
-      // older clusters stays unchanged.
-      const gpuTypesList =
-        gpuPreferences.length > 0
-          ? gpuPreferences
-          : clusterGPUTypes.length === 1 && clusterGPUTypes[0]?.type
-          ? [clusterGPUTypes[0].type]
-          : []
-      // Legacy singular mirror — kept for pre-multitype clients still
-      // reading `gpu_type`. See CLAUDE.md back-compat rule.
-      const primaryGpuType = gpuTypesList[0] || ''
-      if (editingReservation) {
-        // Partial update
-        const input: UpdateGPUReservationInput = {
-          title,
-          description,
-          cluster,
-          namespace,
-          gpu_count: count,
-          gpu_type: primaryGpuType,
-          gpu_types: gpuTypesList,
-          start_date: rfc3339StartDate,
-          duration_hours: parseInt(durationHours) || DEFAULT_RESERVATION_DURATION_HOURS,
-          notes,
-          quota_enforced: enforceQuota,
-          quota_name: enforceQuota ? quotaName : '',
-          max_cluster_gpus: selectedClusterInfo?.totalGPUs }
-        reservationId = await onSave(input)
-      } else {
-        // Create
-        const input: CreateGPUReservationInput = {
-          title,
-          description,
-          cluster,
-          namespace,
-          gpu_count: count,
-          gpu_type: primaryGpuType,
-          gpu_types: gpuTypesList,
-          start_date: rfc3339StartDate,
-          duration_hours: parseInt(durationHours) || DEFAULT_RESERVATION_DURATION_HOURS,
-          notes,
-          quota_enforced: enforceQuota,
-          quota_name: enforceQuota ? quotaName : '',
-          max_cluster_gpus: selectedClusterInfo?.totalGPUs }
-        reservationId = await onSave(input)
-      }
-
-      // Create K8s ResourceQuota (auto-creates namespace if needed)
-      if (enforceQuota) {
-        try {
-          const hard: Record<string, string> = {
-            [gpuResourceKey]: String(count) }
-          for (const r of extraResources) {
-            if (r.key && r.value) hard[r.key] = r.value
-          }
-          // If the reservation was renamed, the quota name (which is
-          // derived from the title) will be different. Delete the old
-          // quota first so it does not linger orphaned in the namespace.
-          if (
-            editingReservation &&
-            originalQuotaName &&
-            originalQuotaName !== quotaName &&
-            editingReservation.cluster &&
-            editingReservation.namespace
-          ) {
-            try {
-              await deleteResourceQuota(
-                editingReservation.cluster,
-                editingReservation.namespace,
-                originalQuotaName,
-              )
-            } catch {
-              // Non-fatal: old quota may already be gone (e.g. 404).
-              // Proceed with creating the renamed quota regardless.
-            }
-          }
-          await createOrUpdateResourceQuota({ cluster, namespace, name: quotaName, hard, ensure_namespace: isNewNamespace })
-          // Quota enforced successfully — activate the reservation
-          const id = reservationId || editingReservation?.id
-          if (id) {
-            try { await onActivate(id) } catch { /* non-fatal */ }
-          }
-        } catch {
-          // Non-fatal: reservation is saved, but quota enforcement failed — stays pending
-          onError(t('gpuReservations.form.errors.quotaFailed'))
-        }
-      }
-
-      onSaved()
-      onClose()
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : t('gpuReservations.form.errors.saveFailed')
-      setError(msg)
-      onError(msg)
-    } finally {
-      setIsSaving(false)
-    }
-  }
+    t,
+    cluster, setCluster,
+    namespace, isNewNamespace, setNsField,
+    title, setTitle,
+    description, setDescription,
+    gpuCount, setGpuCount,
+    gpuPreferences, setGpuPreferences,
+    startDate, setStartDate,
+    durationHours, setDurationHours,
+    notes, setNotes,
+    enforceQuota,
+    extraResources, setExtraResources,
+    isSaving,
+    error,
+    showDiscardConfirm, setShowDiscardConfirm,
+    forceClose,
+    handleClose,
+    handleSave,
+    namespacesLoading,
+    namespacesError,
+    refetchNamespaces,
+    clusterNamespaces,
+    selectedClusterInfo,
+    maxGPUs,
+    gpuResourceKey,
+    clusterGPUTypes,
+    quotaName,
+    GPU_KEYS,
+  } = useReservationFormState({
+    editingReservation,
+    gpuClusters,
+    allNodes,
+    prefillDate,
+    forceLive,
+    knownNamespacesByCluster,
+    onSave,
+    onActivate,
+    onSaved,
+    onError,
+    onClose,
+  })
 
   return (
     <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={false} closeOnEscape={true}>
@@ -475,219 +153,44 @@ export function ReservationFormModal({
               className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
           </div>
 
-          {/* Cluster (GPU-only, with counts) */}
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.clusterLabel')}</label>
-            <select value={cluster} onChange={e => { setCluster(e.target.value); setNsField({ value: '', isNew: false }); setGpuPreferences([]) }}
-              disabled={!!editingReservation}
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50">
-              <option value="">{t('gpuReservations.form.fields.selectCluster')}</option>
-              {gpuClusters.map(c => (
-                <option key={c.name} value={c.name}>
-                  {t('gpuReservations.form.fields.clusterOption', { name: c.name, available: c.availableGPUs, total: c.totalGPUs })}
-                </option>
-              ))}
-            </select>
-            {gpuClusters.length === 0 && (
-              <div className="text-xs text-yellow-400 mt-1">{t('gpuReservations.form.fields.noClustersWithGpus')}</div>
-            )}
-          </div>
+          <ClusterPicker
+            t={t}
+            cluster={cluster}
+            setCluster={setCluster}
+            namespace={namespace}
+            isNewNamespace={isNewNamespace}
+            setNsField={setNsField}
+            setGpuPreferences={setGpuPreferences}
+            gpuClusters={gpuClusters}
+            clusterNamespaces={clusterNamespaces}
+            editingReservation={editingReservation}
+            namespacesLoading={namespacesLoading}
+            namespacesError={namespacesError}
+            refetchNamespaces={refetchNamespaces}
+          />
 
-          {/* Namespace */}
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.namespaceLabel')}</label>
-            {!isNewNamespace ? (
-              <select
-                value={namespace}
-                onChange={e => {
-                  if (e.target.value === '__new__' || e.target.value === '__new_bottom__') {
-                    setNsField({ value: '', isNew: true })
-                    setTimeout(() => document.getElementById('new-ns-input')?.focus(), 0)
-                  } else {
-                    setNsField(prev => ({ ...prev, value: e.target.value }))
-                  }
-                }}
-                disabled={!!editingReservation || !cluster || (namespacesLoading && clusterNamespaces.length === 0)}
-                className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground disabled:opacity-50"
-              >
-                <option value="">{t('gpuReservations.form.fields.selectNamespace')}</option>
-                <option value="__new__">{t('gpuReservations.form.fields.newNamespace')}</option>
-                {clusterNamespaces.map(ns => (
-                  <option key={ns} value={ns}>{ns}</option>
-                ))}
-                {clusterNamespaces.length > 0 && (
-                  <option value="__new_bottom__">{t('gpuReservations.form.fields.newNamespace')}</option>
-                )}
-              </select>
-            ) : (
-              <div className="flex gap-2">
-                <input
-                  id="new-ns-input"
-                  type="text"
-                  value={namespace}
-                  onChange={e => setNsField(prev => ({ ...prev, value: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '') }))}
-                  placeholder={t('gpuReservations.form.fields.enterNamespace')}
-                  disabled={!!editingReservation}
-                  className="flex-1 px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground disabled:opacity-50"
-                  autoFocus
-                />
-                <button
-                  type="button"
-                  onClick={() => setNsField({ value: '', isNew: false })}
-                  className="px-3 py-2 rounded-lg bg-secondary border border-border text-muted-foreground hover:text-foreground"
-                  title={t('gpuReservations.form.fields.backToList')}
-                  aria-label={t('gpuReservations.form.fields.backToList')}
-                >
-                  &times;
-                </button>
-              </div>
-            )}
-            {cluster && !isNewNamespace && namespacesLoading && (
-              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                <span>{t('common:status.loadingNamespaces')}</span>
-              </div>
-            )}
-            {cluster && !isNewNamespace && namespacesError && !namespacesLoading && (
-              <div className="mt-2 flex items-center gap-2 text-xs text-red-400">
-                <span>{namespacesError}</span>
-                <button
-                  type="button"
-                  onClick={() => void refetchNamespaces()}
-                  className="font-medium underline underline-offset-2 hover:text-red-300"
-                >
-                  Retry
-                </button>
-              </div>
-            )}
-          </div>
+          <ResourceRequestFields
+            t={t}
+            gpuCount={gpuCount}
+            setGpuCount={setGpuCount}
+            maxGPUs={maxGPUs}
+            selectedClusterInfo={selectedClusterInfo}
+            clusterGPUTypes={clusterGPUTypes}
+            gpuPreferences={gpuPreferences}
+            setGpuPreferences={setGpuPreferences}
+            enforceQuota={enforceQuota}
+            extraResources={extraResources}
+            setExtraResources={setExtraResources}
+            gpuKeys={GPU_KEYS}
+          />
 
-          {/* GPU Count */}
-          <div>
-            <label className="block text-sm font-medium text-muted-foreground mb-1">
-              {t('gpuReservations.form.fields.gpuCountLabel')}
-              {selectedClusterInfo && (
-                <span className="text-xs text-green-400 ml-2">
-                  {t('gpuReservations.form.fields.maxAvailable', { count: selectedClusterInfo.availableGPUs })}
-                </span>
-              )}
-            </label>
-            <input type="number" value={gpuCount} onChange={e => setGpuCount(e.target.value)}
-              min="1" max={maxGPUs || undefined}
-              placeholder={t('gpuReservations.form.fields.gpuCountPlaceholder')}
-              className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
-          </div>
-
-          {/* GPU Type Selection — multi-select. Toggling a type
-              adds or removes it from the accepted-types list. Selecting
-              none means "no preference" (server accepts any type);
-              selecting two or more lets a developer reserve "any
-              sufficiently powerful GPU". */}
-          {clusterGPUTypes.length > 1 && (
-            <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-2">{t('gpuReservations.form.fields.gpuTypeLabel')}</label>
-              <div className="flex flex-wrap gap-2">
-                {clusterGPUTypes.map(gt => {
-                  const isSelected = gpuPreferences.includes(gt.type)
-                  return (
-                    <button
-                      key={gt.type}
-                      type="button"
-                      aria-pressed={isSelected}
-                      onClick={() => {
-                        setGpuPreferences(prev =>
-                          prev.includes(gt.type)
-                            ? prev.filter(t => t !== gt.type)
-                            : [...prev, gt.type],
-                        )
-                      }}
-                      className={cn(
-                        'flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm transition-colors',
-                        isSelected
-                          ? 'border-purple-500 bg-purple-500/10 text-purple-400'
-                          : 'border-border bg-secondary text-muted-foreground hover:text-foreground',
-                      )}
-                    >
-                      <Zap className="w-3.5 h-3.5" />
-                      {gt.type}
-                      <span className="text-xs opacity-70">{t('gpuReservations.form.fields.gpuTypeAvailability', { available: gt.available, total: gt.total })}</span>
-                    </button>
-                  )
-                })}
-              </div>
-              <div className="mt-1 text-xs text-muted-foreground">
-                {/* Helper copy for the multi-type selector.
-                    Kept as plain English for now — a follow-up PR
-                    will add i18n keys to all locale bundles once the
-                    base feature lands and the UX is approved. */}
-                {gpuPreferences.length === 0
-                  ? 'No type selected — any GPU will be accepted.'
-                  : gpuPreferences.length === 1
-                  ? '1 type accepted'
-                  : `${gpuPreferences.length} types accepted`}
-              </div>
-            </div>
-          )}
-          {/* Single GPU type — show as info */}
-          {clusterGPUTypes.length === 1 && (
-            <div className="flex items-center gap-2 text-sm text-muted-foreground">
-              <Zap className="w-3.5 h-3.5 text-purple-400" />
-              {clusterGPUTypes[0].type}
-              <span className="text-xs">{t('gpuReservations.form.fields.singleGpuType', { available: clusterGPUTypes[0].available, total: clusterGPUTypes[0].total })}</span>
-            </div>
-          )}
-
-          {/* Start Date and Duration */}
-          <div className="grid grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.startDateLabel')}</label>
-              <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}
-                className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground" />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.durationLabel')}</label>
-              <input type="number" value={durationHours} onChange={e => setDurationHours(e.target.value)}
-                min="1" placeholder={t('gpuReservations.form.fields.durationPlaceholder')}
-                className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
-            </div>
-          </div>
-
-          {/* Additional Resource Limits */}
-          {enforceQuota && (
-            <div>
-              <div className="flex items-center justify-between mb-2">
-                <label className="text-sm font-medium text-muted-foreground">{t('gpuReservations.form.fields.additionalLimits')}</label>
-                <button onClick={() => setExtraResources([...extraResources, { key: '', value: '' }])}
-                  className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-blue-500/20 text-blue-400 hover:bg-blue-500/30">
-                  <Plus className="w-3 h-3" /> {t('gpuReservations.form.fields.add')}
-                </button>
-              </div>
-              {extraResources.map((r, i) => (
-                <div key={i} className="flex items-center gap-2 mb-2">
-                  <select value={r.key} onChange={e => {
-                    const updated = [...extraResources]
-                    updated[i].key = e.target.value
-                    setExtraResources(updated)
-                  }} className="flex-1 px-2 py-1.5 rounded bg-secondary border border-border text-sm text-foreground">
-                    <option value="">{t('gpuReservations.form.fields.selectResource')}</option>
-                    {COMMON_RESOURCE_TYPES.filter(rt => !GPU_KEYS.some(gk => rt.key.includes(gk))).map(rt => (
-                      <option key={rt.key} value={rt.key}>{rt.label}</option>
-                    ))}
-                  </select>
-                  <input type="text" value={r.value} onChange={e => {
-                    const updated = [...extraResources]
-                    updated[i].value = e.target.value
-                    setExtraResources(updated)
-                  }} placeholder={t('gpuReservations.form.fields.resourcePlaceholder')} className="w-24 px-2 py-1.5 rounded bg-secondary border border-border text-sm text-foreground" />
-                  <button onClick={() => setExtraResources(extraResources.filter((_, j) => j !== i))}
-                    className="p-1 hover:bg-secondary rounded text-muted-foreground hover:text-red-400"
-                    aria-label="Remove resource limit">
-                    <Trash2 className="w-4 h-4" aria-hidden="true" />
-                  </button>
-                </div>
-              ))}
-            </div>
-          )}
+          <ScheduleSelector
+            t={t}
+            startDate={startDate}
+            setStartDate={setStartDate}
+            durationHours={durationHours}
+            setDurationHours={setDurationHours}
+          />
 
           {/* Notes */}
           <div>

--- a/web/src/components/gpu/ResourceRequestFields.tsx
+++ b/web/src/components/gpu/ResourceRequestFields.tsx
@@ -1,7 +1,8 @@
 import { Zap, Plus, Trash2 } from 'lucide-react'
-import type { TFunction } from 'i18next'
 import { cn } from '../../lib/cn'
 import { COMMON_RESOURCE_TYPES } from '../../hooks/useMCP'
+
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 interface ClusterGpuType {
   type: string
@@ -15,7 +16,7 @@ interface ExtraResource {
 }
 
 interface ResourceRequestFieldsProps {
-  t: TFunction
+  t: TranslateFn
   gpuCount: string
   setGpuCount: (value: string) => void
   maxGPUs: number

--- a/web/src/components/gpu/ResourceRequestFields.tsx
+++ b/web/src/components/gpu/ResourceRequestFields.tsx
@@ -1,0 +1,166 @@
+import { Zap, Plus, Trash2 } from 'lucide-react'
+import type { TFunction } from 'i18next'
+import { cn } from '../../lib/cn'
+import { COMMON_RESOURCE_TYPES } from '../../hooks/useMCP'
+
+interface ClusterGpuType {
+  type: string
+  total: number
+  available: number
+}
+
+interface ExtraResource {
+  key: string
+  value: string
+}
+
+interface ResourceRequestFieldsProps {
+  t: TFunction
+  gpuCount: string
+  setGpuCount: (value: string) => void
+  maxGPUs: number
+  selectedClusterInfo?: { availableGPUs: number }
+  clusterGPUTypes: ClusterGpuType[]
+  gpuPreferences: string[]
+  setGpuPreferences: (updater: string[] | ((prev: string[]) => string[])) => void
+  enforceQuota: boolean
+  extraResources: ExtraResource[]
+  setExtraResources: (resources: ExtraResource[]) => void
+  gpuKeys: string[]
+}
+
+/**
+ * GPU count, GPU type preference, and additional resource-limit fields
+ * for the reservation form. Extracted from ReservationFormModal.tsx
+ * (#21613) to reduce the parent component's line count.
+ */
+export function ResourceRequestFields({
+  t,
+  gpuCount,
+  setGpuCount,
+  maxGPUs,
+  selectedClusterInfo,
+  clusterGPUTypes,
+  gpuPreferences,
+  setGpuPreferences,
+  enforceQuota,
+  extraResources,
+  setExtraResources,
+  gpuKeys,
+}: ResourceRequestFieldsProps) {
+  return (
+    <>
+      {/* GPU Count */}
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground mb-1">
+          {t('gpuReservations.form.fields.gpuCountLabel')}
+          {selectedClusterInfo && (
+            <span className="text-xs text-green-400 ml-2">
+              {t('gpuReservations.form.fields.maxAvailable', { count: selectedClusterInfo.availableGPUs })}
+            </span>
+          )}
+        </label>
+        <input type="number" value={gpuCount} onChange={e => setGpuCount(e.target.value)}
+          min="1" max={maxGPUs || undefined}
+          placeholder={t('gpuReservations.form.fields.gpuCountPlaceholder')}
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
+      </div>
+
+      {/* GPU Type Selection — multi-select. Toggling a type
+          adds or removes it from the accepted-types list. Selecting
+          none means "no preference" (server accepts any type);
+          selecting two or more lets a developer reserve "any
+          sufficiently powerful GPU". */}
+      {clusterGPUTypes.length > 1 && (
+        <div>
+          <label className="block text-sm font-medium text-muted-foreground mb-2">{t('gpuReservations.form.fields.gpuTypeLabel')}</label>
+          <div className="flex flex-wrap gap-2">
+            {clusterGPUTypes.map(gt => {
+              const isSelected = gpuPreferences.includes(gt.type)
+              return (
+                <button
+                  key={gt.type}
+                  type="button"
+                  aria-pressed={isSelected}
+                  onClick={() => {
+                    setGpuPreferences(prev =>
+                      prev.includes(gt.type)
+                        ? prev.filter(pref => pref !== gt.type)
+                        : [...prev, gt.type],
+                    )
+                  }}
+                  className={cn(
+                    'flex items-center gap-2 px-3 py-1.5 rounded-lg border text-sm transition-colors',
+                    isSelected
+                      ? 'border-purple-500 bg-purple-500/10 text-purple-400'
+                      : 'border-border bg-secondary text-muted-foreground hover:text-foreground',
+                  )}
+                >
+                  <Zap className="w-3.5 h-3.5" />
+                  {gt.type}
+                  <span className="text-xs opacity-70">{t('gpuReservations.form.fields.gpuTypeAvailability', { available: gt.available, total: gt.total })}</span>
+                </button>
+              )
+            })}
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground">
+            {/* Helper copy for the multi-type selector.
+                Kept as plain English for now — a follow-up PR
+                will add i18n keys to all locale bundles once the
+                base feature lands and the UX is approved. */}
+            {gpuPreferences.length === 0
+              ? 'No type selected — any GPU will be accepted.'
+              : gpuPreferences.length === 1
+              ? '1 type accepted'
+              : `${gpuPreferences.length} types accepted`}
+          </div>
+        </div>
+      )}
+      {/* Single GPU type — show as info */}
+      {clusterGPUTypes.length === 1 && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Zap className="w-3.5 h-3.5 text-purple-400" />
+          {clusterGPUTypes[0].type}
+          <span className="text-xs">{t('gpuReservations.form.fields.singleGpuType', { available: clusterGPUTypes[0].available, total: clusterGPUTypes[0].total })}</span>
+        </div>
+      )}
+
+      {/* Additional Resource Limits */}
+      {enforceQuota && (
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="text-sm font-medium text-muted-foreground">{t('gpuReservations.form.fields.additionalLimits')}</label>
+            <button onClick={() => setExtraResources([...extraResources, { key: '', value: '' }])}
+              className="flex items-center gap-1 px-2 py-1 text-xs rounded bg-blue-500/20 text-blue-400 hover:bg-blue-500/30">
+              <Plus className="w-3 h-3" /> {t('gpuReservations.form.fields.add')}
+            </button>
+          </div>
+          {extraResources.map((r, i) => (
+            <div key={i} className="flex items-center gap-2 mb-2">
+              <select value={r.key} onChange={e => {
+                const updated = [...extraResources]
+                updated[i].key = e.target.value
+                setExtraResources(updated)
+              }} className="flex-1 px-2 py-1.5 rounded bg-secondary border border-border text-sm text-foreground">
+                <option value="">{t('gpuReservations.form.fields.selectResource')}</option>
+                {COMMON_RESOURCE_TYPES.filter(rt => !gpuKeys.some(gk => rt.key.includes(gk))).map(rt => (
+                  <option key={rt.key} value={rt.key}>{rt.label}</option>
+                ))}
+              </select>
+              <input type="text" value={r.value} onChange={e => {
+                const updated = [...extraResources]
+                updated[i].value = e.target.value
+                setExtraResources(updated)
+              }} placeholder={t('gpuReservations.form.fields.resourcePlaceholder')} className="w-24 px-2 py-1.5 rounded bg-secondary border border-border text-sm text-foreground" />
+              <button onClick={() => setExtraResources(extraResources.filter((_, j) => j !== i))}
+                className="p-1 hover:bg-secondary rounded text-muted-foreground hover:text-red-400"
+                aria-label="Remove resource limit">
+                <Trash2 className="w-4 h-4" aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  )
+}

--- a/web/src/components/gpu/ResourceRequestFields.tsx
+++ b/web/src/components/gpu/ResourceRequestFields.tsx
@@ -2,7 +2,7 @@ import { Zap, Plus, Trash2 } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { COMMON_RESOURCE_TYPES } from '../../hooks/useMCP'
 
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
 
 interface ClusterGpuType {
   type: string

--- a/web/src/components/gpu/ScheduleSelector.tsx
+++ b/web/src/components/gpu/ScheduleSelector.tsx
@@ -1,0 +1,32 @@
+import type { TFunction } from 'i18next'
+
+interface ScheduleSelectorProps {
+  t: TFunction
+  startDate: string
+  setStartDate: (value: string) => void
+  durationHours: string
+  setDurationHours: (value: string) => void
+}
+
+/**
+ * Start-date and duration fields for the reservation form. Extracted
+ * from ReservationFormModal.tsx (#21613) to reduce the parent
+ * component's line count.
+ */
+export function ScheduleSelector({ t, startDate, setStartDate, durationHours, setDurationHours }: ScheduleSelectorProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.startDateLabel')}</label>
+        <input type="date" value={startDate} onChange={e => setStartDate(e.target.value)}
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground" />
+      </div>
+      <div>
+        <label className="block text-sm font-medium text-muted-foreground mb-1">{t('gpuReservations.form.fields.durationLabel')}</label>
+        <input type="number" value={durationHours} onChange={e => setDurationHours(e.target.value)}
+          min="1" placeholder={t('gpuReservations.form.fields.durationPlaceholder')}
+          className="w-full px-3 py-2 rounded-lg bg-secondary border border-border text-foreground placeholder:text-muted-foreground" />
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/gpu/ScheduleSelector.tsx
+++ b/web/src/components/gpu/ScheduleSelector.tsx
@@ -1,4 +1,4 @@
-type TranslateFn = (key: string, options?: Record<string, unknown>) => string
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
 
 interface ScheduleSelectorProps {
   t: TranslateFn

--- a/web/src/components/gpu/ScheduleSelector.tsx
+++ b/web/src/components/gpu/ScheduleSelector.tsx
@@ -1,7 +1,7 @@
-import type { TFunction } from 'i18next'
+type TranslateFn = (key: string, options?: Record<string, unknown>) => string
 
 interface ScheduleSelectorProps {
-  t: TFunction
+  t: TranslateFn
   startDate: string
   setStartDate: (value: string) => void
   durationHours: string

--- a/web/src/components/gpu/useReservationFormState.ts
+++ b/web/src/components/gpu/useReservationFormState.ts
@@ -1,0 +1,414 @@
+import { useState, useMemo } from 'react'
+import { useTranslation } from 'react-i18next'
+import {
+  useNamespaces,
+  createOrUpdateResourceQuota,
+  deleteResourceQuota,
+} from '../../hooks/useMCP'
+import type { GPUNode } from '../../hooks/useMCP'
+import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInput } from '../../hooks/useGPUReservations'
+import { normalizeGpuTypes } from '../../hooks/useGPUReservations'
+import type { GPUClusterInfo } from './ReservationFormModal'
+
+// GPU resource keys used to identify GPU quotas
+const GPU_KEYS = ['nvidia.com/gpu', 'amd.com/gpu', 'gpu.intel.com/i915']
+
+/** Maximum length of the sanitized title segment in a generated quota name. */
+const QUOTA_NAME_TITLE_MAX_LEN = 40
+
+/** Default reservation duration in hours when the field is left blank. */
+const DEFAULT_RESERVATION_DURATION_HOURS = 24
+
+const FILTERED_NS_PREFIXES = ['openshift-', 'kube-']
+const FILTERED_NS_EXACT = ['default', 'kube-system', 'kube-public', 'kube-node-lease']
+
+/**
+ * Normalize any accepted start-date representation to the `YYYY-MM-DD`
+ * format required by `<input type="date">`. Accepts either a bare date
+ * (`2024-01-15`) or a full RFC 3339 timestamp (`2024-01-15T09:00:00Z`)
+ * and returns just the date portion. Empty input returns an empty string.
+ */
+function toDateInputValue(value: string | undefined | null): string {
+  if (!value) return ''
+  // Both `YYYY-MM-DD` and `YYYY-MM-DDT...` share the same date prefix.
+  return value.split('T')[0]
+}
+
+/**
+ * Convert a `<input type="date">` value (`YYYY-MM-DD`) to an RFC 3339
+ * timestamp representing local midnight with an explicit timezone offset
+ * (`YYYY-MM-DDT00:00:00±HH:MM`). If the input is already an RFC 3339
+ * timestamp, it is returned as-is.
+ *
+ * The local-offset form (rather than `Z`) prevents an off-by-one-day
+ * display in calendar views: downstream code parses `start_date` with
+ * `new Date(...)` and normalizes via `setHours(0, 0, 0, 0)`, which
+ * shifts a hard-coded UTC midnight back a day for any user west of UTC
+ * (e.g. Jan 15 00:00 UTC → Jan 14 in PST). Encoding the user's local
+ * offset keeps the calendar day stable across the wire.
+ */
+function toRFC3339StartDate(value: string): string {
+  if (!value) return ''
+  if (value.includes('T')) return value
+
+  // Date.getTimezoneOffset returns minutes WEST of UTC (positive for the
+  // Americas, negative for Europe/Asia), so flip the sign to get the
+  // signed offset that goes into the RFC 3339 string.
+  const offsetMinutesWestOfUTC = new Date().getTimezoneOffset()
+  const totalOffsetMinutes = -offsetMinutesWestOfUTC
+  const offsetSign = totalOffsetMinutes >= 0 ? '+' : '-'
+  const absoluteOffsetMinutes = Math.abs(totalOffsetMinutes)
+  const minutesPerHour = 60
+  const offsetHours = String(Math.floor(absoluteOffsetMinutes / minutesPerHour)).padStart(2, '0')
+  const offsetMinutes = String(absoluteOffsetMinutes % minutesPerHour).padStart(2, '0')
+
+  return `${value}T00:00:00${offsetSign}${offsetHours}:${offsetMinutes}`
+}
+
+/**
+ * Derive the Kubernetes ResourceQuota name from a reservation title.
+ * Exported as a local helper so both the current-title quota name and
+ * the ORIGINAL-title quota name (used for cleanup on rename) are
+ * computed identically.
+ */
+function deriveQuotaName(title: string): string {
+  if (!title) return ''
+  return `gpu-${title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, QUOTA_NAME_TITLE_MAX_LEN)}`
+}
+
+export interface UseReservationFormStateOptions {
+  editingReservation: GPUReservation | null
+  gpuClusters: GPUClusterInfo[]
+  allNodes: GPUNode[]
+  prefillDate?: string | null
+  forceLive?: boolean
+  knownNamespacesByCluster?: Record<string, string[]>
+  onSave: (input: CreateGPUReservationInput | UpdateGPUReservationInput) => Promise<string | void>
+  onActivate: (id: string) => Promise<void>
+  onSaved: () => void
+  onError: (msg: string) => void
+  onClose: () => void
+}
+
+/**
+ * Encapsulates all form field state, derived cluster/namespace/GPU-type
+ * data, dirty-checking, and the save/quota-provisioning workflow for
+ * ReservationFormModal. Extracted from ReservationFormModal.tsx (#21613)
+ * to reduce the component's hook count and line count.
+ */
+export function useReservationFormState({
+  editingReservation,
+  gpuClusters,
+  allNodes,
+  prefillDate,
+  forceLive,
+  knownNamespacesByCluster,
+  onSave,
+  onActivate,
+  onSaved,
+  onError,
+  onClose,
+}: UseReservationFormStateOptions) {
+  const { t } = useTranslation(['cards', 'common'])
+  const [cluster, setCluster] = useState(editingReservation?.cluster || '')
+  // namespace value and "create new" toggle always change together → merged into
+  // a single state object so each user interaction causes only one re-render.
+  const [nsField, setNsField] = useState<{ value: string; isNew: boolean }>({
+    value: editingReservation?.namespace || '',
+    isNew: false,
+  })
+  const namespace = nsField.value
+  const isNewNamespace = nsField.isNew
+  const [title, setTitle] = useState(editingReservation?.title || '')
+  const [description, setDescription] = useState(editingReservation?.description || '')
+  const [gpuCount, setGpuCount] = useState(editingReservation ? String(editingReservation.gpu_count) : '')
+  // Multi-type preference. `gpuPreferences` holds the list of
+  // acceptable GPU types for this reservation — an empty array is
+  // "no preference" (any type is acceptable), a one-element array is
+  // the legacy single-type behaviour, and two or more entries implement
+  // the multi-type-preference feature requested by
+  // @MikeSpreitzer. Seeded from both the legacy `gpu_type` string and
+  // the new `gpu_types` array via `normalizeGpuTypes` so edits of
+  // existing pre-migration reservations keep their type.
+  const [gpuPreferences, setGpuPreferences] = useState<string[]>(() => normalizeGpuTypes(editingReservation))
+  const [startDate, setStartDate] = useState(
+    toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
+  )
+  const [durationHours, setDurationHours] = useState(editingReservation ? String(editingReservation.duration_hours) : '')
+  const [notes, setNotes] = useState(editingReservation?.notes || '')
+  const enforceQuota = true
+  const [extraResources, setExtraResources] = useState<Array<{ key: string; value: string }>>([])
+  const [isSaving, setIsSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
+
+  // Snapshot of the initial form state used for dirty detection. Captured
+  // once when the modal is first rendered for this editing target so the
+  // unsaved-changes dialog compares against the ORIGINAL values (not the
+  // current values, which would always look "clean").
+  const initialSnapshot = useMemo(
+    () => ({
+      cluster: editingReservation?.cluster || '',
+      namespace: editingReservation?.namespace || '',
+      title: editingReservation?.title || '',
+      description: editingReservation?.description || '',
+      gpuCount: editingReservation ? String(editingReservation.gpu_count) : '',
+      // Snapshot the multi-type preference list so dirty
+      // detection can see a type-only edit. Sorted so order churn
+      // does not trip a false positive.
+      gpuPreferences: [...normalizeGpuTypes(editingReservation)].sort(),
+      startDate: toDateInputValue(editingReservation?.start_date) || prefillDate || new Date().toISOString().split('T')[0],
+      durationHours: editingReservation ? String(editingReservation.duration_hours) : '',
+      notes: editingReservation?.notes || '' }),
+    // Re-snapshot only when the modal is opened for a different reservation
+    // or with a different prefill date.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [editingReservation?.id, prefillDate],
+  )
+
+  const forceClose = () => {
+    setShowDiscardConfirm(false)
+    onClose()
+  }
+
+  // Returns true if ANY user-editable field has diverged from the initial
+  // snapshot. Previously this only inspected title/description, so edits
+  // to cluster, namespace, GPU count/type, dates, duration, notes, or
+  // extra resources could be discarded without confirmation.
+  const isDirty = (): boolean => {
+    if (cluster !== initialSnapshot.cluster) return true
+    if (namespace !== initialSnapshot.namespace) return true
+    if (title !== initialSnapshot.title) return true
+    if (description !== initialSnapshot.description) return true
+    if (gpuCount !== initialSnapshot.gpuCount) return true
+    // Compare the sorted multi-type list. Order is intentionally
+    // ignored because the form renders the same set regardless of
+    // toggle order — only membership matters for dirty detection.
+    const currentGpuPrefSorted = [...gpuPreferences].sort()
+    if (currentGpuPrefSorted.length !== initialSnapshot.gpuPreferences.length) return true
+    for (let i = 0; i < currentGpuPrefSorted.length; i++) {
+      if (currentGpuPrefSorted[i] !== initialSnapshot.gpuPreferences[i]) return true
+    }
+    if (startDate !== initialSnapshot.startDate) return true
+    if (durationHours !== initialSnapshot.durationHours) return true
+    if (notes !== initialSnapshot.notes) return true
+    // extraResources always starts empty for both create and edit flows —
+    // any entry means the user added a row.
+    if (extraResources.length > 0) return true
+    return false
+  }
+
+  const handleClose = () => {
+    if (isDirty()) {
+      setShowDiscardConfirm(true)
+      return
+    }
+    onClose()
+  }
+
+  const {
+    namespaces: rawNamespaces,
+    isLoading: namespacesLoading,
+    error: namespacesError,
+    refetch: refetchNamespaces,
+  } = useNamespaces(cluster || undefined, forceLive)
+
+  // Union the hook result with namespaces from existing reservations on
+  // this cluster. Memoized to avoid re-allocating on every keystroke.
+  const mergedRawNamespaces = useMemo(() => {
+    const knownForCluster = (cluster && knownNamespacesByCluster?.[cluster]) || []
+    if (knownForCluster.length === 0) return rawNamespaces
+    return Array.from(new Set<string>([...rawNamespaces, ...knownForCluster])).sort()
+  }, [rawNamespaces, cluster, knownNamespacesByCluster])
+
+  // Filter out system namespaces from the dropdown
+  const clusterNamespaces = mergedRawNamespaces.filter(ns =>
+      !FILTERED_NS_PREFIXES.some(prefix => ns.startsWith(prefix)) &&
+      !FILTERED_NS_EXACT.includes(ns)
+    )
+
+  // Get the selected cluster's GPU info
+  const selectedClusterInfo = gpuClusters.find(c => c.name === cluster)
+  const maxGPUs = selectedClusterInfo?.availableGPUs ?? 0
+
+  // Auto-detect GPU resource key from cluster's GPU types
+  const gpuResourceKey = (() => {
+    if (!cluster) return 'limits.nvidia.com/gpu'
+    const clusterNodes = allNodes.filter(n => n.cluster === cluster)
+    const hasAMD = clusterNodes.some(n => n.gpuType.toLowerCase().includes('amd') || n.manufacturer?.toLowerCase().includes('amd'))
+    const hasIntel = clusterNodes.some(n => n.gpuType.toLowerCase().includes('intel') || n.manufacturer?.toLowerCase().includes('intel'))
+    if (hasAMD) return 'limits.amd.com/gpu'
+    if (hasIntel) return 'gpu.intel.com/i915'
+    return 'limits.nvidia.com/gpu'
+  })()
+
+  // GPU types available on selected cluster with per-type counts
+  const clusterGPUTypes = (() => {
+    if (!cluster) return [] as Array<{ type: string; total: number; available: number }>
+    const typeMap: Record<string, { total: number; allocated: number }> = {}
+    for (const n of allNodes.filter(n => n.cluster === cluster)) {
+      if (!typeMap[n.gpuType]) typeMap[n.gpuType] = { total: 0, allocated: 0 }
+      typeMap[n.gpuType].total += n.gpuCount
+      typeMap[n.gpuType].allocated += n.gpuAllocated
+    }
+    return Object.entries(typeMap).map(([type, d]) => ({
+      type,
+      total: d.total,
+      available: d.total - d.allocated }))
+  })()
+
+  // Auto-generate quota name from title
+  const quotaName = deriveQuotaName(title)
+  // Quota name computed from the ORIGINAL title, used to clean up a
+  // stale ResourceQuota if the user renamed the reservation.
+  const originalQuotaName = deriveQuotaName(editingReservation?.title || '')
+
+  const handleSave = async () => {
+    const count = parseInt(gpuCount)
+    // For edits, capacity validation must account for the GPUs the current
+    // reservation already holds: max allowed = availableGPUs + originalCount.
+    // Without this, an edit could request more GPUs than the cluster has.
+    const originalCount = editingReservation?.gpu_count ?? 0
+    const sameClusterAsOriginal = editingReservation ? cluster === editingReservation.cluster : true
+    const capacityCeiling = editingReservation && sameClusterAsOriginal
+      ? maxGPUs + originalCount
+      : maxGPUs
+    const validationError = !cluster
+      ? t('gpuReservations.form.errors.selectCluster')
+      : !namespace
+      ? t('gpuReservations.form.errors.selectNamespace')
+      : !title
+      ? t('gpuReservations.form.errors.titleRequired')
+      : !count || count < 1
+      ? t('gpuReservations.form.errors.gpuCountMin')
+      : count > capacityCeiling
+      ? t('gpuReservations.form.errors.gpuCountMax', { max: capacityCeiling, cluster })
+      : null
+    setError(validationError)
+    if (validationError) return
+
+    setIsSaving(true)
+    try {
+      let reservationId: string | void
+      // Backend requires RFC 3339; <input type="date"> only emits YYYY-MM-DD,
+      // so normalize to midnight UTC before sending.
+      const rfc3339StartDate = toRFC3339StartDate(startDate)
+      // Canonical list of accepted GPU types. An empty list is
+      // "no preference" (server-side: any GPU acceptable). If the user
+      // left every type toggled off but the cluster only has one type,
+      // fall back to that single type so the back-compat path with
+      // older clusters stays unchanged.
+      const gpuTypesList =
+        gpuPreferences.length > 0
+          ? gpuPreferences
+          : clusterGPUTypes.length === 1 && clusterGPUTypes[0]?.type
+          ? [clusterGPUTypes[0].type]
+          : []
+      // Legacy singular mirror — kept for pre-multitype clients still
+      // reading `gpu_type`. See CLAUDE.md back-compat rule.
+      const primaryGpuType = gpuTypesList[0] || ''
+      const sharedInput = {
+        title,
+        description,
+        cluster,
+        namespace,
+        gpu_count: count,
+        gpu_type: primaryGpuType,
+        gpu_types: gpuTypesList,
+        start_date: rfc3339StartDate,
+        duration_hours: parseInt(durationHours) || DEFAULT_RESERVATION_DURATION_HOURS,
+        notes,
+        quota_enforced: enforceQuota,
+        quota_name: enforceQuota ? quotaName : '',
+        max_cluster_gpus: selectedClusterInfo?.totalGPUs }
+      reservationId = editingReservation
+        ? await onSave(sharedInput as UpdateGPUReservationInput)
+        : await onSave(sharedInput as CreateGPUReservationInput)
+
+      // Create K8s ResourceQuota (auto-creates namespace if needed)
+      if (enforceQuota) {
+        try {
+          const hard: Record<string, string> = {
+            [gpuResourceKey]: String(count) }
+          for (const r of extraResources) {
+            if (r.key && r.value) hard[r.key] = r.value
+          }
+          // If the reservation was renamed, the quota name (which is
+          // derived from the title) will be different. Delete the old
+          // quota first so it does not linger orphaned in the namespace.
+          if (
+            editingReservation &&
+            originalQuotaName &&
+            originalQuotaName !== quotaName &&
+            editingReservation.cluster &&
+            editingReservation.namespace
+          ) {
+            try {
+              await deleteResourceQuota(
+                editingReservation.cluster,
+                editingReservation.namespace,
+                originalQuotaName,
+              )
+            } catch {
+              // Non-fatal: old quota may already be gone (e.g. 404).
+              // Proceed with creating the renamed quota regardless.
+            }
+          }
+          await createOrUpdateResourceQuota({ cluster, namespace, name: quotaName, hard, ensure_namespace: isNewNamespace })
+          // Quota enforced successfully — activate the reservation
+          const id = reservationId || editingReservation?.id
+          if (id) {
+            try { await onActivate(id) } catch { /* non-fatal */ }
+          }
+        } catch {
+          // Non-fatal: reservation is saved, but quota enforcement failed — stays pending
+          onError(t('gpuReservations.form.errors.quotaFailed'))
+        }
+      }
+
+      onSaved()
+      onClose()
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : t('gpuReservations.form.errors.saveFailed')
+      setError(msg)
+      onError(msg)
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  return {
+    t,
+    cluster, setCluster,
+    namespace, isNewNamespace, setNsField,
+    title, setTitle,
+    description, setDescription,
+    gpuCount, setGpuCount,
+    gpuPreferences, setGpuPreferences,
+    startDate, setStartDate,
+    durationHours, setDurationHours,
+    notes, setNotes,
+    enforceQuota,
+    extraResources, setExtraResources,
+    isSaving,
+    error,
+    showDiscardConfirm, setShowDiscardConfirm,
+    forceClose,
+    handleClose,
+    handleSave,
+    namespacesLoading,
+    namespacesError,
+    refetchNamespaces,
+    clusterNamespaces,
+    selectedClusterInfo,
+    maxGPUs,
+    gpuResourceKey,
+    clusterGPUTypes,
+    quotaName,
+    GPU_KEYS,
+  }
+}

--- a/web/src/components/gpu/useReservationFormState.ts
+++ b/web/src/components/gpu/useReservationFormState.ts
@@ -10,6 +10,8 @@ import type { GPUReservation, CreateGPUReservationInput, UpdateGPUReservationInp
 import { normalizeGpuTypes } from '../../hooks/useGPUReservations'
 import type { GPUClusterInfo } from './ReservationFormModal'
 
+type TranslateFn = (key: string, options?: string | Record<string, unknown>) => string
+
 // GPU resource keys used to identify GPU quotas
 const GPU_KEYS = ['nvidia.com/gpu', 'amd.com/gpu', 'gpu.intel.com/i915']
 
@@ -113,7 +115,8 @@ export function useReservationFormState({
   onError,
   onClose,
 }: UseReservationFormStateOptions) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tTyped } = useTranslation(['cards', 'common'])
+  const t = tTyped as unknown as TranslateFn
   const [cluster, setCluster] = useState(editingReservation?.cluster || '')
   // namespace value and "create new" toggle always change together → merged into
   // a single state object so each user interaction causes only one re-render.


### PR DESCRIPTION
Fixes #21505
Fixes #21613
Fixes #21617

## What

Splits large GPU and cluster components into focused hooks and sub-components, following the pattern already established by `useGPUReservationForm.ts` / `useGPUDashboardCards.ts` (#21717).

| File | Before | After |
|---|---|---|
| `web/src/components/clusters/Clusters.tsx` | 599 lines | 411 lines |
| `web/src/components/clusters/components/NamespaceResources.tsx` | 660 lines | 494 lines |
| `web/src/components/clusters/components/GPUDetailModal.tsx` | 506 lines | 197 lines |
| `web/src/components/gpu/ReservationFormModal.tsx` | 734 lines | 237 lines |

### New files

- `useClusterViewState.ts` — filter/sort/layout-mode state + URL sync (extracted from `Clusters.tsx`)
- `useClusterMutations.ts` — rename/remove-cluster network calls (extracted from `Clusters.tsx`)
- `clusterStatValues.ts` — pure `StatsOverview` value mapping (extracted from `Clusters.tsx`)
- `namespaceResourceUtils.ts` — `buildAllResources`, `getStatusBgColor` (extracted from `NamespaceResources.tsx`)
- `ResourceTypeAccordion.tsx`, `SimpleResourceRow.tsx` — generic accordion/row components replacing 8 near-identical blocks (extracted from `NamespaceResources.tsx`)
- `gpuDetailUtils.ts` — pure GPU aggregation calculations (extracted from `GPUDetailModal.tsx`)
- `GPUSpecsPanel.tsx`, `GPUUtilizationList.tsx`, `GPUNodesTable.tsx` — presentational sub-components (extracted from `GPUDetailModal.tsx`)
- `useReservationFormState.ts` — all form field state, validation, and the save/quota-provisioning workflow (extracted from `ReservationFormModal.tsx`)
- `ClusterPicker.tsx`, `ResourceRequestFields.tsx`, `ScheduleSelector.tsx` — form field sub-components (extracted from `ReservationFormModal.tsx`)

No behavior changes — all logic preserved verbatim in the extracted modules.

## Issue status

- #21505 (umbrella): the 5 files listed are now split — `GPUReservations.tsx` was already split in #21717; the remaining 4 files are split in this PR.
- #21612 (`GPUReservations.tsx`): already closed as completed via #21717 — no action needed here.
- #21613 (`ReservationFormModal` + `GPUDetailModal`): fixed in this PR.
- #21617 (`Clusters.tsx` + `NamespaceResources.tsx`): fixed in this PR.
- #21616 (`CardWrapper` + `ConsoleOfflineDetectionCard`): **not included** — left open. `CardWrapper` is used by 150+ cards and the issue explicitly requires running `@ui-compliance-test` and byte-for-byte behavior verification before merging, which needs a running app instance. Deferred to a focused follow-up PR to keep this change reviewable and reduce blast radius. A comment with this rationale has been added to #21616.

## Note on prior attempt

A previous PR from this branch (#21518) was closed due to repeated CI build/lint failures. This PR is a fresh implementation from `main`; sizing and scope were kept smaller per-file to reduce risk, and multiple rounds of manual review (import/usage audits, brace-balance checks, field-name cross-checks against the actual TS interfaces) were done to catch the class of errors that broke the previous attempt. CI will still validate build/lint/tests on this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
