### PR TITLE
[scanner] fix: address nightly compliance regressions (2026-07-29)

### DIFF
--- a/web/src/hooks/useAdmissionWebhooks.ts
+++ b/web/src/hooks/useAdmissionWebhooks.ts
@@ -143,7 +143,10 @@ export function useAdmissionWebhooks(): UseAdmissionWebhooksResult {
   const cachedData = useRef(loadFromCache())
   const cachedSnapshot = cachedData.current
   const [webhooks, setWebhooks] = useState<WebhookData[]>(cachedSnapshot?.data || [])
-  const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? true)
+  // Start as false (show loading skeleton) when there is no cached snapshot;
+  // the refetch will flip this to true if the first fetch fails (demo fallback).
+  // Matches the CLAUDE.md card-cache pattern: isDemoFallback must be false while isLoading is true.
+  const [isDemoData, setIsDemoData] = useState(cachedSnapshot?.isDemoData ?? false)
   const [isLoading, setIsLoading] = useState(!cachedSnapshot)
   const [isRefreshing, setIsRefreshing] = useState(false)
   const [consecutiveFailures, setConsecutiveFailures] = useState(0)


### PR DESCRIPTION
Fixes #21817
Fixes #21818
Fixes #21822
Fixes #21823
Fixes #21824
Fixes #21825
Fixes #21826
Fixes #21827
Fixes #21828
Fixes #21829
Fixes #21830
Fixes #21831
Fixes #21832

## Root Cause

All 13 nightly failures on 2026-07-29 share a single root cause: the **TypeScript build failed** at commit `969eca8`, causing every downstream test job (compliance, perf, dashboard-health) to be skipped with "No summary available".

The build errors were introduced by the 2026-07-28/29 overnight scanner PRs:

| File | Error |
|------|-------|
| `CardHeader.tsx` | `t: TFunction` (unparameterized) — incompatible with `TFunction<readonly ['cards', 'common']>` callers |
| `OfflineStatusDisplay.tsx` | Same `TFunction` mismatch |
| `ConsoleOfflineDetectionCard.tsx` | Arrow function returning void-typed call where `void` return expected |
| `AddClusterForm.tsx` | `version: string` required field, but callers don't always supply it |

These were fixed in main by commit `288b64d2` (PR #21814, merged 07:08 UTC — after the nightly ran at 05:59 UTC).

## This PR

This branch is based on `288b64d2` (the fix is already in `main`). The single additional commit addresses a related card-cache compliance pattern found during investigation:

**`useAdmissionWebhooks.ts`** — `isDemoData` was initialized to `true` when no cache snapshot existed, meaning demo data was active while `isLoading` was also `true`. This violates the CLAUDE.md card-cache rule:

> `isDemoFallback` must be `false` while `isLoading` is `true`

Changed `?? true` → `?? false` so the loading skeleton shows on first visit. The demo fallback still triggers correctly on fetch failure via `!initialLoadDone.current` in the catch block.

## Verification

CI will validate build + all compliance suites on this PR. The nightly tomorrow will run against the fixed `main` and should produce passing results.