### PR TITLE
[scanner] fix: resolve TypeScript build errors on main

### DIFF
--- a/web/src/components/cards/CardHeader.tsx
+++ b/web/src/components/cards/CardHeader.tsx
@@ -1,5 +1,4 @@
 import type { ComponentType, ReactNode } from 'react'
-import type { TFunction } from 'i18next'
 import { cn } from '@/lib/cn'
 import { InfoTooltip } from './card-wrapper/InfoTooltip'
 import { CardMeta } from './CardMeta'
@@ -11,7 +10,7 @@ interface CardHeaderProps {
   resolvedIconColor: string
   title: string
   description: string
-  t: TFunction
+  t: (key: string, options?: Record<string, unknown>) => string
   showDemoIndicator: boolean
   effectiveIsDemoData: boolean
   isLive?: boolean

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -621,7 +621,8 @@ export const CardWrapper = memo(function CardWrapper({
   // (TS2322) because of its complex overloaded/generic call signature. Wrap it
   // in a simple function that matches CardHeader's expected shape.
   const headerT = useCallback(
-    (key: string, options?: Record<string, unknown>) => t(key, options),
+    (key: string, options?: Record<string, unknown>) =>
+      (t as (key: string, options?: Record<string, unknown>) => string)(key, options),
     [t]
   )
 

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -615,6 +615,16 @@ export const CardWrapper = memo(function CardWrapper({
   )
   const forceLiveValue = useMemo(() => !!forceLive, [forceLive])
 
+  // #21775 — CardHeader expects a plain `(key, options?) => string` translator.
+  // Passing the raw i18next TFunction<['cards','common']> directly triggers an
+  // excessively deep type instantiation (TS2589) and a signature mismatch
+  // (TS2322) because of its complex overloaded/generic call signature. Wrap it
+  // in a simple function that matches CardHeader's expected shape.
+  const headerT = useCallback(
+    (key: string, options?: Record<string, unknown>) => t(key, options),
+    [t]
+  )
+
   return (
     <CardTypeContext.Provider value={cardType}>
     <CardExpandedContext.Provider value={cardExpandedValue}>
@@ -668,7 +678,7 @@ export const CardWrapper = memo(function CardWrapper({
               resolvedIconColor={resolvedIconColor}
               title={title}
               description={description}
-              t={t}
+              t={headerT}
               showDemoIndicator={showDemoIndicator}
               effectiveIsDemoData={effectiveIsDemoData}
               isLive={isLive}

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -678,7 +678,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
     isFiltered,
   })
 
-  const handleStartAnalysis = () => checkKeyAndRun(() => startMission(analysisMissionConfig))
+  const handleStartAnalysis = () => checkKeyAndRun(() => { startMission(analysisMissionConfig) })
 
   return (
     <div className="h-full flex flex-col relative">
@@ -707,7 +707,6 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         predictionIntervalMinutes={predictionSettings.interval}
         onDrillToCluster={drillToCluster}
         onTriggerAnalysis={triggerAIAnalysis}
-        t={t}
       />
 
       {/* Card Controls: Search, Cluster Filter, Sort */}

--- a/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
+++ b/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
@@ -1,6 +1,6 @@
 import { Info, RefreshCw, Sparkles, TrendingUp } from 'lucide-react'
 import { cn } from '../../../lib/cn'
-import type { TFunction } from 'i18next'
+import { useTranslation } from 'react-i18next'
 
 interface OfflineStatusDisplayProps {
   currentClusterIssueCount: number
@@ -21,7 +21,6 @@ interface OfflineStatusDisplayProps {
   predictionIntervalMinutes: number
   onDrillToCluster: (cluster: string) => void
   onTriggerAnalysis: () => void
-  t: TFunction
 }
 
 export function OfflineStatusDisplay({
@@ -39,8 +38,9 @@ export function OfflineStatusDisplay({
   predictionIntervalMinutes,
   onDrillToCluster,
   onTriggerAnalysis,
-  t,
 }: OfflineStatusDisplayProps) {
+  const { t: tCards } = useTranslation('cards')
+  const { t: tCommon } = useTranslation('common')
   return (
     <div className="grid grid-cols-2 @md:grid-cols-3 gap-2 mb-4">
       <div
@@ -56,12 +56,12 @@ export function OfflineStatusDisplay({
           }
         }}
         title={currentClusterIssueCount > 0
-          ? t('common:healthCheck.issuesTooltip', { count: currentClusterIssueCount })
-          : t('cards:consoleOfflineDetection.allHealthy')}
+          ? tCommon('healthCheck.issuesTooltip', { count: currentClusterIssueCount })
+          : tCards('consoleOfflineDetection.allHealthy')}
       >
         <div className="text-xl font-bold text-foreground">{currentClusterIssueCount}</div>
         <div className={cn('text-2xs', currentClusterIssueCount > 0 ? 'text-red-400' : 'text-green-400')}>
-          {t('common:common.issues', { defaultValue: 'Issues' })}
+          {tCommon('common.issues', { defaultValue: 'Issues' })}
         </div>
       </div>
       <div
@@ -80,7 +80,7 @@ export function OfflineStatusDisplay({
       >
         <div className="text-xl font-bold text-foreground">{gpuIssueCount}</div>
         <div className={cn('text-2xs', gpuIssueCount > 0 ? 'text-yellow-400' : 'text-green-400')}>
-          {t('cards:consoleOfflineDetection.gpuIssues')}
+          {tCards('consoleOfflineDetection.gpuIssues')}
         </div>
       </div>
       <div
@@ -122,7 +122,7 @@ ${aiEnabled ? '\nClick to run AI analysis now' : ''}`}
           'text-2xs flex items-center gap-1',
           totalPredicted > 0 ? 'text-blue-400' : 'text-green-400'
         )}>
-          {t('cards:consoleOfflineDetection.predicted')}
+          {tCards('consoleOfflineDetection.predicted')}
           <Info className="w-3 h-3 opacity-60" />
         </div>
       </div>

--- a/web/src/components/settings/sections/AddClusterForm.tsx
+++ b/web/src/components/settings/sections/AddClusterForm.tsx
@@ -5,7 +5,7 @@ import { ClusterProgressBanner } from './ClusterProgressBanner'
 
 interface ToolInfo {
   name: string
-  version: string
+  version: string | undefined
 }
 
 type ClusterProgress = ComponentProps<typeof ClusterProgressBanner>['progress']

--- a/web/src/components/settings/sections/AddClusterForm.tsx
+++ b/web/src/components/settings/sections/AddClusterForm.tsx
@@ -5,7 +5,7 @@ import { ClusterProgressBanner } from './ClusterProgressBanner'
 
 interface ToolInfo {
   name: string
-  version: string | undefined
+  version?: string
 }
 
 type ClusterProgress = ComponentProps<typeof ClusterProgressBanner>['progress']

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -35,16 +35,6 @@ function loadFromStorage<T>(key: string, defaultValue: T, validator?: (value: un
   return defaultValue
 }
 
-// Save to localStorage
-function saveToStorage<T>(key: string, value: T): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value))
-  } catch (e: unknown) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
-    // Silently fail - localStorage quota may be exceeded but functionality continues
-  }
-}
-
 // Default empty stats returned when AlertsProvider is absent
 const _defaultAlertStats: AlertStats = { total: 0, firing: 0, resolved: 0, critical: 0, warning: 0, info: 0, acknowledged: 0 }
 


### PR DESCRIPTION
Fixes #21764, Fixes #21765, Fixes #21766, Fixes #21773, Fixes #21774

## TypeScript Build Error Fixes

Resolves 11 TypeScript errors introduced by component-split PRs #21754–#21759.

### Changes

**`web/src/components/cards/CardHeader.tsx`**
- Relax `t` prop type from `TFunction` (i18next branded) to `(key: string, options?: Record<string, unknown>) => string`
- Fixes TS2322/TS2589 — brand mismatch when `CardWrapper` passes `TFunction<['cards','common']>`

**`web/src/components/cards/console-missions/OfflineStatusDisplay.tsx`**
- Remove `t: TFunction` prop; call `useTranslation('cards')` and `useTranslation('common')` internally
- Replace namespace-prefixed keys (`common:...`, `cards:...`) with direct keys on the correct hook
- Fixes TS2345 at lines 59, 60, 83, 125

**`web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx`**
- Remove `t={t}` prop from `<OfflineStatusDisplay>` (no longer needed)
- Wrap `startMission(analysisMissionConfig)` in block body `{ }` to discard `string` return value
- Fixes TS2322 at lines 681 and 710

**`web/src/components/settings/sections/AddClusterForm.tsx`**
- Widen `ToolInfo.version` from `string` to `string | undefined` to match `LocalClusterTool`
- Fixes TS2322 in `LocalClustersSection.tsx:332`

**`web/src/hooks/useAlerts.ts`**
- Remove unused `saveToStorage` helper function
- Fixes TS6133