### PR TITLE
[scanner] fix: improve freshness, refresh, and event a11y parity

### DIFF
--- a/web/src/components/cards/EnterpriseComplianceCards.tsx
+++ b/web/src/components/cards/EnterpriseComplianceCards.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'react-i18next'
 import { useNavigate } from 'react-router-dom'
 import { authFetch, safeJson } from '../../lib/api'
 import { useCache } from '../../lib/cache'
+import { useDemoMode } from '../../hooks/useDemoMode'
 import { TechnicalAcronym } from '../shared/TechnicalAcronym'
 
 // ── Shared helpers ────────────────────────────────────────────────────────
@@ -91,18 +92,21 @@ function MiniStat({ label, value, color = 'text-foreground' }: { label: string; 
 
 export function HIPAACard() {
   const { t } = useTranslation('errors')
+  const { isDemoMode } = useDemoMode()
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(!isDemoMode)
   const [error, setError] = useState<string | null>(null)
   useEffect(() => {
+    if (isDemoMode) { setIsLoading(false); return }
     setIsLoading(true)
     authFetch('/api/compliance/hipaa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
       .catch((err: unknown) => { setError(err instanceof Error ? err.message : t('messages.failedToLoad')); console.error(err) })
       .finally(() => setIsLoading(false))
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDemoMode])
   return (
     <CardShell title="HIPAA Compliance" icon={Shield} onClick={() => nav('/hipaa')}>
       {error ? (
@@ -130,18 +134,21 @@ export function HIPAACard() {
 
 export function GxPCard() {
   const { t } = useTranslation('errors')
+  const { isDemoMode } = useDemoMode()
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, unknown> | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(!isDemoMode)
   const [error, setError] = useState<string | null>(null)
   useEffect(() => {
+    if (isDemoMode) { setIsLoading(false); return }
     setIsLoading(true)
     authFetch('/api/compliance/gxp/summary')
       .then(r => r.ok ? safeJson<Record<string, unknown>>(r) : null)
       .then(setData)
       .catch((err: unknown) => { setError(err instanceof Error ? err.message : t('messages.failedToLoad')); console.error(err) })
       .finally(() => setIsLoading(false))
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDemoMode])
   return (
     <CardShell title="GxP Validation (21 CFR 11)" icon={FileText} onClick={() => nav('/gxp')}>
       {error ? (
@@ -173,18 +180,21 @@ export function GxPCard() {
 
 export function BAACard() {
   const { t } = useTranslation('errors')
+  const { isDemoMode } = useDemoMode()
   const nav = useNavigate()
   const [data, setData] = useState<Record<string, number> | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  const [isLoading, setIsLoading] = useState(!isDemoMode)
   const [error, setError] = useState<string | null>(null)
   useEffect(() => {
+    if (isDemoMode) { setIsLoading(false); return }
     setIsLoading(true)
     authFetch('/api/compliance/baa/summary')
       .then(r => r.ok ? safeJson<Record<string, number>>(r) : null)
       .then(setData)
       .catch((err: unknown) => { setError(err instanceof Error ? err.message : t('messages.failedToLoad')); console.error(err) })
       .finally(() => setIsLoading(false))
-  }, [])
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isDemoMode])
   return (
     <CardShell title="BAA Tracker" icon={FileText} onClick={() => nav('/baa')}>
       {error ? (

--- a/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
+++ b/web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx
@@ -26,7 +26,13 @@ vi.mock('../NamespaceCard', () => ({
     onSelect: () => void
     onDelete?: () => void
   }) => (
-    <div data-testid="namespace-card" onClick={onSelect}>
+    <div
+      data-testid="namespace-card"
+      role="button"
+      tabIndex={0}
+      onClick={onSelect}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect() } }}
+    >
       <span>{namespace.name}</span>
       {onDelete && <button onClick={(e) => { e.stopPropagation(); onDelete() }} aria-label="Delete namespace" />}
     </div>


### PR DESCRIPTION
Fixes #21738
Fixes #21740

> Note on #21739: See investigation below — findings are largely false positives.

## Summary

### #21740 — Event handler accessibility parity
**File:** `web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx`

The `NamespaceCard` mock had an `onClick` handler without corresponding keyboard support. Added `role="button"`, `tabIndex={0}`, and `onKeyDown` (Enter/Space) to the mock so tests accurately model accessible interactive elements.

### #21738 — Stale data and freshness indicators
**File:** `web/src/components/cards/EnterpriseComplianceCards.tsx`

`HIPAACard`, `GxPCard`, and `BAACard` performed raw `authFetch` calls in `useEffect` without subscribing to the global demo mode toggle. This caused live API calls (and failures) even when demo mode was active.

Fix: import `useDemoMode` and bail out early from the fetch when `isDemoMode` is true. The existing "No data" fallback is shown in demo mode, which is correct behavior for these lightweight summary cards that link to full compliance dashboards.

Note: Other `EnterpriseComplianceCards` components that use the shared `useSummaryData` hook are already handled — `useCache` internally respects `demoMode` via its `effectiveEnabled` check.

### #21739 — Refresh icon animation consistency (investigation result: false positives)

After investigating all flagged components, the Auto-QA scanner appears to produce false positives for this issue. Every component I examined already has conditional `animate-spin`:

- `UnifiedDashboard.tsx` → `cn('w-4 h-4 text-muted-foreground', isLoading && 'animate-spin')`
- `RepoPicker.tsx` → `` `w-3.5 h-3.5 ${scan.isRefreshing ? 'animate-spin' : ''}` ``
- `SegregationOfDuties.tsx` → `cn('w-4 h-4', loading && 'animate-spin')`
- `OperatorStatus.tsx` → `` `w-3 h-3 ${isRefreshing ? 'animate-spin' : ''}` ``
- `PodIssues.tsx` → `shouldSpin && isRefreshing && 'animate-spin'`
- `NamespaceManager.tsx` → `animate-spin` on loading state spinner
- `UnifiedStatBlock.tsx` → `animate-spin` inside a `{showPulse && ...}` block
- `KustomizationStatus.tsx` → `(isRefreshing || ks.status === 'Progressing') && 'animate-spin'`

The scanner appears to match any file importing `RefreshCw` without `animate-spin` as a literal adjacent string, missing conditional expressions like `cn(condition && 'animate-spin')` or template literals. No code changes are needed for #21739. Closing as not planned with concrete evidence.

## Files changed
- `web/src/components/namespaces/__tests__/NamespaceClusterGroup.test.tsx` (a11y fix)
- `web/src/components/cards/EnterpriseComplianceCards.tsx` (demo mode subscription)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>