### PR TITLE
[scanner] fix: resolve TypeScript build errors on main

### DIFF
--- a/web/src/components/cards/CardHeader.tsx
+++ b/web/src/components/cards/CardHeader.tsx
@@ -11,7 +11,7 @@ interface CardHeaderProps {
   resolvedIconColor: string
   title: string
   description: string
-  t: TFunction<'cards'>
+  t: TFunction
   showDemoIndicator: boolean
   effectiveIsDemoData: boolean
   isLive?: boolean
@@ -78,7 +78,15 @@ export function CardHeader({
         {dragHandle}
         {ResolvedIcon && <ResolvedIcon className={cn('h-4 w-4 shrink-0', resolvedIconColor)} />}
         <h2 className="truncate text-sm font-medium text-foreground">{title}</h2>
-        <InfoTooltip text={description || t('messages.descriptionComingSoon', { title })} />
+        <InfoTooltip
+          text={
+            description ||
+            t('common:messages.descriptionComingSoon', {
+              title,
+              defaultValue: `Description for ${title} coming soon`,
+            })
+          }
+        />
         <CardMeta
           showDemoIndicator={showDemoIndicator}
           isDemoData={effectiveIsDemoData}

--- a/web/src/components/cards/CardHeader.tsx
+++ b/web/src/components/cards/CardHeader.tsx
@@ -11,7 +11,7 @@ interface CardHeaderProps {
   resolvedIconColor: string
   title: string
   description: string
-  t: TFunction
+  t: TFunction<'cards'>
   showDemoIndicator: boolean
   effectiveIsDemoData: boolean
   isLive?: boolean

--- a/web/src/components/cards/CardWrapper.tsx
+++ b/web/src/components/cards/CardWrapper.tsx
@@ -236,7 +236,8 @@ export const CardWrapper = memo(function CardWrapper({
   skeletonRows,
   registerExpandTrigger,
   children }: CardWrapperProps) {
-  const { t } = useTranslation(['cards', 'common'])
+  const { t: tCards } = useTranslation('cards')
+  const { t: tCommon } = useTranslation('common')
   const { setFullScreen } = useMissions()
   const [isExpanded, setIsExpanded] = useState(false)
   const { containerSize, expandedContentRef } = useResizeHandle(isExpanded)
@@ -522,10 +523,10 @@ export const CardWrapper = memo(function CardWrapper({
   // Use external messages if provided, otherwise use local state
   const messages = externalMessages ?? localMessages
 
-  const title = t(`titles.${cardType}`, CARD_TITLES[cardType] || '') || customTitle || cardType
-  const description = t(`descriptions.${cardType}`, CARD_DESCRIPTIONS[cardType] || '')
+  const title = tCards(`titles.${cardType}`, CARD_TITLES[cardType] || '') || customTitle || cardType
+  const description = tCards(`descriptions.${cardType}`, CARD_DESCRIPTIONS[cardType] || '')
   const swapType = pendingSwap?.newType || ''
-  const newTitle = pendingSwap?.newTitle || t(`titles.${swapType}`, CARD_TITLES[swapType] || '') || swapType
+  const newTitle = pendingSwap?.newTitle || tCards(`titles.${swapType}`, CARD_TITLES[swapType] || '') || swapType
 
   // Get icon from prop or registry
   const cardIconConfig = CARD_ICONS[cardType]
@@ -668,7 +669,7 @@ export const CardWrapper = memo(function CardWrapper({
               resolvedIconColor={resolvedIconColor}
               title={title}
               description={description}
-              t={t}
+              t={tCards}
               showDemoIndicator={showDemoIndicator}
               effectiveIsDemoData={effectiveIsDemoData}
               isLive={isLive}
@@ -752,7 +753,7 @@ export const CardWrapper = memo(function CardWrapper({
               onSwapCancel={onSwapCancel}
               showSummary={showSummary}
               lastSummary={lastSummary}
-              summaryLabel={t('common:labels.sinceFocus')}
+              summaryLabel={tCommon('labels.sinceFocus')}
             />
           </div>
           </div>{/* Close outer wrapper for demo corner brackets */}

--- a/web/src/components/cards/console-missions/AIAnalysisPanel.tsx
+++ b/web/src/components/cards/console-missions/AIAnalysisPanel.tsx
@@ -38,7 +38,7 @@ export function AIAnalysisPanel({
     return (
       <div className="w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-lg text-sm text-muted-foreground bg-secondary/30">
         <Loader2 className="w-4 h-4 animate-spin" />
-        {t('common:common.loading', 'Loading...')}
+        {t('common:loading', 'Loading...')}
       </div>
     )
   }
@@ -72,7 +72,7 @@ export function AIAnalysisPanel({
       {filteredTotalIssues === 0 && filteredTotalPredicted === 0 ? (
         <>
           <CheckCircle className="w-4 h-4" />
-          {isFiltered ? t('common:common.noMatchingItems', 'No matching items') : t('cards:consoleOfflineDetection.allHealthy', 'All Healthy')}
+          {isFiltered ? t('common:noMatchingItems', 'No matching items') : t('cards:consoleOfflineDetection.allHealthy', 'All Healthy')}
         </>
       ) : runningMission ? (
         <>

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -259,7 +259,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         return [{
           cluster: cluster.name,
           state,
-          reason: t('common:common.unhealthy'),
+          reason: t('common:unhealthy'),
           reasonDetailed: cluster.errorMessage || t('cards:clusterHealth.clusterHasIssues'),
           severity: 'warning',
         }]
@@ -269,7 +269,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         return [{
           cluster: cluster.name,
           state,
-          reason: t('common:common.offline'),
+          reason: t('common:offline'),
           reasonDetailed: isClusterTokenExpired(cluster)
             ? t('cards:clusterHealth.tokenExpired')
             : (cluster.errorMessage || t('cards:clusterHealth.offlineCheckNetwork')),
@@ -739,7 +739,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         <CardSearchInput
           value={search}
           onChange={setSearch}
-          placeholder={t('common:common.searchIssues')}
+          placeholder={t('common:searchIssues')}
           className="flex-1 mb-0!"
         />
         {rootCauseGroups.length > 0 && rootCauseGroups.some(g => g.items.length > 1) && (

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -259,7 +259,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         return [{
           cluster: cluster.name,
           state,
-          reason: t('common:unhealthy'),
+          reason: t('common:common.unhealthy'),
           reasonDetailed: cluster.errorMessage || t('cards:clusterHealth.clusterHasIssues'),
           severity: 'warning',
         }]
@@ -269,7 +269,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         return [{
           cluster: cluster.name,
           state,
-          reason: t('common:offline'),
+          reason: t('common:common.offline'),
           reasonDetailed: isClusterTokenExpired(cluster)
             ? t('cards:clusterHealth.tokenExpired')
             : (cluster.errorMessage || t('cards:clusterHealth.offlineCheckNetwork')),
@@ -678,7 +678,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
     isFiltered,
   })
 
-  const handleStartAnalysis = () => checkKeyAndRun(() => startMission(analysisMissionConfig))
+  const handleStartAnalysis = () => checkKeyAndRun(() => { startMission(analysisMissionConfig) })
 
   return (
     <div className="h-full flex flex-col relative">
@@ -739,7 +739,7 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         <CardSearchInput
           value={search}
           onChange={setSearch}
-          placeholder={t('common:searchIssues')}
+          placeholder={t('common:common.searchIssues')}
           className="flex-1 mb-0!"
         />
         {rootCauseGroups.length > 0 && rootCauseGroups.some(g => g.items.length > 1) && (

--- a/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
+++ b/web/src/components/cards/console-missions/ConsoleOfflineDetectionCard.tsx
@@ -678,7 +678,9 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
     isFiltered,
   })
 
-  const handleStartAnalysis = () => checkKeyAndRun(() => { startMission(analysisMissionConfig) })
+  const handleStartAnalysis = () => checkKeyAndRun(() => {
+    void startMission(analysisMissionConfig)
+  })
 
   return (
     <div className="h-full flex flex-col relative">
@@ -706,7 +708,9 @@ export function ConsoleOfflineDetectionCard(_props: ConsoleMissionCardProps) {
         thresholds={THRESHOLDS}
         predictionIntervalMinutes={predictionSettings.interval}
         onDrillToCluster={drillToCluster}
-        onTriggerAnalysis={triggerAIAnalysis}
+        onTriggerAnalysis={() => {
+          void triggerAIAnalysis()
+        }}
         t={t}
       />
 

--- a/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
+++ b/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
@@ -21,7 +21,7 @@ interface OfflineStatusDisplayProps {
   predictionIntervalMinutes: number
   onDrillToCluster: (cluster: string) => void
   onTriggerAnalysis: () => void
-  t: TFunction<readonly ['cards', 'common']>
+  t: TFunction
 }
 
 export function OfflineStatusDisplay({

--- a/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
+++ b/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
@@ -61,7 +61,7 @@ export function OfflineStatusDisplay({
       >
         <div className="text-xl font-bold text-foreground">{currentClusterIssueCount}</div>
         <div className={cn('text-2xs', currentClusterIssueCount > 0 ? 'text-red-400' : 'text-green-400')}>
-          {t('common:common.issues', { defaultValue: 'Issues' })}
+          {t('common:cluster.issues', { defaultValue: 'Issues' })}
         </div>
       </div>
       <div

--- a/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
+++ b/web/src/components/cards/console-missions/OfflineStatusDisplay.tsx
@@ -21,7 +21,7 @@ interface OfflineStatusDisplayProps {
   predictionIntervalMinutes: number
   onDrillToCluster: (cluster: string) => void
   onTriggerAnalysis: () => void
-  t: TFunction
+  t: TFunction<readonly ['cards', 'common']>
 }
 
 export function OfflineStatusDisplay({

--- a/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
+++ b/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
@@ -86,7 +86,7 @@ export function RootCauseAnalyzer({
     return (
       <div className="flex items-center justify-center h-full text-sm text-muted-foreground py-4">
         <CheckCircle className="w-4 h-4 mr-2 text-green-400" />
-        {search || localClusterFilter.length > 0 ? t('common:noMatchingItems') : t('cards:consoleOfflineDetection.allHealthy')}
+        {search || localClusterFilter.length > 0 ? t('common:common.noMatchingItems') : t('cards:consoleOfflineDetection.allHealthy')}
       </div>
     )
   }

--- a/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
+++ b/web/src/components/cards/console-missions/RootCauseAnalyzer.tsx
@@ -68,7 +68,7 @@ export function RootCauseAnalyzer({
     return (
       <div className="flex items-center justify-center h-full py-4 text-sm text-muted-foreground">
         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-        {t('common:common.loading', 'Loading...')}
+        {t('common:loading', 'Loading...')}
       </div>
     )
   }
@@ -86,7 +86,7 @@ export function RootCauseAnalyzer({
     return (
       <div className="flex items-center justify-center h-full text-sm text-muted-foreground py-4">
         <CheckCircle className="w-4 h-4 mr-2 text-green-400" />
-        {search || localClusterFilter.length > 0 ? t('common:common.noMatchingItems') : t('cards:consoleOfflineDetection.allHealthy')}
+        {search || localClusterFilter.length > 0 ? t('common:noMatchingItems') : t('cards:consoleOfflineDetection.allHealthy')}
       </div>
     )
   }

--- a/web/src/components/cards/console-missions/UnifiedItemsList.tsx
+++ b/web/src/components/cards/console-missions/UnifiedItemsList.tsx
@@ -46,7 +46,7 @@ export function UnifiedItemsList({
     return (
       <div className="flex items-center justify-center h-full py-4 text-sm text-muted-foreground">
         <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-        {t('common:common.loading', 'Loading...')}
+        {t('common:loading', 'Loading...')}
       </div>
     )
   }
@@ -159,7 +159,7 @@ function OfflineNodeRow({
           )}
         </div>
         <div className="text-red-400 truncate mt-0.5">
-          {rootCause?.details || (node.unschedulable ? t('common:common.cordoned') : node.status)}
+          {rootCause?.details || (node.unschedulable ? t('common:cordoned') : node.status)}
         </div>
       </div>
       <div className="flex items-center gap-1 shrink-0 ml-2">
@@ -199,7 +199,7 @@ function ClusterHealthIssueRow({
         <div className="flex items-center gap-1.5 flex-wrap">
           <span className="font-medium text-foreground truncate">{issue.cluster}</span>
           <StatusBadge color={isCritical ? 'red' : 'yellow'} size="xs" className="shrink-0">
-            {issue.state === 'unreachable' ? t('common:common.offline') : t('common:common.unhealthy')}
+            {issue.state === 'unreachable' ? t('common:offline') : t('common:unhealthy')}
           </StatusBadge>
           <ClusterBadge cluster={issue.cluster} size="sm" />
         </div>

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -101,7 +101,12 @@ export function LocalClustersSection() {
 
   const hasVClusterTool = installedTools.some(t => t.name === 'vcluster')
   /** Local cluster tools excluding vcluster (vcluster has its own section) */
-  const localClusterTools = installedTools.filter(t => t.name !== 'vcluster')
+  const localClusterTools = installedTools
+    .filter(t => t.name !== 'vcluster')
+    .map(tool => ({
+      ...tool,
+      version: tool.version ?? 'unknown',
+    }))
 
   // KubeVirt detection: check which connected clusters have the kubevirt namespace
   const kubevirtClusters = (healthyClusters || []).filter(c =>

--- a/web/src/hooks/useAlerts.ts
+++ b/web/src/hooks/useAlerts.ts
@@ -35,16 +35,6 @@ function loadFromStorage<T>(key: string, defaultValue: T, validator?: (value: un
   return defaultValue
 }
 
-// Save to localStorage
-function saveToStorage<T>(key: string, value: T): void {
-  try {
-    localStorage.setItem(key, JSON.stringify(value))
-  } catch (e: unknown) {
-    console.error(`Failed to save ${key} to localStorage:`, e)
-    // Silently fail - localStorage quota may be exceeded but functionality continues
-  }
-}
-
 // Default empty stats returned when AlertsProvider is absent
 const _defaultAlertStats: AlertStats = { total: 0, firing: 0, resolved: 0, critical: 0, warning: 0, info: 0, acknowledged: 0 }
 


### PR DESCRIPTION
Fixes main CI failures in the frontend build by correcting invalid i18n keys, narrowing the CardWrapper translation hooks, normalizing local cluster tool versions for AddClusterForm, and removing an unused alert storage helper.