### PR TITLE
[quality] test: 61 unit tests for EventModal.utils and GPUDetailModal.utils

### DIFF
--- a/web/src/components/clusters/components/__tests__/GPUDetailModal.utils.test.ts
+++ b/web/src/components/clusters/components/__tests__/GPUDetailModal.utils.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import type { GPUNode } from '../../../../hooks/mcp/types.gpu'
+import {
+  extractManufacturer,
+  getUtilizationColor,
+  buildGpuTypeInfo,
+  buildClusterInfo,
+  GPU_UTIL_HIGH,
+  GPU_UTIL_WARN,
+} from '../GPUDetailModal.utils'
+
+function node(overrides: Partial<GPUNode> = {}): GPUNode {
+  return {
+    name: overrides.name ?? 'node-a',
+    cluster: overrides.cluster ?? 'c1',
+    gpuType: overrides.gpuType ?? 'NVIDIA A100',
+    gpuCount: overrides.gpuCount ?? 4,
+    gpuAllocated: overrides.gpuAllocated ?? 2,
+    ...overrides,
+  } as GPUNode
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+describe('GPUDetailModal.utils constants', () => {
+  it('exposes utilization thresholds', () => {
+    expect(GPU_UTIL_HIGH).toBe(90)
+    expect(GPU_UTIL_WARN).toBe(70)
+  })
+})
+
+// ─── extractManufacturer ─────────────────────────────────────────────────────
+
+describe('extractManufacturer', () => {
+  it.each([
+    ['NVIDIA A100', 'NVIDIA'],
+    ['nvidia h100', 'NVIDIA'],
+    ['AMD MI300', 'AMD'],
+    ['AMD Radeon Pro', 'AMD'],
+    ['Radeon Instinct', 'AMD'],
+    ['Intel Gaudi2', 'Intel'],
+    ['intel xpu', 'Intel'],
+  ])('detects %s → %s', (input, expected) => {
+    expect(extractManufacturer(input)).toBe(expected)
+  })
+
+  it('returns Unknown for unrecognized vendors', () => {
+    expect(extractManufacturer('IBM AIU')).toBe('Unknown')
+    expect(extractManufacturer('Google TPU v5')).toBe('Unknown')
+    expect(extractManufacturer('')).toBe('Unknown')
+  })
+})
+
+// ─── getUtilizationColor ─────────────────────────────────────────────────────
+
+describe('getUtilizationColor', () => {
+  it('returns red at or above GPU_UTIL_HIGH', () => {
+    expect(getUtilizationColor(90)).toBe('text-red-400')
+    expect(getUtilizationColor(100)).toBe('text-red-400')
+    expect(getUtilizationColor(150)).toBe('text-red-400')
+  })
+
+  it('returns yellow at or above GPU_UTIL_WARN but below GPU_UTIL_HIGH', () => {
+    expect(getUtilizationColor(70)).toBe('text-yellow-400')
+    expect(getUtilizationColor(89)).toBe('text-yellow-400')
+    expect(getUtilizationColor(89.999)).toBe('text-yellow-400')
+  })
+
+  it('returns green below GPU_UTIL_WARN', () => {
+    expect(getUtilizationColor(0)).toBe('text-green-400')
+    expect(getUtilizationColor(69)).toBe('text-green-400')
+    expect(getUtilizationColor(-5)).toBe('text-green-400')
+  })
+})
+
+// ─── buildGpuTypeInfo ────────────────────────────────────────────────────────
+
+describe('buildGpuTypeInfo', () => {
+  it('returns empty for empty input', () => {
+    expect(buildGpuTypeInfo([])).toEqual([])
+  })
+
+  it('aggregates counts, allocation, availability, and node count per gpuType', () => {
+    const result = buildGpuTypeInfo([
+      node({ name: 'a', cluster: 'c1', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 2 }),
+      node({ name: 'b', cluster: 'c1', gpuType: 'NVIDIA A100', gpuCount: 2, gpuAllocated: 2 }),
+      node({ name: 'c', cluster: 'c2', gpuType: 'AMD MI300', gpuCount: 8, gpuAllocated: 1 }),
+    ])
+    const a100 = result.find((r) => r.type === 'NVIDIA A100')!
+    const amd = result.find((r) => r.type === 'AMD MI300')!
+    expect(a100).toMatchObject({
+      type: 'NVIDIA A100',
+      manufacturer: 'NVIDIA',
+      totalGPUs: 6,
+      allocatedGPUs: 4,
+      availableGPUs: 2,
+      nodeCount: 2,
+    })
+    expect(amd).toMatchObject({
+      type: 'AMD MI300',
+      manufacturer: 'AMD',
+      totalGPUs: 8,
+      allocatedGPUs: 1,
+      availableGPUs: 7,
+      nodeCount: 1,
+    })
+  })
+
+  it('deduplicates cluster names in the clusters array', () => {
+    const result = buildGpuTypeInfo([
+      node({ name: 'a', cluster: 'prod', gpuType: 'NVIDIA A100' }),
+      node({ name: 'b', cluster: 'prod', gpuType: 'NVIDIA A100' }),
+      node({ name: 'c', cluster: 'staging', gpuType: 'NVIDIA A100' }),
+    ])
+    expect(result[0].clusters).toEqual(['prod', 'staging'])
+  })
+
+  it('sorts results by descending totalGPUs', () => {
+    const result = buildGpuTypeInfo([
+      node({ name: 'a', gpuType: 'Small', gpuCount: 1 }),
+      node({ name: 'b', gpuType: 'Big', gpuCount: 10 }),
+      node({ name: 'c', gpuType: 'Medium', gpuCount: 5 }),
+    ])
+    expect(result.map((r) => r.type)).toEqual(['Big', 'Medium', 'Small'])
+  })
+})
+
+// ─── buildClusterInfo ────────────────────────────────────────────────────────
+
+describe('buildClusterInfo', () => {
+  it('returns empty for empty input', () => {
+    expect(buildClusterInfo([])).toEqual([])
+  })
+
+  it('aggregates counts per cluster and lists unique GPU types', () => {
+    const result = buildClusterInfo([
+      node({ name: 'a', cluster: 'prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 3 }),
+      node({ name: 'b', cluster: 'prod', gpuType: 'NVIDIA A100', gpuCount: 4, gpuAllocated: 1 }),
+      node({ name: 'c', cluster: 'prod', gpuType: 'AMD MI300', gpuCount: 2, gpuAllocated: 0 }),
+      node({ name: 'd', cluster: 'staging', gpuType: 'Intel Gaudi2', gpuCount: 1, gpuAllocated: 1 }),
+    ])
+    const prod = result.find((r) => r.cluster === 'prod')!
+    const staging = result.find((r) => r.cluster === 'staging')!
+    expect(prod).toMatchObject({
+      cluster: 'prod',
+      totalGPUs: 10,
+      allocatedGPUs: 4,
+      availableGPUs: 6,
+      nodeCount: 3,
+    })
+    expect(new Set(prod.gpuTypes)).toEqual(new Set(['NVIDIA A100', 'AMD MI300']))
+    expect(staging).toMatchObject({
+      cluster: 'staging',
+      totalGPUs: 1,
+      allocatedGPUs: 1,
+      availableGPUs: 0,
+      nodeCount: 1,
+      gpuTypes: ['Intel Gaudi2'],
+    })
+  })
+
+  it('sorts clusters by descending totalGPUs', () => {
+    const result = buildClusterInfo([
+      node({ cluster: 'small', gpuCount: 1 }),
+      node({ cluster: 'huge', gpuCount: 20 }),
+      node({ cluster: 'mid', gpuCount: 5 }),
+    ])
+    expect(result.map((r) => r.cluster)).toEqual(['huge', 'mid', 'small'])
+  })
+})

--- a/web/src/components/stellar/__tests__/EventModal.utils.test.ts
+++ b/web/src/components/stellar/__tests__/EventModal.utils.test.ts
@@ -1,0 +1,313 @@
+import { describe, it, expect } from 'vitest'
+import type { StellarNotification, StellarSolve } from '../../../types/stellar'
+import {
+  severityColor,
+  statusLabel,
+  extractResourceName,
+  formatAbsoluteUtc,
+  formatRelative,
+  buildInvestigatePrompt,
+  matchesSolve,
+  getErrorMessage,
+  RELATED_EVENT_LIMIT,
+  TIMELINE_ENTRY_LIMIT,
+  INVESTIGATION_ACTIVITY_LIMIT,
+  INVESTIGATION_TEXTAREA_ROWS,
+  CONFIRMATION_TEXTAREA_ROWS,
+} from '../EventModal.utils'
+
+function notification(overrides: Partial<StellarNotification> = {}): StellarNotification {
+  return {
+    id: overrides.id ?? 'n1',
+    type: overrides.type ?? 'event',
+    severity: overrides.severity ?? 'info',
+    title: overrides.title ?? 'Untitled',
+    body: overrides.body ?? '',
+    read: overrides.read ?? false,
+    createdAt: overrides.createdAt ?? '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as StellarNotification
+}
+
+function solve(overrides: Partial<StellarSolve> = {}): StellarSolve {
+  return {
+    id: overrides.id ?? 's1',
+    eventId: overrides.eventId ?? 'e1',
+    userId: overrides.userId ?? 'u1',
+    cluster: overrides.cluster ?? 'c1',
+    namespace: overrides.namespace ?? 'ns1',
+    workload: overrides.workload ?? 'w1',
+    status: overrides.status ?? 'running',
+    actionsTaken: overrides.actionsTaken ?? 0,
+    summary: overrides.summary ?? '',
+    startedAt: overrides.startedAt ?? '2026-01-01T00:00:00Z',
+    ...overrides,
+  } as StellarSolve
+}
+
+// ─── constants ───────────────────────────────────────────────────────────────
+
+describe('EventModal.utils constants', () => {
+  it('exposes expected numeric limits', () => {
+    expect(RELATED_EVENT_LIMIT).toBe(6)
+    expect(TIMELINE_ENTRY_LIMIT).toBe(8)
+    expect(INVESTIGATION_ACTIVITY_LIMIT).toBe(6)
+    expect(INVESTIGATION_TEXTAREA_ROWS).toBe(3)
+    expect(CONFIRMATION_TEXTAREA_ROWS).toBe(4)
+  })
+})
+
+// ─── severityColor ───────────────────────────────────────────────────────────
+
+describe('severityColor', () => {
+  it('returns critical color for critical severity', () => {
+    expect(severityColor('critical')).toBe('var(--s-critical)')
+  })
+  it('returns warning color for warning severity', () => {
+    expect(severityColor('warning')).toBe('var(--s-warning)')
+  })
+  it('falls back to info color for info severity', () => {
+    expect(severityColor('info')).toBe('var(--s-info)')
+  })
+  it('falls back to info color for unknown severity', () => {
+    expect(severityColor('unknown-value')).toBe('var(--s-info)')
+    expect(severityColor('')).toBe('var(--s-info)')
+  })
+})
+
+// ─── statusLabel ─────────────────────────────────────────────────────────────
+
+describe('statusLabel', () => {
+  it.each([
+    ['investigating', 'Investigating'],
+    ['resolved', 'Resolved'],
+    ['dismissed', 'Removed'],
+    ['exhausted', 'Paused'],
+    ['open', 'Open'],
+    ['escalated', 'Escalated'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(statusLabel(input)).toBe(expected)
+  })
+
+  it('defaults to Escalated for unknown status', () => {
+    expect(statusLabel('bogus')).toBe('Escalated')
+  })
+
+  it('defaults to Escalated when status is undefined', () => {
+    expect(statusLabel(undefined)).toBe('Escalated')
+  })
+})
+
+// ─── extractResourceName ─────────────────────────────────────────────────────
+
+describe('extractResourceName', () => {
+  it('returns empty string when dedupeKey is absent', () => {
+    expect(extractResourceName(notification())).toBe('')
+  })
+
+  it('parses ev-prefixed dedupeKey (ev:cluster:ns:name)', () => {
+    expect(
+      extractResourceName(notification({ dedupeKey: 'ev:prod:kube-system:coredns' })),
+    ).toBe('coredns')
+  })
+
+  it('parses non-ev dedupeKey (cluster:ns:name)', () => {
+    expect(
+      extractResourceName(notification({ dedupeKey: 'prod:kube-system:coredns' })),
+    ).toBe('coredns')
+  })
+
+  it('returns empty when dedupeKey has too few segments', () => {
+    expect(extractResourceName(notification({ dedupeKey: 'ev:only' }))).toBe('')
+    expect(extractResourceName(notification({ dedupeKey: 'a:b' }))).toBe('')
+  })
+})
+
+// ─── formatAbsoluteUtc ───────────────────────────────────────────────────────
+
+describe('formatAbsoluteUtc', () => {
+  it('returns Unavailable for undefined input', () => {
+    expect(formatAbsoluteUtc(undefined)).toBe('Unavailable')
+  })
+
+  it('returns Unavailable for empty string', () => {
+    expect(formatAbsoluteUtc('')).toBe('Unavailable')
+  })
+
+  it('returns Unavailable for invalid date string', () => {
+    expect(formatAbsoluteUtc('not-a-date')).toBe('Unavailable')
+  })
+
+  it('formats a valid ISO date as UTC and suffixes " UTC"', () => {
+    const out = formatAbsoluteUtc('2026-03-15T04:05:06Z')
+    expect(out.endsWith(' UTC')).toBe(true)
+    // Deterministic components (locale/CI-independent digits)
+    expect(out).toMatch(/\b2026\b/)
+    expect(out).toMatch(/04:05:06/)
+  })
+})
+
+// ─── formatRelative ──────────────────────────────────────────────────────────
+
+describe('formatRelative', () => {
+  it('returns "just now" for undefined', () => {
+    expect(formatRelative(undefined)).toBe('just now')
+  })
+
+  it('returns "just now" for a timestamp <1 minute ago', () => {
+    const now = Date.now()
+    expect(formatRelative(new Date(now - 30 * 1000).toISOString())).toBe('just now')
+  })
+
+  it('returns Nm ago for minutes up to 59', () => {
+    const now = Date.now()
+    expect(formatRelative(new Date(now - 5 * 60 * 1000 - 500).toISOString())).toBe('5m ago')
+    expect(formatRelative(new Date(now - 59 * 60 * 1000 - 500).toISOString())).toBe('59m ago')
+  })
+
+  it('returns Nh ago for hours up to 23', () => {
+    const now = Date.now()
+    expect(formatRelative(new Date(now - 3 * 3600 * 1000 - 500).toISOString())).toBe('3h ago')
+    expect(formatRelative(new Date(now - 23 * 3600 * 1000 - 500).toISOString())).toBe('23h ago')
+  })
+
+  it('returns Nd ago for anything ≥24 hours', () => {
+    const now = Date.now()
+    expect(formatRelative(new Date(now - 24 * 3600 * 1000 - 500).toISOString())).toBe('1d ago')
+    expect(formatRelative(new Date(now - 7 * 24 * 3600 * 1000 - 500).toISOString())).toBe('7d ago')
+  })
+})
+
+// ─── buildInvestigatePrompt ──────────────────────────────────────────────────
+
+describe('buildInvestigatePrompt', () => {
+  it('includes cluster and namespace when both present', () => {
+    const p = buildInvestigatePrompt(
+      notification({ title: 'CrashLoop', cluster: 'prod', namespace: 'default' }),
+    )
+    expect(p).toContain('Investigate CrashLoop')
+    expect(p).toContain('on cluster prod')
+    expect(p).toContain('in namespace default')
+  })
+
+  it('omits cluster suffix when cluster is missing', () => {
+    const p = buildInvestigatePrompt(notification({ title: 'X', namespace: 'ns' }))
+    expect(p).not.toContain('on cluster')
+    expect(p).toContain('in namespace ns')
+  })
+
+  it('omits namespace suffix when namespace is missing', () => {
+    const p = buildInvestigatePrompt(notification({ title: 'X', cluster: 'c' }))
+    expect(p).toContain('on cluster c')
+    expect(p).not.toContain('in namespace')
+  })
+
+  it('omits both suffixes when neither cluster nor namespace is set', () => {
+    const p = buildInvestigatePrompt(notification({ title: 'X' }))
+    expect(p.startsWith('Investigate X.')).toBe(true)
+  })
+})
+
+// ─── matchesSolve ────────────────────────────────────────────────────────────
+
+describe('matchesSolve', () => {
+  it('returns false when cluster differs', () => {
+    expect(
+      matchesSolve(
+        notification({ cluster: 'a', namespace: 'ns', dedupeKey: 'ev:a:ns:foo' }),
+        solve({ cluster: 'b', namespace: 'ns', workload: 'foo' }),
+      ),
+    ).toBe(false)
+  })
+
+  it('returns false when namespace differs', () => {
+    expect(
+      matchesSolve(
+        notification({ cluster: 'a', namespace: 'ns1', dedupeKey: 'ev:a:ns1:foo' }),
+        solve({ cluster: 'a', namespace: 'ns2', workload: 'foo' }),
+      ),
+    ).toBe(false)
+  })
+
+  it('treats missing notification.cluster/namespace as empty string', () => {
+    // solve.cluster='' & solve.namespace='' should match a notification without those fields
+    expect(
+      matchesSolve(
+        notification({ id: 'evx' }),
+        solve({ cluster: '', namespace: '', workload: 'anything', eventId: 'evx' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('falls back to id === eventId when dedupeKey does not yield a resource name', () => {
+    expect(
+      matchesSolve(
+        notification({ id: 'ev-42', cluster: 'a', namespace: 'ns' }),
+        solve({ cluster: 'a', namespace: 'ns', workload: 'ignored', eventId: 'ev-42' }),
+      ),
+    ).toBe(true)
+    expect(
+      matchesSolve(
+        notification({ id: 'ev-42', cluster: 'a', namespace: 'ns' }),
+        solve({ cluster: 'a', namespace: 'ns', workload: 'ignored', eventId: 'other' }),
+      ),
+    ).toBe(false)
+  })
+
+  it('matches when resource name starts with the workload', () => {
+    expect(
+      matchesSolve(
+        notification({ cluster: 'a', namespace: 'ns', dedupeKey: 'ev:a:ns:myapp-abc123' }),
+        solve({ cluster: 'a', namespace: 'ns', workload: 'myapp' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('matches when workload equals the resource name exactly', () => {
+    expect(
+      matchesSolve(
+        notification({ cluster: 'a', namespace: 'ns', dedupeKey: 'ev:a:ns:coredns' }),
+        solve({ cluster: 'a', namespace: 'ns', workload: 'coredns' }),
+      ),
+    ).toBe(true)
+  })
+
+  it('does not match on suffix-only workload substrings', () => {
+    expect(
+      matchesSolve(
+        notification({ cluster: 'a', namespace: 'ns', dedupeKey: 'ev:a:ns:coredns' }),
+        solve({ cluster: 'a', namespace: 'ns', workload: 'dns' }),
+      ),
+    ).toBe(false)
+  })
+})
+
+// ─── getErrorMessage ─────────────────────────────────────────────────────────
+
+describe('getErrorMessage', () => {
+  it('returns fallback for null/undefined/primitive input', () => {
+    expect(getErrorMessage(null, 'fb')).toBe('fb')
+    expect(getErrorMessage(undefined, 'fb')).toBe('fb')
+    expect(getErrorMessage(42, 'fb')).toBe('fb')
+    expect(getErrorMessage('str', 'fb')).toBe('fb')
+  })
+
+  it('extracts axios-shaped response.data.error before falling back', () => {
+    const err = { response: { data: { error: 'server rejected' } } }
+    expect(getErrorMessage(err, 'fb')).toBe('server rejected')
+  })
+
+  it('returns Error.message when input is an Error instance', () => {
+    expect(getErrorMessage(new Error('boom'), 'fb')).toBe('boom')
+  })
+
+  it('returns fallback when Error.message is empty', () => {
+    expect(getErrorMessage(new Error(''), 'fb')).toBe('fb')
+  })
+
+  it('returns fallback when response.data.error is absent', () => {
+    expect(getErrorMessage({ response: { data: {} } }, 'fb')).toBe('fb')
+    expect(getErrorMessage({ response: {} }, 'fb')).toBe('fb')
+    expect(getErrorMessage({ notResponse: true }, 'fb')).toBe('fb')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds **61 unit tests** for two previously-uncovered `*.utils.ts` modules extracted from the scanner-generated modal splits (per issue #21762). Follow-up to PR #21763 which covered the last three tiny `.utils.ts` files; this pair are the largest remaining untested pure-logic modules.

### New test files

| File | Tests | What's verified |
|------|-------|-----------------|
| `components/stellar/__tests__/EventModal.utils.test.ts` | **42** | `severityColor` (critical/warning/info/unknown); `statusLabel` (6 enum branches + default + undefined); `extractResourceName` (`ev:` prefix vs plain, short-segment guards, missing dedupeKey); `formatAbsoluteUtc` (Unavailable branches for `undefined`/empty/invalid, locale-independent digit assertions on valid ISO); `formatRelative` (just-now/minutes/hours/days windows, all boundary conditions); `buildInvestigatePrompt` (cluster + namespace suffix combinatorics, 4 cases); `matchesSolve` (cluster/namespace mismatch, empty-string fallback, dedupeKey→resource-name matching, workload **prefix vs suffix distinction**); `getErrorMessage` (axios `response.data.error` shape, `Error` instance, empty message, unknown input) |
| `components/clusters/components/__tests__/GPUDetailModal.utils.test.ts` | **19** | `extractManufacturer` (NVIDIA/AMD/Intel/Radeon detection + Unknown fallback for IBM/Google/empty); `getUtilizationColor` (`GPU_UTIL_HIGH=90` / `GPU_UTIL_WARN=70` **threshold boundaries** including >100 and negative); `buildGpuTypeInfo` (per-type aggregation, cluster dedup within array, descending totalGPUs sort); `buildClusterInfo` (per-cluster aggregation, gpuTypes dedup, descending totalGPUs sort) |

All tests are pure Vitest — no React/DOM required. Verified locally:

```
$ npx vitest run \
    src/components/stellar/__tests__/EventModal.utils.test.ts \
    src/components/clusters/components/__tests__/GPUDetailModal.utils.test.ts

  ✓ EventModal.utils.test.ts (42 tests)
  ✓ GPUDetailModal.utils.test.ts (19 tests)
  Test Files  2 passed (2)
       Tests  61 passed (61)
```

### Notes

- `formatRelative` uses `Date.now()` internally; tests compute expected offsets relative to `Date.now()` at test time with a small (500ms) cushion so boundary bins are deterministic regardless of scheduler jitter — avoids the fragility of `vi.useFakeTimers()` / `vi.setSystemTime()` in this setup.
- `matchesSolve` exercises the subtle rule that `resourceName.startsWith(solve.workload)` matches while a suffix (e.g. workload=`dns` on `coredns`) does not — this is a behavioral invariant the extracted modal relies on.

Refs #21762

---
*Filed by quality agent (ACMM L4/L6 — full mode)*