### PR TITLE
🌱 Split oversized hooks & lib-layer files under max-lines limit

### DIFF
--- a/web/src/hooks/mcp/compute.ts
+++ b/web/src/hooks/mcp/compute.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { fetchSSE } from '../../lib/sseClient'
 import { reportAgentDataSuccess, isAgentUnavailable } from '../useLocalAgent'
@@ -12,7 +11,11 @@ import { MCP_EXTENDED_TIMEOUT_MS, MCP_HOOK_TIMEOUT_MS, POLL_INTERVAL_FAST_MS, LO
 import { classifyError, type ClusterErrorType } from '../../lib/errorClassifier'
 import { isInClusterMode } from '../useBackendHealth'
 import { getClusterModeBaseUrl, isClusterModeBackend } from '../../lib/cache/fetcherUtils'
-import type { GPUNode, NodeInfo, NVIDIAOperatorStatus } from './types'
+import type { GPUNode, NodeInfo } from './types'
+import { getDemoGPUNodes, getDemoNodes } from './compute/demoData'
+
+export { useNVIDIAOperators } from './compute/nvidia'
+
 
 // GPU fetch retry configuration
 const GPU_FETCH_MAX_RETRIES = 2
@@ -616,199 +619,6 @@ export function useNodes(cluster?: string) {
   // multi-cluster drill-down can explain an empty list with "lacks
   // list-nodes RBAC on cluster X" rather than a generic warning.
   return { nodes, isLoading, error, clusterErrors, refetch }
-}
-
-// Hook to get NVIDIA operator status
-export function useNVIDIAOperators(cluster?: string) {
-  const [operators, setOperators] = useState<NVIDIAOperatorStatus[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-
-  const refetch = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const params: Record<string, string> = {}
-      if (cluster) params.cluster = cluster
-
-      const agentBaseUrl = getClusterModeBaseUrl()
-      if (!agentBaseUrl) {
-        setOperators([])
-        setError(null)
-        return
-      }
-
-      // Try SSE streaming first
-      const token = await getStoredAuthToken()
-      if ((token && token !== 'demo-token') || isInClusterMode()) {
-        try {
-          const accumulated: NVIDIAOperatorStatus[] = []
-          const result = await fetchSSE<NVIDIAOperatorStatus>({
-            url: `${agentBaseUrl}/nvidia-operators/stream`,
-            params,
-            itemsKey: 'operators',
-            onClusterData: (_clusterName, items) => {
-              accumulated.push(...items)
-              setOperators([...accumulated])
-              setIsLoading(false)
-            },
-          })
-          setOperators(result)
-          setError(null)
-          setIsLoading(false)
-          return
-        } catch {
-          // SSE failed, fall through to REST
-        }
-      }
-
-      // REST fallback
-      const urlParams = new URLSearchParams()
-      if (cluster) urlParams.append('cluster', cluster)
-      const resp = await agentFetch(`${agentBaseUrl}/nvidia-operators?${urlParams}`)
-      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
-      const data = await resp.json()
-      if (data.operators) {
-        setOperators(data.operators)
-      } else if (data.operator) {
-        setOperators([data.operator])
-      } else {
-        setOperators([])
-      }
-      setError(null)
-    } catch {
-      setError(null)
-      setOperators([])
-    } finally {
-      setIsLoading(false)
-    }
-  }, [cluster])
-
-  useEffect(() => {
-    refetch()
-  }, [refetch])
-
-  return { operators, isLoading, error, refetch }
-}
-
-// Demo data functions (not exported)
-
-function getDemoGPUNodes(): GPUNode[] {
-  return [
-    // vllm-gpu-cluster - Large GPU cluster for AI/ML workloads
-    { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU' },
-    { name: 'gpu-node-2', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 8, acceleratorType: 'GPU' },
-    { name: 'gpu-node-3', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' },
-    { name: 'gpu-node-4', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA H100', gpuCount: 8, gpuAllocated: 7, acceleratorType: 'GPU' },
-    // EKS - Production ML inference
-    { name: 'eks-gpu-1', cluster: 'eks-prod-us-east-1', gpuType: 'NVIDIA A10G', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'GPU' },
-    { name: 'eks-gpu-2', cluster: 'eks-prod-us-east-1', gpuType: 'NVIDIA A10G', gpuCount: 4, gpuAllocated: 4, acceleratorType: 'GPU' },
-    // GKE - Training workloads with GPUs and TPUs
-    { name: 'gke-gpu-pool-1', cluster: 'gke-staging', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
-    { name: 'gke-gpu-pool-2', cluster: 'gke-staging', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 2, acceleratorType: 'GPU' },
-    // GKE - TPU nodes (Google Cloud)
-    { name: 'gke-tpu-node-1', cluster: 'gke-staging', gpuType: 'Google TPU v4', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'TPU', manufacturer: 'Google' },
-    { name: 'gke-tpu-node-2', cluster: 'gke-staging', gpuType: 'Google TPU v5e', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'TPU', manufacturer: 'Google' },
-    // AKS - Dev/test GPUs
-    { name: 'aks-gpu-node', cluster: 'aks-dev-westeu', gpuType: 'NVIDIA V100', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
-    // OpenShift - Enterprise ML
-    { name: 'ocp-gpu-worker-1', cluster: 'openshift-prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 4, acceleratorType: 'GPU' },
-    { name: 'ocp-gpu-worker-2', cluster: 'openshift-prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 2, acceleratorType: 'GPU' },
-    // Intel Gaudi (AI accelerator, classified as GPU)
-    { name: 'gaudi-node-1', cluster: 'openshift-prod', gpuType: 'Intel Gaudi2', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU', manufacturer: 'Intel' },
-    // IBM AIU nodes (on OCI cluster)
-    { name: 'oci-aiu-node-1', cluster: 'oci-oke-phoenix', gpuType: 'IBM AIU', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'AIU', manufacturer: 'IBM' },
-    { name: 'oci-aiu-node-2', cluster: 'oci-oke-phoenix', gpuType: 'IBM AIU', gpuCount: 4, gpuAllocated: 2, acceleratorType: 'AIU', manufacturer: 'IBM' },
-    // Intel XPU nodes (on AKS cluster)
-    { name: 'aks-xpu-node-1', cluster: 'aks-dev-westeu', gpuType: 'Intel Data Center GPU Max', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'XPU', manufacturer: 'Intel' },
-    { name: 'aks-xpu-node-2', cluster: 'aks-dev-westeu', gpuType: 'Intel Data Center GPU Flex', gpuCount: 8, gpuAllocated: 5, acceleratorType: 'XPU', manufacturer: 'Intel' },
-    // OCI - Oracle GPU shapes
-    { name: 'oke-gpu-node', cluster: 'oci-oke-phoenix', gpuType: 'NVIDIA A10', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'GPU' },
-    // Alibaba - China region ML
-    { name: 'ack-gpu-worker', cluster: 'alibaba-ack-shanghai', gpuType: 'NVIDIA V100', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU' },
-    // Rancher - Managed GPU pool
-    { name: 'rancher-gpu-1', cluster: 'rancher-mgmt', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
-  ]
-}
-
-function getDemoNodes(): NodeInfo[] {
-  return [
-    {
-      name: 'node-1',
-      cluster: 'prod-east',
-      status: 'Ready',
-      roles: ['control-plane', 'master'],
-      internalIP: '10.0.1.10',
-      kubeletVersion: 'v1.28.4',
-      containerRuntime: 'containerd://1.6.24',
-      os: 'Ubuntu 22.04.3 LTS',
-      architecture: 'amd64',
-      cpuCapacity: '8',
-      memoryCapacity: '32Gi',
-      storageCapacity: '200Gi',
-      podCapacity: '110',
-      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
-      labels: { 'node-role.kubernetes.io/control-plane': '' },
-      taints: ['node-role.kubernetes.io/control-plane:NoSchedule'],
-      age: '45d',
-      unschedulable: false,
-    },
-    {
-      name: 'node-2',
-      cluster: 'prod-east',
-      status: 'Ready',
-      roles: ['worker'],
-      internalIP: '10.0.1.11',
-      kubeletVersion: 'v1.28.4',
-      containerRuntime: 'containerd://1.6.24',
-      os: 'Ubuntu 22.04.3 LTS',
-      architecture: 'amd64',
-      cpuCapacity: '16',
-      memoryCapacity: '64Gi',
-      storageCapacity: '500Gi',
-      podCapacity: '110',
-      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
-      labels: { 'node.kubernetes.io/instance-type': 'm5.4xlarge' },
-      age: '45d',
-      unschedulable: false,
-    },
-    {
-      name: 'gpu-node-1',
-      cluster: 'vllm-d',
-      status: 'Ready',
-      roles: ['worker'],
-      internalIP: '10.0.2.20',
-      kubeletVersion: 'v1.28.4',
-      containerRuntime: 'containerd://1.6.24',
-      os: 'Ubuntu 22.04.3 LTS',
-      architecture: 'amd64',
-      cpuCapacity: '32',
-      memoryCapacity: '128Gi',
-      storageCapacity: '1Ti',
-      podCapacity: '110',
-      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
-      labels: { 'nvidia.com/gpu': 'true', 'node.kubernetes.io/instance-type': 'p3.8xlarge' },
-      age: '30d',
-      unschedulable: false,
-    },
-    {
-      name: 'kind-control-plane',
-      cluster: 'kind-local',
-      status: 'Ready',
-      roles: ['control-plane'],
-      internalIP: '172.18.0.2',
-      kubeletVersion: 'v1.27.3',
-      containerRuntime: 'containerd://1.7.1',
-      os: 'Ubuntu 22.04.2 LTS',
-      architecture: 'amd64',
-      cpuCapacity: '4',
-      memoryCapacity: '8Gi',
-      storageCapacity: '50Gi',
-      podCapacity: '110',
-      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
-      age: '7d',
-      unschedulable: false,
-    },
-  ]
 }
 
 export const __computeTestables = {

--- a/web/src/hooks/mcp/compute/demoData.ts
+++ b/web/src/hooks/mcp/compute/demoData.ts
@@ -1,0 +1,125 @@
+// Static demo/fallback data for GPU nodes and compute nodes. Extracted from
+// compute.ts so the hook implementation file stays under the max-lines limit
+// (tracked by #15790, split by #21606). No behaviour change — same data as
+// before, just moved to a sibling module.
+
+import type { GPUNode, NodeInfo } from '../types'
+
+export function getDemoGPUNodes(): GPUNode[] {
+  return [
+    // vllm-gpu-cluster - Large GPU cluster for AI/ML workloads
+    { name: 'gpu-node-1', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU' },
+    { name: 'gpu-node-2', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 8, acceleratorType: 'GPU' },
+    { name: 'gpu-node-3', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA A100', gpuCount: 8, gpuAllocated: 4, acceleratorType: 'GPU' },
+    { name: 'gpu-node-4', cluster: 'vllm-gpu-cluster', gpuType: 'NVIDIA H100', gpuCount: 8, gpuAllocated: 7, acceleratorType: 'GPU' },
+    // EKS - Production ML inference
+    { name: 'eks-gpu-1', cluster: 'eks-prod-us-east-1', gpuType: 'NVIDIA A10G', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'GPU' },
+    { name: 'eks-gpu-2', cluster: 'eks-prod-us-east-1', gpuType: 'NVIDIA A10G', gpuCount: 4, gpuAllocated: 4, acceleratorType: 'GPU' },
+    // GKE - Training workloads with GPUs and TPUs
+    { name: 'gke-gpu-pool-1', cluster: 'gke-staging', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
+    { name: 'gke-gpu-pool-2', cluster: 'gke-staging', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 2, acceleratorType: 'GPU' },
+    // GKE - TPU nodes (Google Cloud)
+    { name: 'gke-tpu-node-1', cluster: 'gke-staging', gpuType: 'Google TPU v4', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'TPU', manufacturer: 'Google' },
+    { name: 'gke-tpu-node-2', cluster: 'gke-staging', gpuType: 'Google TPU v5e', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'TPU', manufacturer: 'Google' },
+    // AKS - Dev/test GPUs
+    { name: 'aks-gpu-node', cluster: 'aks-dev-westeu', gpuType: 'NVIDIA V100', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
+    // OpenShift - Enterprise ML
+    { name: 'ocp-gpu-worker-1', cluster: 'openshift-prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 4, acceleratorType: 'GPU' },
+    { name: 'ocp-gpu-worker-2', cluster: 'openshift-prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 2, acceleratorType: 'GPU' },
+    // Intel Gaudi (AI accelerator, classified as GPU)
+    { name: 'gaudi-node-1', cluster: 'openshift-prod', gpuType: 'Intel Gaudi2', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU', manufacturer: 'Intel' },
+    // IBM AIU nodes (on OCI cluster)
+    { name: 'oci-aiu-node-1', cluster: 'oci-oke-phoenix', gpuType: 'IBM AIU', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'AIU', manufacturer: 'IBM' },
+    { name: 'oci-aiu-node-2', cluster: 'oci-oke-phoenix', gpuType: 'IBM AIU', gpuCount: 4, gpuAllocated: 2, acceleratorType: 'AIU', manufacturer: 'IBM' },
+    // Intel XPU nodes (on AKS cluster)
+    { name: 'aks-xpu-node-1', cluster: 'aks-dev-westeu', gpuType: 'Intel Data Center GPU Max', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'XPU', manufacturer: 'Intel' },
+    { name: 'aks-xpu-node-2', cluster: 'aks-dev-westeu', gpuType: 'Intel Data Center GPU Flex', gpuCount: 8, gpuAllocated: 5, acceleratorType: 'XPU', manufacturer: 'Intel' },
+    // OCI - Oracle GPU shapes
+    { name: 'oke-gpu-node', cluster: 'oci-oke-phoenix', gpuType: 'NVIDIA A10', gpuCount: 4, gpuAllocated: 3, acceleratorType: 'GPU' },
+    // Alibaba - China region ML
+    { name: 'ack-gpu-worker', cluster: 'alibaba-ack-shanghai', gpuType: 'NVIDIA V100', gpuCount: 8, gpuAllocated: 6, acceleratorType: 'GPU' },
+    // Rancher - Managed GPU pool
+    { name: 'rancher-gpu-1', cluster: 'rancher-mgmt', gpuType: 'NVIDIA T4', gpuCount: 2, gpuAllocated: 1, acceleratorType: 'GPU' },
+  ]
+}
+
+export function getDemoNodes(): NodeInfo[] {
+  return [
+    {
+      name: 'node-1',
+      cluster: 'prod-east',
+      status: 'Ready',
+      roles: ['control-plane', 'master'],
+      internalIP: '10.0.1.10',
+      kubeletVersion: 'v1.28.4',
+      containerRuntime: 'containerd://1.6.24',
+      os: 'Ubuntu 22.04.3 LTS',
+      architecture: 'amd64',
+      cpuCapacity: '8',
+      memoryCapacity: '32Gi',
+      storageCapacity: '200Gi',
+      podCapacity: '110',
+      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
+      labels: { 'node-role.kubernetes.io/control-plane': '' },
+      taints: ['node-role.kubernetes.io/control-plane:NoSchedule'],
+      age: '45d',
+      unschedulable: false,
+    },
+    {
+      name: 'node-2',
+      cluster: 'prod-east',
+      status: 'Ready',
+      roles: ['worker'],
+      internalIP: '10.0.1.11',
+      kubeletVersion: 'v1.28.4',
+      containerRuntime: 'containerd://1.6.24',
+      os: 'Ubuntu 22.04.3 LTS',
+      architecture: 'amd64',
+      cpuCapacity: '16',
+      memoryCapacity: '64Gi',
+      storageCapacity: '500Gi',
+      podCapacity: '110',
+      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
+      labels: { 'node.kubernetes.io/instance-type': 'm5.4xlarge' },
+      age: '45d',
+      unschedulable: false,
+    },
+    {
+      name: 'gpu-node-1',
+      cluster: 'vllm-d',
+      status: 'Ready',
+      roles: ['worker'],
+      internalIP: '10.0.2.20',
+      kubeletVersion: 'v1.28.4',
+      containerRuntime: 'containerd://1.6.24',
+      os: 'Ubuntu 22.04.3 LTS',
+      architecture: 'amd64',
+      cpuCapacity: '32',
+      memoryCapacity: '128Gi',
+      storageCapacity: '1Ti',
+      podCapacity: '110',
+      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
+      labels: { 'nvidia.com/gpu': 'true', 'node.kubernetes.io/instance-type': 'p3.8xlarge' },
+      age: '30d',
+      unschedulable: false,
+    },
+    {
+      name: 'kind-control-plane',
+      cluster: 'kind-local',
+      status: 'Ready',
+      roles: ['control-plane'],
+      internalIP: '172.18.0.2',
+      kubeletVersion: 'v1.27.3',
+      containerRuntime: 'containerd://1.7.1',
+      os: 'Ubuntu 22.04.2 LTS',
+      architecture: 'amd64',
+      cpuCapacity: '4',
+      memoryCapacity: '8Gi',
+      storageCapacity: '50Gi',
+      podCapacity: '110',
+      conditions: [{ type: 'Ready', status: 'True', reason: 'KubeletReady', message: 'kubelet is posting ready status' }],
+      age: '7d',
+      unschedulable: false,
+    },
+  ]
+}

--- a/web/src/hooks/mcp/compute/nvidia.ts
+++ b/web/src/hooks/mcp/compute/nvidia.ts
@@ -1,0 +1,84 @@
+// useNVIDIAOperators hook extracted from compute.ts so the hook
+// implementation file stays under the max-lines limit (tracked by #15790,
+// split by #21606). No behaviour change — this is the same hook that
+// previously lived in compute.ts, re-exported from there for backward
+// compatibility.
+
+import { useState, useEffect, useCallback } from 'react'
+import { fetchSSE } from '../../../lib/sseClient'
+import { getStoredAuthToken } from '../../../lib/authToken'
+import { agentFetch } from '../shared'
+import { isInClusterMode } from '../../useBackendHealth'
+import { getClusterModeBaseUrl } from '../../../lib/cache/fetcherUtils'
+import type { NVIDIAOperatorStatus } from '../types'
+
+export function useNVIDIAOperators(cluster?: string) {
+  const [operators, setOperators] = useState<NVIDIAOperatorStatus[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true)
+    try {
+      const params: Record<string, string> = {}
+      if (cluster) params.cluster = cluster
+
+      const agentBaseUrl = getClusterModeBaseUrl()
+      if (!agentBaseUrl) {
+        setOperators([])
+        setError(null)
+        return
+      }
+
+      // Try SSE streaming first
+      const token = await getStoredAuthToken()
+      if ((token && token !== 'demo-token') || isInClusterMode()) {
+        try {
+          const accumulated: NVIDIAOperatorStatus[] = []
+          const result = await fetchSSE<NVIDIAOperatorStatus>({
+            url: `${agentBaseUrl}/nvidia-operators/stream`,
+            params,
+            itemsKey: 'operators',
+            onClusterData: (_clusterName, items) => {
+              accumulated.push(...items)
+              setOperators([...accumulated])
+              setIsLoading(false)
+            },
+          })
+          setOperators(result)
+          setError(null)
+          setIsLoading(false)
+          return
+        } catch {
+          // SSE failed, fall through to REST
+        }
+      }
+
+      // REST fallback
+      const urlParams = new URLSearchParams()
+      if (cluster) urlParams.append('cluster', cluster)
+      const resp = await agentFetch(`${agentBaseUrl}/nvidia-operators?${urlParams}`)
+      if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+      const data = await resp.json()
+      if (data.operators) {
+        setOperators(data.operators)
+      } else if (data.operator) {
+        setOperators([data.operator])
+      } else {
+        setOperators([])
+      }
+      setError(null)
+    } catch {
+      setError(null)
+      setOperators([])
+    } finally {
+      setIsLoading(false)
+    }
+  }, [cluster])
+
+  useEffect(() => {
+    refetch()
+  }, [refetch])
+
+  return { operators, isLoading, error, refetch }
+}

--- a/web/src/hooks/useStackDiscovery.helpers.ts
+++ b/web/src/hooks/useStackDiscovery.helpers.ts
@@ -1,0 +1,339 @@
+/**
+ * Aggregation/filtering helpers for LLM-d stack discovery. Extracted from
+ * useStackDiscovery.ts so the hook implementation file stays under the
+ * max-lines limit (tracked by #15790, split by #21606). No behaviour
+ * change — same types/functions as before, moved to a sibling module and
+ * re-exported from useStackDiscovery.ts for backward compatibility.
+ */
+import { MS_PER_MINUTE } from '../lib/constants/time'
+
+export const CACHE_KEY = 'kubestellar-stack-cache'
+export const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes
+
+export function safeJsonParse<T>(value: string, fallback: T, context: string): T {
+  try {
+    return JSON.parse(value) as T
+  } catch (err) {
+    console.error(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
+    return fallback
+  }
+}
+
+export interface LLMdStackComponent {
+  name: string
+  namespace: string
+  cluster: string
+  type: 'prefill' | 'decode' | 'both' | 'epp' | 'gateway'
+  status: 'running' | 'pending' | 'error' | 'unknown'
+  replicas: number
+  readyReplicas: number
+  model?: string
+  podNames?: string[]
+}
+
+export type AutoscalerType = 'HPA' | 'WVA' | 'VPA' | null
+
+export interface AutoscalerInfo {
+  type: AutoscalerType
+  name?: string
+  minReplicas?: number
+  maxReplicas?: number
+  currentReplicas?: number
+  desiredReplicas?: number
+}
+
+export interface LLMdStack {
+  id: string                    // Format: "namespace@cluster"
+  name: string                  // Display name (namespace or InferencePool name)
+  namespace: string             // Primary namespace
+  cluster: string
+  inferencePool?: string        // InferencePool CR name if exists
+  components: {
+    prefill: LLMdStackComponent[]
+    decode: LLMdStackComponent[]
+    both: LLMdStackComponent[]   // Unified serving pods
+    epp: LLMdStackComponent | null
+    gateway: LLMdStackComponent | null
+  }
+  status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
+  hasDisaggregation: boolean    // true if prefill.length > 0 && decode.length > 0
+  model?: string                // Primary model name
+  totalReplicas: number
+  readyReplicas: number
+  autoscaler?: AutoscalerInfo   // Autoscaler info if detected
+}
+
+export interface PodResource {
+  metadata: {
+    name: string
+    namespace: string
+    labels?: Record<string, string>
+  }
+  status: {
+    phase: string
+    containerStatuses?: Array<{
+      ready: boolean
+    }>
+  }
+}
+
+export interface ServiceResource {
+  metadata: {
+    name: string
+    namespace: string
+  }
+  spec: {
+    ports?: Array<{
+      port: number
+    }>
+  }
+}
+
+export interface InferencePoolResource {
+  metadata: {
+    name: string
+    namespace: string
+  }
+  spec?: {
+    selector?: {
+      matchLabels?: Record<string, string>
+    }
+  }
+}
+
+export interface GatewayResource {
+  metadata: {
+    name: string
+    namespace: string
+  }
+  spec?: {
+    gatewayClassName?: string
+  }
+  status?: {
+    addresses?: Array<{
+      value: string
+    }>
+  }
+}
+
+export interface DeploymentResource {
+  metadata: { name: string; namespace: string; labels?: Record<string, string> }
+  spec: {
+    replicas?: number
+    template?: { metadata?: { labels?: Record<string, string> } }
+  }
+  status: { replicas?: number; readyReplicas?: number; availableReplicas?: number }
+}
+
+export interface HPAResource {
+  metadata: { name: string; namespace: string }
+  spec?: { minReplicas?: number; maxReplicas?: number }
+  status?: { currentReplicas?: number; desiredReplicas?: number }
+}
+
+export interface WVAResource {
+  metadata: { name: string; namespace: string }
+  spec?: {
+    minReplicas?: number
+    maxReplicas?: number
+    scaleTargetRef?: { namespace?: string }
+  }
+  status?: {
+    currentReplicas?: number
+    desiredReplicas?: number
+    desiredOptimizedAlloc?: { numReplicas?: number }
+  }
+}
+
+export interface VPAResource {
+  metadata: { name: string; namespace: string }
+}
+
+// Namespace heuristics for LLM-d workloads (mirrors useLLMdServers patterns)
+export function isLlmdNamespace(ns: string): boolean {
+  const n = ns.toLowerCase()
+  return n.includes('llm-d') || n.includes('llmd') || n.includes('e2e') || n.includes('vllm') ||
+    n === 'b2' || n.includes('effi') || n.includes('guygir') || n.includes('aibrix') ||
+    n.includes('hc4ai') || n.includes('inf') || n.includes('gaie') || n.includes('sched') ||
+    n.includes('inference') || n.includes('serving') || n.includes('model') ||
+    n.includes('ai-') || n.includes('-ai') || n.includes('ml-')
+}
+
+// Deployment-level detection for LLM-d workloads (mirrors useLLMdServers patterns)
+export function isLlmdDeployment(d: DeploymentResource): boolean {
+  const name = d.metadata.name.toLowerCase()
+  const labels = d.spec.template?.metadata?.labels || {}
+  const nsMatch = isLlmdNamespace(d.metadata.namespace)
+  return (
+    name.includes('vllm') || name.includes('llm-d') || name.includes('llmd') ||
+    name.includes('tgi') || name.includes('triton') ||
+    name.includes('llama') || name.includes('granite') ||
+    name.includes('qwen') || name.includes('mistral') || name.includes('mixtral') ||
+    name.includes('inference') || name.includes('modelservice') ||
+    labels['llmd.org/inferenceServing'] === 'true' ||
+    !!labels['llmd.org/model'] ||
+    !!labels['llm-d.ai/role'] ||
+    labels['app'] === 'llm-inference' ||
+    labels['app.kubernetes.io/name'] === 'vllm' ||
+    labels['app.kubernetes.io/name'] === 'tgi' ||
+    labels['app.kubernetes.io/part-of'] === 'inference' ||
+    name.includes('-epp') || name.endsWith('epp') ||
+    name.includes('scheduling') || name.includes('inference-pool') ||
+    (nsMatch && (name.includes('gateway') || name.includes('ingress')))
+  )
+}
+
+// Number of namespaces to query per batch in Phase 2 deployment discovery
+export const DEPLOYMENT_BATCH_SIZE = 3
+
+// Sort stacks: healthy first, then by name
+export function sortStacks(a: LLMdStack, b: LLMdStack): number {
+  if (a.status === 'healthy' && b.status !== 'healthy') return -1
+  if (a.status !== 'healthy' && b.status === 'healthy') return 1
+  return a.name.localeCompare(b.name)
+}
+
+// Build components from Deployments (used by Phase 2 namespace-level discovery)
+export function buildComponentsFromDeployments(
+  deployments: DeploymentResource[],
+  namespace: string,
+  cluster: string,
+  fallbackModel?: string,
+): {
+  prefill: LLMdStackComponent[]
+  decode: LLMdStackComponent[]
+  both: LLMdStackComponent[]
+  epp: LLMdStackComponent | null
+  model: string | undefined
+} {
+  const prefill: LLMdStackComponent[] = []
+  const decode: LLMdStackComponent[] = []
+  const both: LLMdStackComponent[] = []
+  let epp: LLMdStackComponent | null = null
+  let model = fallbackModel
+
+  for (const dep of (deployments || [])) {
+    const depName = dep.metadata.name.toLowerCase()
+    const depLabels = dep.spec.template?.metadata?.labels || {}
+    const role = depLabels['llm-d.ai/role']?.toLowerCase()
+    const replicas = dep.spec.replicas ?? dep.status.replicas ?? 0
+    const ready = dep.status.readyReplicas ?? 0
+    const depModel = depLabels['llmd.org/model'] || model
+    const depStatus: LLMdStackComponent['status'] =
+      ready === replicas && replicas > 0 ? 'running' : ready > 0 ? 'running' : 'error'
+
+    const isEpp = depName.includes('-epp') || depName.endsWith('epp') ||
+      depName.includes('scheduling') || depName.includes('inference-pool')
+
+    if (isEpp && !epp) {
+      epp = { name: dep.metadata.name, namespace, cluster, type: 'epp', status: ready > 0 ? 'running' : 'pending', replicas, readyReplicas: ready }
+    } else if (role === 'prefill' || (!role && depName.includes('prefill'))) {
+      prefill.push({ name: dep.metadata.name, namespace, cluster, type: 'prefill', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    } else if (role === 'decode' || (!role && depName.includes('decode'))) {
+      decode.push({ name: dep.metadata.name, namespace, cluster, type: 'decode', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    } else {
+      both.push({ name: dep.metadata.name, namespace, cluster, type: 'both', status: depStatus, replicas, readyReplicas: ready, model: depModel })
+    }
+
+    // Pick up model from first deployment with a label
+    if (!model && depLabels['llmd.org/model']) {
+      model = depLabels['llmd.org/model']
+    }
+  }
+
+  return { prefill, decode, both, epp, model }
+}
+
+/**
+ * Merge fresh stack data with cached, preserving details when fresh data degraded
+ * due to partial API failures (e.g., pods fetch timed out but pools succeeded).
+ * This prevents the dropdown from losing P/D/WVA details during background refreshes.
+ */
+export function mergeStackWithCached(fresh: LLMdStack, cached: LLMdStack): LLMdStack {
+  const merged = {
+    ...fresh,
+    components: { ...fresh.components } }
+
+  // Preserve pod component details if fresh lost them (likely API failure)
+  if (fresh.components.prefill.length === 0 && cached.components.prefill.length > 0) {
+    merged.components.prefill = cached.components.prefill
+  }
+  if (fresh.components.decode.length === 0 && cached.components.decode.length > 0) {
+    merged.components.decode = cached.components.decode
+  }
+  if (fresh.components.both.length === 0 && cached.components.both.length > 0) {
+    merged.components.both = cached.components.both
+  }
+
+  // Preserve EPP/Gateway if fresh didn't find them
+  if (!merged.components.epp && cached.components.epp) {
+    merged.components.epp = cached.components.epp
+  }
+  if (!merged.components.gateway && cached.components.gateway) {
+    merged.components.gateway = cached.components.gateway
+  }
+
+  // Preserve autoscaler if fresh didn't detect it
+  if (!merged.autoscaler && cached.autoscaler) {
+    merged.autoscaler = cached.autoscaler
+  }
+
+  // Preserve model name
+  if (!merged.model && cached.model) {
+    merged.model = cached.model
+  }
+
+  // Recalculate derived fields from the (possibly preserved) components
+  const allServing = [...merged.components.prefill, ...merged.components.decode, ...merged.components.both]
+  merged.totalReplicas = allServing.reduce((sum, c) => sum + c.replicas, 0)
+  merged.readyReplicas = allServing.reduce((sum, c) => sum + c.readyReplicas, 0)
+  merged.hasDisaggregation = merged.components.prefill.length > 0 && merged.components.decode.length > 0
+  merged.status = getStackStatus(merged.components)
+
+  return merged
+}
+
+export function getStackStatus(components: LLMdStack['components']): LLMdStack['status'] {
+  const allComponents = [
+    ...components.prefill,
+    ...components.decode,
+    ...components.both,
+    components.epp,
+    components.gateway,
+  ].filter(Boolean) as LLMdStackComponent[]
+
+  if (allComponents.length === 0) return 'unknown'
+
+  const running = allComponents.filter(c => c.status === 'running').length
+  const total = allComponents.length
+
+  if (running === total) return 'healthy'
+  if (running > 0) return 'degraded'
+  return 'unhealthy'
+}
+
+// Load cached stacks from localStorage
+export function loadCachedStacks(): { stacks: LLMdStack[]; timestamp: number } | null {
+  try {
+    const cached = localStorage.getItem(CACHE_KEY)
+    if (!cached) return null
+    const parsed = safeJsonParse<{ stacks?: LLMdStack[]; timestamp?: number } | null>(cached, null, 'stack cache')
+    if (parsed?.timestamp && parsed.stacks) {
+      return { stacks: parsed.stacks, timestamp: parsed.timestamp }
+    }
+  } catch {
+    // Ignore storage errors
+  }
+  return null
+}
+
+// Save stacks to localStorage cache
+export function saveCachedStacks(stacks: LLMdStack[]) {
+  try {
+    localStorage.setItem(CACHE_KEY, JSON.stringify({
+      stacks,
+      timestamp: Date.now() }))
+  } catch {
+    // Ignore storage errors
+  }
+}

--- a/web/src/hooks/useStackDiscovery.ts
+++ b/web/src/hooks/useStackDiscovery.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 /**
  * LLM-d Stack Discovery Hook
  *
@@ -14,338 +13,40 @@ import { getDemoMode } from './useDemoMode'
 import type { LLMdServer } from './useLLMd'
 import { DEFAULT_REFRESH_INTERVAL_MS as REFRESH_INTERVAL_MS } from '../lib/constants'
 import { KUBECTL_MEDIUM_TIMEOUT_MS, KUBECTL_EXTENDED_TIMEOUT_MS } from '../lib/constants/network'
-import { MS_PER_MINUTE } from '../lib/constants/time'
+import type {
+  LLMdStackComponent,
+  AutoscalerInfo,
+  LLMdStack,
+  PodResource,
+  ServiceResource,
+  InferencePoolResource,
+  GatewayResource,
+  DeploymentResource,
+  HPAResource,
+  WVAResource,
+  VPAResource,
+} from './useStackDiscovery.helpers'
+import {
+  CACHE_TTL_MS,
+  safeJsonParse,
+  isLlmdNamespace,
+  isLlmdDeployment,
+  DEPLOYMENT_BATCH_SIZE,
+  sortStacks,
+  buildComponentsFromDeployments,
+  mergeStackWithCached,
+  getStackStatus,
+  loadCachedStacks,
+  saveCachedStacks,
+} from './useStackDiscovery.helpers'
 
-const CACHE_KEY = 'kubestellar-stack-cache'
-const CACHE_TTL_MS = 5 * MS_PER_MINUTE // 5 minutes
+export type {
+  LLMdStackComponent,
+  AutoscalerType,
+  AutoscalerInfo,
+  LLMdStack,
+} from './useStackDiscovery.helpers'
 
-function safeJsonParse<T>(value: string, fallback: T, context: string): T {
-  try {
-    return JSON.parse(value) as T
-  } catch (err) {
-    console.error(`[useStackDiscovery] Ignoring malformed JSON for ${context}:`, err)
-    return fallback
-  }
-}
-
-export interface LLMdStackComponent {
-  name: string
-  namespace: string
-  cluster: string
-  type: 'prefill' | 'decode' | 'both' | 'epp' | 'gateway'
-  status: 'running' | 'pending' | 'error' | 'unknown'
-  replicas: number
-  readyReplicas: number
-  model?: string
-  podNames?: string[]
-}
-
-export type AutoscalerType = 'HPA' | 'WVA' | 'VPA' | null
-
-export interface AutoscalerInfo {
-  type: AutoscalerType
-  name?: string
-  minReplicas?: number
-  maxReplicas?: number
-  currentReplicas?: number
-  desiredReplicas?: number
-}
-
-export interface LLMdStack {
-  id: string                    // Format: "namespace@cluster"
-  name: string                  // Display name (namespace or InferencePool name)
-  namespace: string             // Primary namespace
-  cluster: string
-  inferencePool?: string        // InferencePool CR name if exists
-  components: {
-    prefill: LLMdStackComponent[]
-    decode: LLMdStackComponent[]
-    both: LLMdStackComponent[]   // Unified serving pods
-    epp: LLMdStackComponent | null
-    gateway: LLMdStackComponent | null
-  }
-  status: 'healthy' | 'degraded' | 'unhealthy' | 'unknown'
-  hasDisaggregation: boolean    // true if prefill.length > 0 && decode.length > 0
-  model?: string                // Primary model name
-  totalReplicas: number
-  readyReplicas: number
-  autoscaler?: AutoscalerInfo   // Autoscaler info if detected
-}
-
-interface PodResource {
-  metadata: {
-    name: string
-    namespace: string
-    labels?: Record<string, string>
-  }
-  status: {
-    phase: string
-    containerStatuses?: Array<{
-      ready: boolean
-    }>
-  }
-}
-
-interface ServiceResource {
-  metadata: {
-    name: string
-    namespace: string
-  }
-  spec: {
-    ports?: Array<{
-      port: number
-    }>
-  }
-}
-
-interface InferencePoolResource {
-  metadata: {
-    name: string
-    namespace: string
-  }
-  spec?: {
-    selector?: {
-      matchLabels?: Record<string, string>
-    }
-  }
-}
-
-interface GatewayResource {
-  metadata: {
-    name: string
-    namespace: string
-  }
-  spec?: {
-    gatewayClassName?: string
-  }
-  status?: {
-    addresses?: Array<{
-      value: string
-    }>
-  }
-}
-
-interface DeploymentResource {
-  metadata: { name: string; namespace: string; labels?: Record<string, string> }
-  spec: {
-    replicas?: number
-    template?: { metadata?: { labels?: Record<string, string> } }
-  }
-  status: { replicas?: number; readyReplicas?: number; availableReplicas?: number }
-}
-
-interface HPAResource {
-  metadata: { name: string; namespace: string }
-  spec?: { minReplicas?: number; maxReplicas?: number }
-  status?: { currentReplicas?: number; desiredReplicas?: number }
-}
-
-interface WVAResource {
-  metadata: { name: string; namespace: string }
-  spec?: {
-    minReplicas?: number
-    maxReplicas?: number
-    scaleTargetRef?: { namespace?: string }
-  }
-  status?: {
-    currentReplicas?: number
-    desiredReplicas?: number
-    desiredOptimizedAlloc?: { numReplicas?: number }
-  }
-}
-
-interface VPAResource {
-  metadata: { name: string; namespace: string }
-}
-
-// Namespace heuristics for LLM-d workloads (mirrors useLLMdServers patterns)
-function isLlmdNamespace(ns: string): boolean {
-  const n = ns.toLowerCase()
-  return n.includes('llm-d') || n.includes('llmd') || n.includes('e2e') || n.includes('vllm') ||
-    n === 'b2' || n.includes('effi') || n.includes('guygir') || n.includes('aibrix') ||
-    n.includes('hc4ai') || n.includes('inf') || n.includes('gaie') || n.includes('sched') ||
-    n.includes('inference') || n.includes('serving') || n.includes('model') ||
-    n.includes('ai-') || n.includes('-ai') || n.includes('ml-')
-}
-
-// Deployment-level detection for LLM-d workloads (mirrors useLLMdServers patterns)
-function isLlmdDeployment(d: DeploymentResource): boolean {
-  const name = d.metadata.name.toLowerCase()
-  const labels = d.spec.template?.metadata?.labels || {}
-  const nsMatch = isLlmdNamespace(d.metadata.namespace)
-  return (
-    name.includes('vllm') || name.includes('llm-d') || name.includes('llmd') ||
-    name.includes('tgi') || name.includes('triton') ||
-    name.includes('llama') || name.includes('granite') ||
-    name.includes('qwen') || name.includes('mistral') || name.includes('mixtral') ||
-    name.includes('inference') || name.includes('modelservice') ||
-    labels['llmd.org/inferenceServing'] === 'true' ||
-    !!labels['llmd.org/model'] ||
-    !!labels['llm-d.ai/role'] ||
-    labels['app'] === 'llm-inference' ||
-    labels['app.kubernetes.io/name'] === 'vllm' ||
-    labels['app.kubernetes.io/name'] === 'tgi' ||
-    labels['app.kubernetes.io/part-of'] === 'inference' ||
-    name.includes('-epp') || name.endsWith('epp') ||
-    name.includes('scheduling') || name.includes('inference-pool') ||
-    (nsMatch && (name.includes('gateway') || name.includes('ingress')))
-  )
-}
-
-// Number of namespaces to query per batch in Phase 2 deployment discovery
-const DEPLOYMENT_BATCH_SIZE = 3
-
-// Sort stacks: healthy first, then by name
-function sortStacks(a: LLMdStack, b: LLMdStack): number {
-  if (a.status === 'healthy' && b.status !== 'healthy') return -1
-  if (a.status !== 'healthy' && b.status === 'healthy') return 1
-  return a.name.localeCompare(b.name)
-}
-
-// Build components from Deployments (used by Phase 2 namespace-level discovery)
-function buildComponentsFromDeployments(
-  deployments: DeploymentResource[],
-  namespace: string,
-  cluster: string,
-  fallbackModel?: string,
-): {
-  prefill: LLMdStackComponent[]
-  decode: LLMdStackComponent[]
-  both: LLMdStackComponent[]
-  epp: LLMdStackComponent | null
-  model: string | undefined
-} {
-  const prefill: LLMdStackComponent[] = []
-  const decode: LLMdStackComponent[] = []
-  const both: LLMdStackComponent[] = []
-  let epp: LLMdStackComponent | null = null
-  let model = fallbackModel
-
-  for (const dep of (deployments || [])) {
-    const depName = dep.metadata.name.toLowerCase()
-    const depLabels = dep.spec.template?.metadata?.labels || {}
-    const role = depLabels['llm-d.ai/role']?.toLowerCase()
-    const replicas = dep.spec.replicas ?? dep.status.replicas ?? 0
-    const ready = dep.status.readyReplicas ?? 0
-    const depModel = depLabels['llmd.org/model'] || model
-    const depStatus: LLMdStackComponent['status'] =
-      ready === replicas && replicas > 0 ? 'running' : ready > 0 ? 'running' : 'error'
-
-    const isEpp = depName.includes('-epp') || depName.endsWith('epp') ||
-      depName.includes('scheduling') || depName.includes('inference-pool')
-
-    if (isEpp && !epp) {
-      epp = { name: dep.metadata.name, namespace, cluster, type: 'epp', status: ready > 0 ? 'running' : 'pending', replicas, readyReplicas: ready }
-    } else if (role === 'prefill' || (!role && depName.includes('prefill'))) {
-      prefill.push({ name: dep.metadata.name, namespace, cluster, type: 'prefill', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-    } else if (role === 'decode' || (!role && depName.includes('decode'))) {
-      decode.push({ name: dep.metadata.name, namespace, cluster, type: 'decode', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-    } else {
-      both.push({ name: dep.metadata.name, namespace, cluster, type: 'both', status: depStatus, replicas, readyReplicas: ready, model: depModel })
-    }
-
-    // Pick up model from first deployment with a label
-    if (!model && depLabels['llmd.org/model']) {
-      model = depLabels['llmd.org/model']
-    }
-  }
-
-  return { prefill, decode, both, epp, model }
-}
-
-/**
- * Merge fresh stack data with cached, preserving details when fresh data degraded
- * due to partial API failures (e.g., pods fetch timed out but pools succeeded).
- * This prevents the dropdown from losing P/D/WVA details during background refreshes.
- */
-function mergeStackWithCached(fresh: LLMdStack, cached: LLMdStack): LLMdStack {
-  const merged = {
-    ...fresh,
-    components: { ...fresh.components } }
-
-  // Preserve pod component details if fresh lost them (likely API failure)
-  if (fresh.components.prefill.length === 0 && cached.components.prefill.length > 0) {
-    merged.components.prefill = cached.components.prefill
-  }
-  if (fresh.components.decode.length === 0 && cached.components.decode.length > 0) {
-    merged.components.decode = cached.components.decode
-  }
-  if (fresh.components.both.length === 0 && cached.components.both.length > 0) {
-    merged.components.both = cached.components.both
-  }
-
-  // Preserve EPP/Gateway if fresh didn't find them
-  if (!merged.components.epp && cached.components.epp) {
-    merged.components.epp = cached.components.epp
-  }
-  if (!merged.components.gateway && cached.components.gateway) {
-    merged.components.gateway = cached.components.gateway
-  }
-
-  // Preserve autoscaler if fresh didn't detect it
-  if (!merged.autoscaler && cached.autoscaler) {
-    merged.autoscaler = cached.autoscaler
-  }
-
-  // Preserve model name
-  if (!merged.model && cached.model) {
-    merged.model = cached.model
-  }
-
-  // Recalculate derived fields from the (possibly preserved) components
-  const allServing = [...merged.components.prefill, ...merged.components.decode, ...merged.components.both]
-  merged.totalReplicas = allServing.reduce((sum, c) => sum + c.replicas, 0)
-  merged.readyReplicas = allServing.reduce((sum, c) => sum + c.readyReplicas, 0)
-  merged.hasDisaggregation = merged.components.prefill.length > 0 && merged.components.decode.length > 0
-  merged.status = getStackStatus(merged.components)
-
-  return merged
-}
-
-function getStackStatus(components: LLMdStack['components']): LLMdStack['status'] {
-  const allComponents = [
-    ...components.prefill,
-    ...components.decode,
-    ...components.both,
-    components.epp,
-    components.gateway,
-  ].filter(Boolean) as LLMdStackComponent[]
-
-  if (allComponents.length === 0) return 'unknown'
-
-  const running = allComponents.filter(c => c.status === 'running').length
-  const total = allComponents.length
-
-  if (running === total) return 'healthy'
-  if (running > 0) return 'degraded'
-  return 'unhealthy'
-}
-
-// Load cached stacks from localStorage
-function loadCachedStacks(): { stacks: LLMdStack[]; timestamp: number } | null {
-  try {
-    const cached = localStorage.getItem(CACHE_KEY)
-    if (!cached) return null
-    const parsed = safeJsonParse<{ stacks?: LLMdStack[]; timestamp?: number } | null>(cached, null, 'stack cache')
-    if (parsed?.timestamp && parsed.stacks) {
-      return { stacks: parsed.stacks, timestamp: parsed.timestamp }
-    }
-  } catch {
-    // Ignore storage errors
-  }
-  return null
-}
-
-// Save stacks to localStorage cache
-function saveCachedStacks(stacks: LLMdStack[]) {
-  try {
-    localStorage.setItem(CACHE_KEY, JSON.stringify({
-      stacks,
-      timestamp: Date.now() }))
-  } catch {
-    // Ignore storage errors
-  }
-}
 
 /**
  * Hook to discover llm-d stacks from clusters

--- a/web/src/hooks/useTokenUsage.math.ts
+++ b/web/src/hooks/useTokenUsage.math.ts
@@ -1,0 +1,56 @@
+// Pure token-budget math helpers extracted from useTokenUsage.ts so the hook
+// implementation file stays under the max-lines limit (tracked by #15790,
+// split by #21605). These functions have no side effects and no dependency
+// on the hook's module-level singleton state.
+
+import type { TokenAlertLevel, TokenUsage, TokenUsageByCategory } from './useTokenUsage.types'
+
+export const LOCAL_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' })
+
+export const DEFAULT_SETTINGS = {
+  limit: 500000000, // 500M tokens daily default
+  warningThreshold: 0.7, // 70%
+  criticalThreshold: 0.9, // 90%
+  stopThreshold: 1.0, // 100%
+}
+
+const NEXT_RESET_DAY_OFFSET = 1
+
+export const DEFAULT_BY_CATEGORY: TokenUsageByCategory = {
+  missions: 0,
+  diagnose: 0,
+  insights: 0,
+  predictions: 0,
+  other: 0 }
+
+export function getTokenAlertLevel(usage: Pick<TokenUsage, 'used' | 'limit' | 'warningThreshold' | 'criticalThreshold' | 'stopThreshold'>): TokenAlertLevel {
+  if (usage.limit <= 0) return 'normal'
+
+  const percentageUsed = usage.used / usage.limit
+  const stopThreshold = usage.stopThreshold > 0 ? usage.stopThreshold : DEFAULT_SETTINGS.stopThreshold
+
+  if (percentageUsed >= stopThreshold) return 'stopped'
+  if (percentageUsed >= usage.criticalThreshold) return 'critical'
+  if (percentageUsed >= usage.warningThreshold) return 'warning'
+  return 'normal'
+}
+
+export function reconcileUsageBreakdown(totalUsed: number, byCategory: TokenUsageByCategory): TokenUsageByCategory {
+  // If no tokens used, reset all categories to 0 (prevents stale demo/cached data from showing)
+  if (totalUsed === 0) {
+    return { ...DEFAULT_BY_CATEGORY }
+  }
+  const knownCategories = byCategory.missions + byCategory.diagnose + byCategory.insights + byCategory.predictions
+  const other = Math.max(totalUsed - knownCategories, 0)
+  return other === byCategory.other ? byCategory : { ...byCategory, other }
+}
+
+export function getUsagePeriodKey(now = new Date()): string {
+  return LOCAL_DATE_FORMATTER.format(now)
+}
+
+export function getNextResetDate(): string {
+  const now = new Date()
+  const nextReset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + NEXT_RESET_DAY_OFFSET)
+  return nextReset.toISOString()
+}

--- a/web/src/hooks/useTokenUsage.ts
+++ b/web/src/hooks/useTokenUsage.ts
@@ -1,4 +1,3 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { useState, useEffect } from 'react'
 import { isAgentUnavailable, reportAgentDataSuccess, reportAgentDataError } from './useLocalAgent'
 import { getDemoMode } from './useDemoMode'
@@ -10,6 +9,18 @@ import {
   TokenUsageUnauthenticatedError,
   type UserTokenUsageRecord,
 } from '../lib/tokenUsageApi'
+import type { TokenCategory, TokenUsageByCategory, TokenUsage, TokenAlertLevel } from './useTokenUsage.types'
+import {
+  DEFAULT_SETTINGS,
+  DEFAULT_BY_CATEGORY,
+  getTokenAlertLevel,
+  reconcileUsageBreakdown,
+  getUsagePeriodKey,
+  getNextResetDate,
+} from './useTokenUsage.math'
+
+export type { TokenCategory, TokenUsageByCategory, TokenUsage, TokenAlertLevel } from './useTokenUsage.types'
+export { getTokenAlertLevel } from './useTokenUsage.math'
 
 /** Maximum token delta to attribute in a single poll cycle (prevents init spikes) */
 const MAX_SINGLE_DELTA_TOKENS = 50_000
@@ -42,72 +53,11 @@ const TOKEN_USAGE_FLUSH_INTERVAL_MS = 30_000
  */
 const TOKEN_USAGE_FLUSH_THRESHOLD = 100
 
-export type TokenCategory = 'missions' | 'diagnose' | 'insights' | 'predictions' | 'other'
-
-export interface TokenUsageByCategory {
-  missions: number
-  diagnose: number
-  insights: number
-  predictions: number
-  other: number
-}
-
-export interface TokenUsage {
-  used: number
-  limit: number
-  warningThreshold: number
-  criticalThreshold: number
-  stopThreshold: number
-  resetDate: string
-  byCategory: TokenUsageByCategory
-}
-
-export type TokenAlertLevel = 'normal' | 'warning' | 'critical' | 'stopped'
-
-export function getTokenAlertLevel(usage: Pick<TokenUsage, 'used' | 'limit' | 'warningThreshold' | 'criticalThreshold' | 'stopThreshold'>): TokenAlertLevel {
-  if (usage.limit <= 0) return 'normal'
-
-  const percentageUsed = usage.used / usage.limit
-  const stopThreshold = usage.stopThreshold > 0 ? usage.stopThreshold : DEFAULT_SETTINGS.stopThreshold
-
-  if (percentageUsed >= stopThreshold) return 'stopped'
-  if (percentageUsed >= usage.criticalThreshold) return 'critical'
-  if (percentageUsed >= usage.warningThreshold) return 'warning'
-  return 'normal'
-}
-
 const SETTINGS_KEY = 'kubestellar-token-settings'
 const CATEGORY_KEY = 'kubestellar-token-categories'
 const PERIOD_KEY = 'kubestellar-token-period'
 const SETTINGS_CHANGED_EVENT = 'kubestellar-token-settings-changed'
 const POLL_INTERVAL_MS = 30_000 // Poll every 30 seconds
-const LOCAL_DATE_FORMATTER = new Intl.DateTimeFormat('en-CA', { year: 'numeric', month: '2-digit', day: '2-digit' })
-
-const DEFAULT_SETTINGS = {
-  limit: 500000000, // 500M tokens daily default
-  warningThreshold: 0.7, // 70%
-  criticalThreshold: 0.9, // 90%
-  stopThreshold: 1.0, // 100%
-}
-
-const NEXT_RESET_DAY_OFFSET = 1
-
-const DEFAULT_BY_CATEGORY: TokenUsageByCategory = {
-  missions: 0,
-  diagnose: 0,
-  insights: 0,
-  predictions: 0,
-  other: 0 }
-
-function reconcileUsageBreakdown(totalUsed: number, byCategory: TokenUsageByCategory): TokenUsageByCategory {
-  // If no tokens used, reset all categories to 0 (prevents stale demo/cached data from showing)
-  if (totalUsed === 0) {
-    return { ...DEFAULT_BY_CATEGORY }
-  }
-  const knownCategories = byCategory.missions + byCategory.diagnose + byCategory.insights + byCategory.predictions
-  const other = Math.max(totalUsed - knownCategories, 0)
-  return other === byCategory.other ? byCategory : { ...byCategory, other }
-}
 
 // Demo mode token usage - simulate realistic usage
 const DEMO_TOKEN_USAGE = 1247832 // ~25% of 5M limit
@@ -205,10 +155,6 @@ function persistUsage(lastKnown: number, sessionId: string | null): void {
   } catch {
     // Quota exceeded / private mode — ignore, this is best-effort.
   }
-}
-
-function getUsagePeriodKey(now = new Date()): string {
-  return LOCAL_DATE_FORMATTER.format(now)
 }
 
 function resetUsagePeriodState(nextPeriod: string, forceNotify = false): void {
@@ -784,12 +730,6 @@ export function useTokenUsage() {
     resetUsage,
     isAIDisabled,
     isDemoData }
-}
-
-function getNextResetDate(): string {
-  const now = new Date()
-  const nextReset = new Date(now.getFullYear(), now.getMonth(), now.getDate() + NEXT_RESET_DAY_OFFSET)
-  return nextReset.toISOString()
 }
 
 /**

--- a/web/src/hooks/useTokenUsage.types.ts
+++ b/web/src/hooks/useTokenUsage.types.ts
@@ -1,0 +1,25 @@
+// Shared type definitions for token usage tracking. Extracted from
+// useTokenUsage.ts so the hook implementation file stays under the
+// max-lines limit (tracked by #15790, split by #21605).
+
+export type TokenCategory = 'missions' | 'diagnose' | 'insights' | 'predictions' | 'other'
+
+export interface TokenUsageByCategory {
+  missions: number
+  diagnose: number
+  insights: number
+  predictions: number
+  other: number
+}
+
+export interface TokenUsage {
+  used: number
+  limit: number
+  warningThreshold: number
+  criticalThreshold: number
+  stopThreshold: number
+  resetDate: string
+  byCategory: TokenUsageByCategory
+}
+
+export type TokenAlertLevel = 'normal' | 'warning' | 'critical' | 'stopped'

--- a/web/src/lib/auth.tsx
+++ b/web/src/lib/auth.tsx
@@ -1,18 +1,15 @@
-/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */
 import { createContext, use, useState, useEffect, useCallback, useMemo, useRef, ReactNode } from 'react'
-import { MS_PER_SECOND } from './constants/time'
 import { checkOAuthConfigured, checkOAuthConfiguredWithRetry } from './api'
 import { dashboardSync } from './dashboards/dashboardSync'
-import i18n from './i18n'
 import { clearPermissionsCache } from '../hooks/usePermissions'
 import { disconnectPresence } from '../hooks/useActiveUsers'
 import { clearSSECache } from './sseClient'
 import { clearClusterCacheOnLogout } from '../hooks/mcp/shared'
 import { clearAgentToken, setAgentToken } from '../hooks/mcp/agentFetch'
-import { DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_HAS_SESSION, STORAGE_KEY_ONBOARDED, STORAGE_KEY_USER_CACHE } from './constants'
+import { DEMO_TOKEN_VALUE, FETCH_DEFAULT_TIMEOUT_MS, STORAGE_KEY_DEMO_MODE, STORAGE_KEY_HAS_SESSION, STORAGE_KEY_ONBOARDED } from './constants'
 import { isLocalAgentSuppressed } from './constants/network'
 import { HTTP_UNAUTHORIZED, HTTP_FORBIDDEN } from './constants/http'
-import { safeGet, safeRemove, safeSet, safeSetJSON } from './safeLocalStorage'
+import { safeGet, safeRemove, safeSet } from './safeLocalStorage'
 import { AUTH_TOKEN_SYNC_KEY, clearStoredAuthToken, getStoredAuthToken, getStoredAuthTokenSync, parseAuthTokenSyncEvent, setStoredAuthToken } from './authToken'
 import { emitLogin, emitLogout, setAnalyticsUserId, setAnalyticsUserProperties, emitConversionStep, emitDeveloperSession, emitSessionRefreshFailure } from './analytics'
 import { setDemoMode as setGlobalDemoMode } from './demoMode'
@@ -20,157 +17,23 @@ import { AuthRefreshResponseSchema, UserSchema } from './schemas'
 import { validateResponse } from './schemas/validate'
 import { ROUTES } from '../config/routes'
 import { redirectToDevLogin, type LoginOptions } from './devLogin'
+import type { User, AuthContextType } from './auth/types'
+import {
+  AUTH_USER_CACHE_KEY,
+  AUTH_USER_CACHE_VALIDATED_KEY,
+  EXPIRY_CHECK_INTERVAL_MS,
+  EXPIRY_WARNING_THRESHOLD_MS,
+  MAX_CACHED_USER_AGE_MS,
+  BACKEND_REVALIDATE_INTERVAL_MS,
+  getJwtExpiryMs,
+  isJWTExpired,
+  showExpiryWarningBanner,
+  getCachedUser,
+  cacheUser,
+} from './auth/tokenHelpers'
 
-interface User {
-  id: string
-  github_id: string
-  github_login: string
-  email?: string
-  slack_id?: string
-  avatar_url?: string
-  role?: 'admin' | 'editor' | 'viewer'
-  onboarded: boolean
-}
-
-interface AuthContextType {
-  user: User | null
-  token: string | null
-  isAuthenticated: boolean
-  isLoading: boolean
-  login: (opts?: LoginOptions) => void
-  logout: () => void
-  setToken: (token: string, onboarded: boolean) => void
-  refreshUser: (overrideToken?: string) => Promise<void>
-}
-
-const AUTH_USER_CACHE_KEY = STORAGE_KEY_USER_CACHE
-/** Timestamp (ms) of the last successful /api/me round-trip — tracked so we
- *  can bound how long cached user data is trusted when the backend is down (#6067). */
-const AUTH_USER_CACHE_VALIDATED_KEY = 'kc-user-cache-validated'
-
-// How often (in ms) to check if the JWT is nearing expiry
-const EXPIRY_CHECK_INTERVAL_MS = 60_000
-// Show a warning banner when the token expires within this many ms
-const EXPIRY_WARNING_THRESHOLD_MS = 30 * 60_000
-
-/** #6067 — maximum age of cached user data (5 min) before we force re-validation. */
-const MAX_CACHED_USER_AGE_MS = 5 * 60 * 1_000
-/** #6067 — interval for background re-validation when the backend is unreachable. */
-const BACKEND_REVALIDATE_INTERVAL_MS = 30_000
-
-/**
- * Decode the expiry timestamp from a JWT without verifying signature.
- * Returns the `exp` value in ms, or null if the token isn't decodable.
- */
-function getJwtExpiryMs(token: string): number | null {
-  try {
-    const parts = token.split('.')
-    if (parts.length !== 3) return null
-    // JWT uses base64url encoding — convert to standard base64 for atob()
-    const base64Url = parts[1]
-    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
-    const payload = JSON.parse(atob(base64))
-    if (typeof payload.exp !== 'number') return null
-    return payload.exp * MS_PER_SECOND
-  } catch {
-    return null
-  }
-}
-
-/**
- * #6058 — Return true only when a token is a *parseable* JWT whose `exp`
- * has passed. For opaque / non-JWT tokens we return false (not expired)
- * so we still attempt the /api/me call and let the backend decide. This
- * avoids false-positive logouts for tokens that simply aren't JWTs.
- */
-export function isJWTExpired(token: string): boolean {
-  const expiryMs = getJwtExpiryMs(token)
-  if (expiryMs === null) return false
-  return Date.now() >= expiryMs
-}
-
-
-/**
- * Inject a DOM-based warning banner when the session is about to expire.
- * The user can click "Refresh Now" to silently renew their token.
- */
-function showExpiryWarningBanner(onRefresh: () => void): void {
-  if (document.getElementById('session-expiry-warning')) return
-
-  /* Spacing & color constants for DOM-based banner (Tailwind unavailable in imperative DOM) */
-  const BANNER_BOTTOM_PX = '24px'
-  const BANNER_GAP_PX = '12px'
-  const BANNER_PAD_V_PX = '12px'
-  const BANNER_PAD_H_PX = '20px'
-  const BANNER_RADIUS_PX = '8px'
-  const WARN_BG = 'hsl(var(--warning) / 0.15)'
-  const WARN_BORDER = 'hsl(var(--warning) / 0.4)'
-  const WARN_TEXT = 'hsl(var(--warning-foreground))'
-  const BTN_MARGIN_LEFT_PX = '8px'
-  const BTN_PAD_V_PX = '4px'
-  const BTN_PAD_H_PX = '12px'
-  const TOAST_Z_INDEX = 99_999
-
-  const banner = document.createElement('div')
-  banner.id = 'session-expiry-warning'
-  banner.style.cssText = `
-    position: fixed; bottom: ${BANNER_BOTTOM_PX}; left: 50%; transform: translateX(-50%); z-index: ${TOAST_Z_INDEX};
-    display: flex; align-items: center; gap: ${BANNER_GAP_PX};
-    padding: ${BANNER_PAD_V_PX} ${BANNER_PAD_H_PX};
-    background: ${WARN_BG};
-    border: 1px solid ${WARN_BORDER};
-    border-radius: ${BANNER_RADIUS_PX}; backdrop-filter: blur(8px);
-    color: ${WARN_TEXT}; font-family: system-ui, sans-serif; font-size: 14px;
-    animation: slideUp 0.3s ease-out;
-  `
-  banner.innerHTML = `
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
-      stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-    </svg>
-    <span><strong>${i18n.t('session.expiresSoon')}</strong></span>
-  `
-
-  const btn = document.createElement('button')
-  btn.textContent = i18n.t('session.refreshNow')
-  btn.style.cssText = `
-    margin-left: ${BTN_MARGIN_LEFT_PX}; padding: ${BTN_PAD_V_PX} ${BTN_PAD_H_PX}; border-radius: ${BANNER_RADIUS_PX};
-    background: hsl(var(--warning) / 0.3); border: 1px solid hsl(var(--warning) / 0.5);
-    color: hsl(var(--warning-foreground)); cursor: pointer; font-size: 13px; font-family: inherit;
-  `
-  btn.onclick = () => {
-    onRefresh()
-    banner.remove()
-  }
-  banner.appendChild(btn)
-
-  // Reuse a single <style> element for the slideUp animation to avoid unbounded DOM growth
-  const STYLE_ID = 'session-banner-animation'
-  if (!document.getElementById(STYLE_ID)) {
-    const style = document.createElement('style')
-    style.id = STYLE_ID
-    style.textContent = `@keyframes slideUp { from { transform: translateX(-50%) translateY(100%); opacity: 0; } to { transform: translateX(-50%) translateY(0); opacity: 1; } }`
-    document.head.appendChild(style)
-  }
-  document.body.appendChild(banner)
-}
-
-function getCachedUser(): User | null {
-  try {
-    const cached = localStorage.getItem(AUTH_USER_CACHE_KEY)
-    return cached ? JSON.parse(cached) : null
-  } catch {
-    return null
-  }
-}
-
-function cacheUser(userData: User | null) {
-  if (userData) {
-    safeSetJSON(AUTH_USER_CACHE_KEY, userData)
-  } else {
-    safeRemove(AUTH_USER_CACHE_KEY)
-  }
-}
+export type { User, AuthContextType } from './auth/types'
+export { isJWTExpired } from './auth/tokenHelpers'
 
 const AuthContext = createContext<AuthContextType | null>(null)
 

--- a/web/src/lib/auth/tokenHelpers.ts
+++ b/web/src/lib/auth/tokenHelpers.ts
@@ -1,0 +1,138 @@
+// Token/JWT helpers and user-cache utilities extracted from auth.tsx so the
+// provider implementation file stays under the max-lines limit (tracked by
+// #15790, split by #21605). No behaviour change — these are the same
+// functions/constants that previously lived at module scope in auth.tsx.
+
+import { MS_PER_SECOND } from '../constants/time'
+import { STORAGE_KEY_USER_CACHE } from '../constants'
+import { safeRemove, safeSetJSON } from '../safeLocalStorage'
+import i18n from '../i18n'
+import type { User } from './types'
+
+export const AUTH_USER_CACHE_KEY = STORAGE_KEY_USER_CACHE
+/** Timestamp (ms) of the last successful /api/me round-trip — tracked so we
+ *  can bound how long cached user data is trusted when the backend is down (#6067). */
+export const AUTH_USER_CACHE_VALIDATED_KEY = 'kc-user-cache-validated'
+
+// How often (in ms) to check if the JWT is nearing expiry
+export const EXPIRY_CHECK_INTERVAL_MS = 60_000
+// Show a warning banner when the token expires within this many ms
+export const EXPIRY_WARNING_THRESHOLD_MS = 30 * 60_000
+
+/** #6067 — maximum age of cached user data (5 min) before we force re-validation. */
+export const MAX_CACHED_USER_AGE_MS = 5 * 60 * 1_000
+/** #6067 — interval for background re-validation when the backend is unreachable. */
+export const BACKEND_REVALIDATE_INTERVAL_MS = 30_000
+
+/**
+ * Decode the expiry timestamp from a JWT without verifying signature.
+ * Returns the `exp` value in ms, or null if the token isn't decodable.
+ */
+export function getJwtExpiryMs(token: string): number | null {
+  try {
+    const parts = token.split('.')
+    if (parts.length !== 3) return null
+    // JWT uses base64url encoding — convert to standard base64 for atob()
+    const base64Url = parts[1]
+    const base64 = base64Url.replace(/-/g, '+').replace(/_/g, '/')
+    const payload = JSON.parse(atob(base64))
+    if (typeof payload.exp !== 'number') return null
+    return payload.exp * MS_PER_SECOND
+  } catch {
+    return null
+  }
+}
+
+/**
+ * #6058 — Return true only when a token is a *parseable* JWT whose `exp`
+ * has passed. For opaque / non-JWT tokens we return false (not expired)
+ * so we still attempt the /api/me call and let the backend decide. This
+ * avoids false-positive logouts for tokens that simply aren't JWTs.
+ */
+export function isJWTExpired(token: string): boolean {
+  const expiryMs = getJwtExpiryMs(token)
+  if (expiryMs === null) return false
+  return Date.now() >= expiryMs
+}
+
+/**
+ * Inject a DOM-based warning banner when the session is about to expire.
+ * The user can click "Refresh Now" to silently renew their token.
+ */
+export function showExpiryWarningBanner(onRefresh: () => void): void {
+  if (document.getElementById('session-expiry-warning')) return
+
+  /* Spacing & color constants for DOM-based banner (Tailwind unavailable in imperative DOM) */
+  const BANNER_BOTTOM_PX = '24px'
+  const BANNER_GAP_PX = '12px'
+  const BANNER_PAD_V_PX = '12px'
+  const BANNER_PAD_H_PX = '20px'
+  const BANNER_RADIUS_PX = '8px'
+  const WARN_BG = 'hsl(var(--warning) / 0.15)'
+  const WARN_BORDER = 'hsl(var(--warning) / 0.4)'
+  const WARN_TEXT = 'hsl(var(--warning-foreground))'
+  const BTN_MARGIN_LEFT_PX = '8px'
+  const BTN_PAD_V_PX = '4px'
+  const BTN_PAD_H_PX = '12px'
+  const TOAST_Z_INDEX = 99_999
+
+  const banner = document.createElement('div')
+  banner.id = 'session-expiry-warning'
+  banner.style.cssText = `
+    position: fixed; bottom: ${BANNER_BOTTOM_PX}; left: 50%; transform: translateX(-50%); z-index: ${TOAST_Z_INDEX};
+    display: flex; align-items: center; gap: ${BANNER_GAP_PX};
+    padding: ${BANNER_PAD_V_PX} ${BANNER_PAD_H_PX};
+    background: ${WARN_BG};
+    border: 1px solid ${WARN_BORDER};
+    border-radius: ${BANNER_RADIUS_PX}; backdrop-filter: blur(8px);
+    color: ${WARN_TEXT}; font-family: system-ui, sans-serif; font-size: 14px;
+    animation: slideUp 0.3s ease-out;
+  `
+  banner.innerHTML = `
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none"
+      stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+    </svg>
+    <span><strong>${i18n.t('session.expiresSoon')}</strong></span>
+  `
+
+  const btn = document.createElement('button')
+  btn.textContent = i18n.t('session.refreshNow')
+  btn.style.cssText = `
+    margin-left: ${BTN_MARGIN_LEFT_PX}; padding: ${BTN_PAD_V_PX} ${BTN_PAD_H_PX}; border-radius: ${BANNER_RADIUS_PX};
+    background: hsl(var(--warning) / 0.3); border: 1px solid hsl(var(--warning) / 0.5);
+    color: hsl(var(--warning-foreground)); cursor: pointer; font-size: 13px; font-family: inherit;
+  `
+  btn.onclick = () => {
+    onRefresh()
+    banner.remove()
+  }
+  banner.appendChild(btn)
+
+  // Reuse a single <style> element for the slideUp animation to avoid unbounded DOM growth
+  const STYLE_ID = 'session-banner-animation'
+  if (!document.getElementById(STYLE_ID)) {
+    const style = document.createElement('style')
+    style.id = STYLE_ID
+    style.textContent = `@keyframes slideUp { from { transform: translateX(-50%) translateY(100%); opacity: 0; } to { transform: translateX(-50%) translateY(0); opacity: 1; } }`
+    document.head.appendChild(style)
+  }
+  document.body.appendChild(banner)
+}
+
+export function getCachedUser(): User | null {
+  try {
+    const cached = localStorage.getItem(AUTH_USER_CACHE_KEY)
+    return cached ? JSON.parse(cached) : null
+  } catch {
+    return null
+  }
+}
+
+export function cacheUser(userData: User | null) {
+  if (userData) {
+    safeSetJSON(AUTH_USER_CACHE_KEY, userData)
+  } else {
+    safeRemove(AUTH_USER_CACHE_KEY)
+  }
+}

--- a/web/src/lib/auth/types.ts
+++ b/web/src/lib/auth/types.ts
@@ -1,0 +1,27 @@
+// Shared type definitions for the auth provider. Extracted from auth.tsx so
+// the provider implementation file stays under the max-lines limit (tracked
+// by #15790, split by #21605).
+
+import type { LoginOptions } from '../devLogin'
+
+export interface User {
+  id: string
+  github_id: string
+  github_login: string
+  email?: string
+  slack_id?: string
+  avatar_url?: string
+  role?: 'admin' | 'editor' | 'viewer'
+  onboarded: boolean
+}
+
+export interface AuthContextType {
+  user: User | null
+  token: string | null
+  isAuthenticated: boolean
+  isLoading: boolean
+  login: (opts?: LoginOptions) => void
+  logout: () => void
+  setToken: (token: string, onboarded: boolean) => void
+  refreshUser: (overrideToken?: string) => Promise<void>
+}


### PR DESCRIPTION
Fixes #21499
Fixes #21605
Fixes #21606

## Summary

Splits the four remaining files flagged with `/* eslint-disable max-lines -- TODO: split this file (tracked by #15790) */` into focused sibling modules and removes the suppression comment from each. The other three files originally listed under #21499 (`lib/unified/types.ts`, `lib/acmm/sources/acmm.ts`, `lib/missions/preflightCheck.ts`) were already split by #21608/#21610.

This is a pure file-organisation refactor — no behaviour change. All original import paths continue to work via re-exports.

## Changes

### `web/src/hooks/useTokenUsage.ts` (828 → ~590 lines)
- **`useTokenUsage.types.ts`** — `TokenCategory`, `TokenUsageByCategory`, `TokenUsage`, `TokenAlertLevel`
- **`useTokenUsage.math.ts`** — pure math helpers: `getTokenAlertLevel`, `reconcileUsageBreakdown`, `getUsagePeriodKey`, `getNextResetDate`, plus the settings/category constants they depend on
- `useTokenUsage.ts` — singleton state, polling, and the React hook; re-exports the public types/functions for backward compatibility

### `web/src/lib/auth.tsx` (859 → ~630 lines)
- **`lib/auth/types.ts`** — `User`, `AuthContextType`
- **`lib/auth/tokenHelpers.ts`** — `getJwtExpiryMs`, `isJWTExpired`, `showExpiryWarningBanner`, `getCachedUser`, `cacheUser`, and the related storage-key/timing constants
- `auth.tsx` — `AuthProvider`/`useAuth` implementation; re-exports `User`, `AuthContextType`, `isJWTExpired` for backward compatibility

### `web/src/hooks/mcp/compute.ts` (817 → ~630 lines)
- **`hooks/mcp/compute/nvidia.ts`** — `useNVIDIAOperators` (fully self-contained hook)
- **`hooks/mcp/compute/demoData.ts`** — static `getDemoGPUNodes` / `getDemoNodes` fallback data
- `compute.ts` — GPU node cache + `useGPUNodes`/`useNodes`; re-exports `useNVIDIAOperators`

### `web/src/hooks/useStackDiscovery.ts` (842 → ~545 lines)
- **`useStackDiscovery.helpers.ts`** — resource type interfaces plus aggregation/filtering helpers: `isLlmdNamespace`, `isLlmdDeployment`, `buildComponentsFromDeployments`, `mergeStackWithCached`, `getStackStatus`, `sortStacks`, `loadCachedStacks`/`saveCachedStacks`
- `useStackDiscovery.ts` — `useStackDiscovery` hook and `stackToServerMetrics`; re-exports `LLMdStack`, `LLMdStackComponent`, `AutoscalerType`, `AutoscalerInfo` for backward compatibility

## Verification

- `cd web && npx tsc --noEmit -p tsconfig.json` — **0 errors** across the whole project
- `cd web && npx eslint <all touched files>` — 0 errors, same warnings as baseline `main` (no new warnings introduced); the stale `Unused eslint-disable directive` warnings are gone now that the suppression comments are removed
- `cd web && npx vitest run <all existing test files for these 4 modules>` — 421 tests, same pass/fail profile as baseline `main` (the handful of intermittent failures reproduce identically on unmodified `main` and are pre-existing vitest worker-pool flakiness, not caused by this change)

## Notes for reviewers

Two earlier attempts at this branch (#21520, #21666, #21671) were closed after taking on too much scope at once (7 files) and hitting rebase/TypeScript breakage. This PR is intentionally scoped to only the 4 files still covered by open issues (#21605, #21606), verified end-to-end with a full `tsc --noEmit` pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
