### PR TITLE
🌱 Split rbac/CanIChecker.tsx (615 → 302 lines)

### DIFF
--- a/web/src/components/rbac/CanIChecker.constants.ts
+++ b/web/src/components/rbac/CanIChecker.constants.ts
@@ -1,0 +1,81 @@
+export const COMMON_VERBS = ['get', 'list', 'create', 'update', 'delete', 'watch', 'patch']
+
+// Common API groups for Kubernetes resources
+export const COMMON_API_GROUPS = [
+  { value: '', label: 'Core API (pods, services, secrets)' },
+  { value: 'apps', label: 'apps (deployments, statefulsets)' },
+  { value: 'rbac.authorization.k8s.io', label: 'rbac.authorization.k8s.io (roles, bindings)' },
+  { value: 'batch', label: 'batch (jobs, cronjobs)' },
+  { value: 'networking.k8s.io', label: 'networking.k8s.io (ingresses)' },
+  { value: 'autoscaling', label: 'autoscaling (hpa)' },
+  { value: 'storage.k8s.io', label: 'storage.k8s.io (storageclasses)' },
+  { value: 'policy', label: 'policy (poddisruptionbudgets)' },
+  { value: 'admissionregistration.k8s.io', label: 'admissionregistration.k8s.io (webhooks)' },
+  { value: 'apiextensions.k8s.io', label: 'apiextensions.k8s.io (crds)' },
+]
+
+// Common user groups, especially for OpenShift
+export const COMMON_USER_GROUPS = [
+  { value: 'system:authenticated', label: 'system:authenticated' },
+  { value: 'system:authenticated:oauth', label: 'system:authenticated:oauth (OpenShift)' },
+  { value: 'system:cluster-admins', label: 'system:cluster-admins' },
+  { value: 'cluster-admins', label: 'cluster-admins (OpenShift)' },
+  { value: 'dedicated-admins', label: 'dedicated-admins (OpenShift Dedicated)' },
+  { value: 'system:serviceaccounts', label: 'system:serviceaccounts' },
+  { value: 'system:masters', label: 'system:masters' },
+]
+
+// Resource to API group mapping - required for correct permission checks
+export const RESOURCE_API_GROUPS: Record<string, string> = {
+  // Core API (empty string)
+  pods: '',
+  services: '',
+  secrets: '',
+  configmaps: '',
+  namespaces: '',
+  nodes: '',
+  persistentvolumeclaims: '',
+  serviceaccounts: '',
+  events: '',
+  endpoints: '',
+  // apps API group
+  deployments: 'apps',
+  replicasets: 'apps',
+  statefulsets: 'apps',
+  daemonsets: 'apps',
+  // rbac.authorization.k8s.io
+  roles: 'rbac.authorization.k8s.io',
+  rolebindings: 'rbac.authorization.k8s.io',
+  clusterroles: 'rbac.authorization.k8s.io',
+  clusterrolebindings: 'rbac.authorization.k8s.io',
+  // batch
+  jobs: 'batch',
+  cronjobs: 'batch',
+  // networking.k8s.io
+  ingresses: 'networking.k8s.io',
+  networkpolicies: 'networking.k8s.io',
+  // autoscaling
+  horizontalpodautoscalers: 'autoscaling',
+  // storage.k8s.io
+  storageclasses: 'storage.k8s.io' }
+
+export const COMMON_RESOURCES = [
+  'pods',
+  'deployments',
+  'services',
+  'secrets',
+  'configmaps',
+  'namespaces',
+  'nodes',
+  'persistentvolumeclaims',
+  'serviceaccounts',
+  'roles',
+  'rolebindings',
+  'clusterroles',
+  'clusterrolebindings',
+  'jobs',
+  'cronjobs',
+  'ingresses',
+  'statefulsets',
+  'daemonsets',
+]

--- a/web/src/components/rbac/CanIChecker.parts.tsx
+++ b/web/src/components/rbac/CanIChecker.parts.tsx
@@ -1,0 +1,267 @@
+import type { ReactNode } from 'react'
+import { Check, X, AlertCircle, ChevronDown } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '../ui/Button'
+import type { CanIResponse } from '../../hooks/usePermissions'
+import type { CheckedSnapshot } from './CanIChecker.state'
+import { COMMON_USER_GROUPS } from './CanIChecker.constants'
+
+const SELECT_CLASS =
+  'w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8'
+const INPUT_CLASS =
+  'w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500'
+const CHEVRON_CLASS =
+  'absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none'
+
+interface LabeledSelectProps {
+  id: string
+  label: ReactNode
+  value: string
+  onChange: (value: string) => void
+  testId: string
+  children: ReactNode
+}
+
+/** Label + styled `<select>` with the shared chevron affordance. */
+export function LabeledSelect({ id, label, value, onChange, testId, children }: LabeledSelectProps) {
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-foreground mb-1">
+        {label}
+      </label>
+      <div className="relative">
+        <select
+          id={id}
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className={SELECT_CLASS}
+          data-testid={testId}
+        >
+          {children}
+        </select>
+        <ChevronDown className={CHEVRON_CLASS} />
+      </div>
+    </div>
+  )
+}
+
+interface CustomValueInputProps {
+  value: string
+  onChange: (value: string) => void
+  placeholder: string
+  testId: string
+}
+
+/** Free-text override shown when the matching dropdown is set to `custom`. */
+export function CustomValueInput({ value, onChange, placeholder, testId }: CustomValueInputProps) {
+  return (
+    <input
+      type="text"
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      placeholder={placeholder}
+      className={`mt-2 ${INPUT_CLASS}`}
+      data-testid={testId}
+    />
+  )
+}
+
+interface UserGroupsFieldProps {
+  selectedUserGroups: string[]
+  customUserGroup: string
+  onToggleGroup: (group: string) => void
+  onCustomGroupChange: (value: string) => void
+  onAddCustomGroup: () => void
+}
+
+/** Multi-select for the user groups impersonated during the check. */
+export function UserGroupsField({
+  selectedUserGroups,
+  customUserGroup,
+  onToggleGroup,
+  onCustomGroupChange,
+  onAddCustomGroup,
+}: UserGroupsFieldProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-foreground mb-1">
+        {t('rbac.userGroups')} <span className="text-muted-foreground">{t('rbac.userGroupsHint')}</span>
+      </label>
+
+      {/* Selected groups display */}
+      {selectedUserGroups.length > 0 && (
+        <div className="flex flex-wrap gap-1 mb-2">
+          {selectedUserGroups.map((group) => (
+            <span
+              key={group}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-blue-500/20 text-blue-400"
+            >
+              {group}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onToggleGroup(group)}
+                className="p-0 hover:text-blue-200"
+                aria-label={t('rbac.removeGroup', { group })}
+                icon={<X className="w-3 h-3" />}
+              />
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Common groups dropdown */}
+      <div className="relative">
+        <select
+          value=""
+          onChange={(e) => {
+            if (e.target.value && !selectedUserGroups.includes(e.target.value)) {
+              onToggleGroup(e.target.value)
+            }
+          }}
+          className={SELECT_CLASS}
+          data-testid="can-i-user-groups"
+        >
+          <option value="">{t('rbac.selectCommonGroups')}</option>
+          {COMMON_USER_GROUPS.filter(g => !selectedUserGroups.includes(g.value)).map((group) => (
+            <option key={group.value} value={group.value}>{group.label}</option>
+          ))}
+        </select>
+        <ChevronDown className={CHEVRON_CLASS} />
+      </div>
+
+      {/* Custom group input */}
+      <div className="mt-2 flex gap-2">
+        <input
+          type="text"
+          value={customUserGroup}
+          onChange={(e) => onCustomGroupChange(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              onAddCustomGroup()
+            }
+          }}
+          placeholder={t('rbac.addCustomGroupPlaceholder')}
+          className="flex-1 p-2 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+        />
+        <Button
+          variant="primary"
+          size="lg"
+          onClick={onAddCustomGroup}
+          disabled={!customUserGroup.trim()}
+          aria-label={t('rbac.add')}
+        >
+          {t('rbac.add')}
+        </Button>
+      </div>
+      <p className="mt-1 text-xs text-muted-foreground">
+        {t('rbac.addGroupsDesc')}
+      </p>
+    </div>
+  )
+}
+
+/** Static cheat-sheet of the most frequently used API groups. */
+export function AdvancedApiGroupsHelp() {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="text-xs text-muted-foreground p-3 bg-secondary/30 rounded-lg">
+      <p className="font-medium mb-2">{t('rbac.commonApiGroupsTitle')}</p>
+      <ul className="space-y-1">
+        <li><code className="text-blue-400">""</code> - {t('rbac.apiGroupCoreDesc')}</li>
+        <li><code className="text-blue-400">apps</code> - {t('rbac.apiGroupAppsDesc')}</li>
+        <li><code className="text-blue-400">rbac.authorization.k8s.io</code> - {t('rbac.apiGroupRbacDesc')}</li>
+        <li><code className="text-blue-400">batch</code> - {t('rbac.apiGroupBatchDesc')}</li>
+        <li><code className="text-blue-400">networking.k8s.io</code> - {t('rbac.apiGroupNetworkingDesc')}</li>
+      </ul>
+    </div>
+  )
+}
+
+interface CanIResultPanelProps {
+  result: CanIResponse
+  snapshot: CheckedSnapshot
+}
+
+/**
+ * Allowed/denied verdict banner. Renders the frozen snapshot captured at Check
+ * time so the displayed verb/resource/namespace match what was actually
+ * checked (Issue 9268).
+ */
+export function CanIResultPanel({ result, snapshot }: CanIResultPanelProps) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div
+      className={`p-4 rounded-lg border ${
+        result.allowed
+          ? 'bg-green-500/10 border-green-500/30'
+          : 'bg-red-500/10 border-red-500/30'
+      }`}
+      data-testid="can-i-result"
+    >
+      <div className="flex items-center gap-2">
+        {result.allowed ? (
+          <>
+            <Check className="w-5 h-5 text-green-500" />
+            <span className="font-medium text-green-500">{t('rbac.allowed')}</span>
+          </>
+        ) : (
+          <>
+            <X className="w-5 h-5 text-red-500" />
+            <span className="font-medium text-red-500">{t('rbac.denied')}</span>
+          </>
+        )}
+      </div>
+      <p className="mt-2 text-sm text-muted-foreground">
+        {t(result.allowed ? 'rbac.youCan' : 'rbac.youCannot')}{' '}
+        <code className="px-1 py-0.5 rounded bg-secondary">{snapshot.verb}</code>{' '}
+        <code className="px-1 py-0.5 rounded bg-secondary">{snapshot.resource}</code>
+        {snapshot.namespace && (
+          <>
+            {' '}{t('rbac.inNamespace')} <code className="px-1 py-0.5 rounded bg-secondary">{snapshot.namespace}</code>
+          </>
+        )}
+      </p>
+      {result.reason && (
+        <p className="mt-1 text-xs text-muted-foreground">{result.reason}</p>
+      )}
+    </div>
+  )
+}
+
+/** Error banner shown when the permission check request itself failed. */
+export function CanIErrorPanel({ error }: { error: string }) {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/30" data-testid="can-i-error">
+      <div className="flex items-center gap-2">
+        <AlertCircle className="w-5 h-5 text-red-500" />
+        <span className="font-medium text-red-500">{t('common.error')}</span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">{error}</p>
+    </div>
+  )
+}
+
+/** Warning shown when no clusters are connected, so nothing can be checked. */
+export function NoClustersWarning() {
+  const { t } = useTranslation('common')
+
+  return (
+    <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
+      <div className="flex items-center gap-2">
+        <AlertCircle className="w-5 h-5 text-yellow-500" />
+        <span className="font-medium text-yellow-500">{t('rbac.noClustersAvailable')}</span>
+      </div>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {t('rbac.connectToCluster')}
+      </p>
+    </div>
+  )
+}

--- a/web/src/components/rbac/CanIChecker.state.ts
+++ b/web/src/components/rbac/CanIChecker.state.ts
@@ -1,0 +1,75 @@
+/**
+ * Snapshot of the inputs that were used for the most recent Check call.
+ * Rendered in the result banner so the banner text stays stable even if the
+ * user edits the verb/resource dropdowns after the result arrives
+ * (Issue 9268).
+ */
+export interface CheckedSnapshot {
+  verb: string
+  resource: string
+  namespace: string | undefined
+}
+
+/** Form state managed by useReducer to batch updates (e.g. handleReset)
+ *  and prevent intermediate re-renders / UI flicker. */
+export interface FormState {
+  cluster: string
+  verb: string
+  resource: string
+  namespace: string
+  customVerb: string
+  customResource: string
+  apiGroup: string
+  customApiGroup: string
+  selectedUserGroups: string[]
+  customUserGroup: string
+  showAdvanced: boolean
+  checkedSnapshot: CheckedSnapshot | null
+}
+
+export const INITIAL_FORM_STATE: FormState = {
+  cluster: '',
+  verb: 'get',
+  resource: 'pods',
+  namespace: '',
+  customVerb: '',
+  customResource: '',
+  apiGroup: '',
+  customApiGroup: '',
+  selectedUserGroups: [],
+  customUserGroup: '',
+  showAdvanced: false,
+  checkedSnapshot: null,
+}
+
+export type FormAction =
+  | { type: 'SET_FIELD'; field: keyof FormState; value: FormState[keyof FormState] }
+  | { type: 'TOGGLE_USER_GROUP'; group: string }
+  | { type: 'ADD_CUSTOM_USER_GROUP' }
+  | { type: 'RESET' }
+
+export function formReducer(state: FormState, action: FormAction): FormState {
+  switch (action.type) {
+    case 'SET_FIELD':
+      return { ...state, [action.field]: action.value }
+    case 'TOGGLE_USER_GROUP': {
+      const groups = state.selectedUserGroups.includes(action.group)
+        ? state.selectedUserGroups.filter(g => g !== action.group)
+        : [...state.selectedUserGroups, action.group]
+      return { ...state, selectedUserGroups: groups }
+    }
+    case 'ADD_CUSTOM_USER_GROUP': {
+      const trimmed = state.customUserGroup.trim()
+      if (!trimmed || state.selectedUserGroups.includes(trimmed)) return state
+      return {
+        ...state,
+        selectedUserGroups: [...state.selectedUserGroups, trimmed],
+        customUserGroup: '',
+      }
+    }
+    case 'RESET':
+      return INITIAL_FORM_STATE
+    default:
+      return state
+  }
+}

--- a/web/src/components/rbac/CanIChecker.tsx
+++ b/web/src/components/rbac/CanIChecker.tsx
@@ -1,168 +1,26 @@
 import { useReducer, useEffect, useMemo } from 'react'
-import { Shield, Check, X, Loader2, AlertCircle, ChevronDown } from 'lucide-react'
+import { Shield, Loader2 } from 'lucide-react'
 import { useCanI } from '../../hooks/usePermissions'
 import { useClusters, useNamespaces } from '../../hooks/useMCP'
 import { Button } from '../ui/Button'
 import { useTranslation } from 'react-i18next'
 import { PageErrorBoundary } from '../PageErrorBoundary'
-
-const COMMON_VERBS = ['get', 'list', 'create', 'update', 'delete', 'watch', 'patch']
-
-// Common API groups for Kubernetes resources
-const COMMON_API_GROUPS = [
-  { value: '', label: 'Core API (pods, services, secrets)' },
-  { value: 'apps', label: 'apps (deployments, statefulsets)' },
-  { value: 'rbac.authorization.k8s.io', label: 'rbac.authorization.k8s.io (roles, bindings)' },
-  { value: 'batch', label: 'batch (jobs, cronjobs)' },
-  { value: 'networking.k8s.io', label: 'networking.k8s.io (ingresses)' },
-  { value: 'autoscaling', label: 'autoscaling (hpa)' },
-  { value: 'storage.k8s.io', label: 'storage.k8s.io (storageclasses)' },
-  { value: 'policy', label: 'policy (poddisruptionbudgets)' },
-  { value: 'admissionregistration.k8s.io', label: 'admissionregistration.k8s.io (webhooks)' },
-  { value: 'apiextensions.k8s.io', label: 'apiextensions.k8s.io (crds)' },
-]
-
-// Common user groups, especially for OpenShift
-const COMMON_USER_GROUPS = [
-  { value: 'system:authenticated', label: 'system:authenticated' },
-  { value: 'system:authenticated:oauth', label: 'system:authenticated:oauth (OpenShift)' },
-  { value: 'system:cluster-admins', label: 'system:cluster-admins' },
-  { value: 'cluster-admins', label: 'cluster-admins (OpenShift)' },
-  { value: 'dedicated-admins', label: 'dedicated-admins (OpenShift Dedicated)' },
-  { value: 'system:serviceaccounts', label: 'system:serviceaccounts' },
-  { value: 'system:masters', label: 'system:masters' },
-]
-
-// Resource to API group mapping - required for correct permission checks
-const RESOURCE_API_GROUPS: Record<string, string> = {
-  // Core API (empty string)
-  pods: '',
-  services: '',
-  secrets: '',
-  configmaps: '',
-  namespaces: '',
-  nodes: '',
-  persistentvolumeclaims: '',
-  serviceaccounts: '',
-  events: '',
-  endpoints: '',
-  // apps API group
-  deployments: 'apps',
-  replicasets: 'apps',
-  statefulsets: 'apps',
-  daemonsets: 'apps',
-  // rbac.authorization.k8s.io
-  roles: 'rbac.authorization.k8s.io',
-  rolebindings: 'rbac.authorization.k8s.io',
-  clusterroles: 'rbac.authorization.k8s.io',
-  clusterrolebindings: 'rbac.authorization.k8s.io',
-  // batch
-  jobs: 'batch',
-  cronjobs: 'batch',
-  // networking.k8s.io
-  ingresses: 'networking.k8s.io',
-  networkpolicies: 'networking.k8s.io',
-  // autoscaling
-  horizontalpodautoscalers: 'autoscaling',
-  // storage.k8s.io
-  storageclasses: 'storage.k8s.io' }
-
-const COMMON_RESOURCES = [
-  'pods',
-  'deployments',
-  'services',
-  'secrets',
-  'configmaps',
-  'namespaces',
-  'nodes',
-  'persistentvolumeclaims',
-  'serviceaccounts',
-  'roles',
-  'rolebindings',
-  'clusterroles',
-  'clusterrolebindings',
-  'jobs',
-  'cronjobs',
-  'ingresses',
-  'statefulsets',
-  'daemonsets',
-]
-
-/**
- * Snapshot of the inputs that were used for the most recent Check call.
- * Rendered in the result banner so the banner text stays stable even if the
- * user edits the verb/resource dropdowns after the result arrives
- * (Issue 9268).
- */
-interface CheckedSnapshot {
-  verb: string
-  resource: string
-  namespace: string | undefined
-}
-
-/** Form state managed by useReducer to batch updates (e.g. handleReset)
- *  and prevent intermediate re-renders / UI flicker. */
-interface FormState {
-  cluster: string
-  verb: string
-  resource: string
-  namespace: string
-  customVerb: string
-  customResource: string
-  apiGroup: string
-  customApiGroup: string
-  selectedUserGroups: string[]
-  customUserGroup: string
-  showAdvanced: boolean
-  checkedSnapshot: CheckedSnapshot | null
-}
-
-const INITIAL_FORM_STATE: FormState = {
-  cluster: '',
-  verb: 'get',
-  resource: 'pods',
-  namespace: '',
-  customVerb: '',
-  customResource: '',
-  apiGroup: '',
-  customApiGroup: '',
-  selectedUserGroups: [],
-  customUserGroup: '',
-  showAdvanced: false,
-  checkedSnapshot: null,
-}
-
-type FormAction =
-  | { type: 'SET_FIELD'; field: keyof FormState; value: FormState[keyof FormState] }
-  | { type: 'TOGGLE_USER_GROUP'; group: string }
-  | { type: 'ADD_CUSTOM_USER_GROUP' }
-  | { type: 'RESET' }
-
-function formReducer(state: FormState, action: FormAction): FormState {
-  switch (action.type) {
-    case 'SET_FIELD':
-      return { ...state, [action.field]: action.value }
-    case 'TOGGLE_USER_GROUP': {
-      const groups = state.selectedUserGroups.includes(action.group)
-        ? state.selectedUserGroups.filter(g => g !== action.group)
-        : [...state.selectedUserGroups, action.group]
-      return { ...state, selectedUserGroups: groups }
-    }
-    case 'ADD_CUSTOM_USER_GROUP': {
-      const trimmed = state.customUserGroup.trim()
-      if (!trimmed || state.selectedUserGroups.includes(trimmed)) return state
-      return {
-        ...state,
-        selectedUserGroups: [...state.selectedUserGroups, trimmed],
-        customUserGroup: '',
-      }
-    }
-    case 'RESET':
-      return INITIAL_FORM_STATE
-    default:
-      return state
-  }
-}
+import {
+  COMMON_VERBS,
+  COMMON_RESOURCES,
+  COMMON_API_GROUPS,
+  RESOURCE_API_GROUPS,
+} from './CanIChecker.constants'
+import { formReducer, INITIAL_FORM_STATE } from './CanIChecker.state'
+import {
+  LabeledSelect,
+  CustomValueInput,
+  UserGroupsField,
+  AdvancedApiGroupsHelp,
+  CanIResultPanel,
+  CanIErrorPanel,
+  NoClustersWarning,
+} from './CanIChecker.parts'
 
 function CanICheckerContent() {
   const { t } = useTranslation('common')
@@ -176,6 +34,10 @@ function CanICheckerContent() {
     customVerb, customResource, apiGroup, customApiGroup,
     selectedUserGroups, customUserGroup, showAdvanced, checkedSnapshot,
   } = form
+
+  const setField = (field: keyof typeof form, value: (typeof form)[keyof typeof form]) => {
+    dispatch({ type: 'SET_FIELD', field, value })
+  }
 
   // Auto-select the first cluster when clusters load and none is selected yet
   useEffect(() => {
@@ -260,110 +122,80 @@ function CanICheckerContent() {
 
       <div className="space-y-4">
         {/* Cluster Selection */}
-        <div>
-          <label htmlFor="cluster-select" className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.cluster')}
-          </label>
-          <div className="relative">
-            <select
-              id="cluster-select"
-              value={cluster}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'cluster', value: e.target.value })}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-cluster"
-            >
-              {clusters.map((c) => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
-        </div>
+        <LabeledSelect
+          id="cluster-select"
+          label={t('rbac.cluster')}
+          value={cluster}
+          onChange={(value) => setField('cluster', value)}
+          testId="can-i-cluster"
+        >
+          {clusters.map((c) => (
+            <option key={c} value={c}>{c}</option>
+          ))}
+        </LabeledSelect>
 
         {/* Verb Selection */}
         <div>
-          <label htmlFor="verb-select" className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.actionVerb')}
-          </label>
-          <div className="relative">
-            <select
-              id="verb-select"
-              value={verb}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'verb', value: e.target.value })}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-verb"
-            >
-              {COMMON_VERBS.map((v) => (
-                <option key={v} value={v}>{v}</option>
-              ))}
-              <option value="custom">{t('rbac.custom')}</option>
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
+          <LabeledSelect
+            id="verb-select"
+            label={t('rbac.actionVerb')}
+            value={verb}
+            onChange={(value) => setField('verb', value)}
+            testId="can-i-verb"
+          >
+            {COMMON_VERBS.map((v) => (
+              <option key={v} value={v}>{v}</option>
+            ))}
+            <option value="custom">{t('rbac.custom')}</option>
+          </LabeledSelect>
           {verb === 'custom' && (
-            <input
-              type="text"
+            <CustomValueInput
               value={customVerb}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'customVerb', value: e.target.value })}
+              onChange={(value) => setField('customVerb', value)}
               placeholder={t('rbac.enterCustomVerb')}
-              className="mt-2 w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-              data-testid="can-i-custom-verb"
+              testId="can-i-custom-verb"
             />
           )}
         </div>
 
         {/* Resource Selection */}
         <div>
-          <label htmlFor="resource-select" className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.resource')}
-          </label>
-          <div className="relative">
-            <select
-              id="resource-select"
-              value={resource}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'resource', value: e.target.value })}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-resource"
-            >
-              {COMMON_RESOURCES.map((r) => (
-                <option key={r} value={r}>{r}</option>
-              ))}
-              <option value="custom">{t('rbac.custom')}</option>
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
+          <LabeledSelect
+            id="resource-select"
+            label={t('rbac.resource')}
+            value={resource}
+            onChange={(value) => setField('resource', value)}
+            testId="can-i-resource"
+          >
+            {COMMON_RESOURCES.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+            <option value="custom">{t('rbac.custom')}</option>
+          </LabeledSelect>
           {resource === 'custom' && (
-            <input
-              type="text"
+            <CustomValueInput
               value={customResource}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'customResource', value: e.target.value })}
+              onChange={(value) => setField('customResource', value)}
               placeholder={t('rbac.enterCustomResource')}
-              className="mt-2 w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-              data-testid="can-i-custom-resource"
+              testId="can-i-custom-resource"
             />
           )}
         </div>
 
         {/* Namespace (optional) */}
         <div>
-          <label htmlFor="namespace-select" className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.namespace')} <span className="text-muted-foreground">{t('rbac.namespaceHint')}</span>
-          </label>
-          <div className="relative">
-            <select
-              id="namespace-select"
-              value={namespace}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'namespace', value: e.target.value })}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-namespace"
-            >
-              <option value="">{t('rbac.allNamespacesClusterScoped')}</option>
-              {availableNamespaces.map((ns) => (
-                <option key={ns} value={ns}>{ns}</option>
-              ))}
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
+          <LabeledSelect
+            id="namespace-select"
+            label={<>{t('rbac.namespace')} <span className="text-muted-foreground">{t('rbac.namespaceHint')}</span></>}
+            value={namespace}
+            onChange={(value) => setField('namespace', value)}
+            testId="can-i-namespace"
+          >
+            <option value="">{t('rbac.allNamespacesClusterScoped')}</option>
+            {availableNamespaces.map((ns) => (
+              <option key={ns} value={ns}>{ns}</option>
+            ))}
+          </LabeledSelect>
           {availableNamespaces.length === 0 && selectedCluster && (
             <p className="mt-1 text-xs text-muted-foreground">{t('rbac.loadingNamespaces')}</p>
           )}
@@ -371,144 +203,56 @@ function CanICheckerContent() {
 
         {/* API Group - dropdown with common groups */}
         <div>
-          <label htmlFor="api-group-select" className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.apiGroup')} <span className="text-muted-foreground">{t('rbac.apiGroupHint')}</span>
-          </label>
-          <div className="relative">
-            <select
-              id="api-group-select"
-              value={apiGroup}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'apiGroup', value: e.target.value })}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-api-group"
-            >
-              <option value="">
-                {resource !== 'custom' && RESOURCE_API_GROUPS[resource] !== undefined
-                  ? `${t('rbac.autoDetect')}: ${RESOURCE_API_GROUPS[resource] || t('rbac.coreAPI')}`
-                  : t('rbac.autoDetectFromResource')
-                }
-              </option>
-              {COMMON_API_GROUPS.map((group) => (
-                <option key={group.value || 'core'} value={group.value}>{group.label}</option>
-              ))}
-              <option value="custom">{t('rbac.custom')}</option>
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
+          <LabeledSelect
+            id="api-group-select"
+            label={<>{t('rbac.apiGroup')} <span className="text-muted-foreground">{t('rbac.apiGroupHint')}</span></>}
+            value={apiGroup}
+            onChange={(value) => setField('apiGroup', value)}
+            testId="can-i-api-group"
+          >
+            <option value="">
+              {resource !== 'custom' && RESOURCE_API_GROUPS[resource] !== undefined
+                ? `${t('rbac.autoDetect')}: ${RESOURCE_API_GROUPS[resource] || t('rbac.coreAPI')}`
+                : t('rbac.autoDetectFromResource')
+              }
+            </option>
+            {COMMON_API_GROUPS.map((group) => (
+              <option key={group.value || 'core'} value={group.value}>{group.label}</option>
+            ))}
+            <option value="custom">{t('rbac.custom')}</option>
+          </LabeledSelect>
           {apiGroup === 'custom' && (
-            <input
-              type="text"
+            <CustomValueInput
               value={customApiGroup}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'customApiGroup', value: e.target.value })}
+              onChange={(value) => setField('customApiGroup', value)}
               placeholder={t('rbac.enterCustomApiGroup')}
-              className="mt-2 w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-              data-testid="can-i-custom-api-group"
+              testId="can-i-custom-api-group"
             />
           )}
         </div>
 
-        {/* User Groups - multi-select dropdown for OpenShift and RBAC */}
-        <div>
-          <label className="block text-sm font-medium text-foreground mb-1">
-            {t('rbac.userGroups')} <span className="text-muted-foreground">{t('rbac.userGroupsHint')}</span>
-          </label>
-
-          {/* Selected groups display */}
-          {selectedUserGroups.length > 0 && (
-            <div className="flex flex-wrap gap-1 mb-2">
-              {selectedUserGroups.map((group) => (
-                <span
-                  key={group}
-                  className="inline-flex items-center gap-1 px-2 py-1 text-xs rounded-full bg-blue-500/20 text-blue-400"
-                >
-                  {group}
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => toggleUserGroup(group)}
-                    className="p-0 hover:text-blue-200"
-                    aria-label={t('rbac.removeGroup', { group })}
-                    icon={<X className="w-3 h-3" />}
-                  />
-                </span>
-              ))}
-            </div>
-          )}
-
-          {/* Common groups dropdown */}
-          <div className="relative">
-            <select
-              value=""
-              onChange={(e) => {
-                if (e.target.value && !selectedUserGroups.includes(e.target.value)) {
-                  toggleUserGroup(e.target.value)
-                }
-              }}
-              className="w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8"
-              data-testid="can-i-user-groups"
-            >
-              <option value="">{t('rbac.selectCommonGroups')}</option>
-              {COMMON_USER_GROUPS.filter(g => !selectedUserGroups.includes(g.value)).map((group) => (
-                <option key={group.value} value={group.value}>{group.label}</option>
-              ))}
-            </select>
-            <ChevronDown className="absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none" />
-          </div>
-
-          {/* Custom group input */}
-          <div className="mt-2 flex gap-2">
-            <input
-              type="text"
-              value={customUserGroup}
-              onChange={(e) => dispatch({ type: 'SET_FIELD', field: 'customUserGroup', value: e.target.value })}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  e.preventDefault()
-                  addCustomUserGroup()
-                }
-              }}
-              placeholder={t('rbac.addCustomGroupPlaceholder')}
-              className="flex-1 p-2 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500"
-            />
-            <Button
-              variant="primary"
-              size="lg"
-              onClick={addCustomUserGroup}
-              disabled={!customUserGroup.trim()}
-              aria-label={t('rbac.add')}
-            >
-              {t('rbac.add')}
-            </Button>
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {t('rbac.addGroupsDesc')}
-          </p>
-        </div>
+        {/* User Groups - multi-select for OpenShift and RBAC */}
+        <UserGroupsField
+          selectedUserGroups={selectedUserGroups}
+          customUserGroup={customUserGroup}
+          onToggleGroup={toggleUserGroup}
+          onCustomGroupChange={(value) => setField('customUserGroup', value)}
+          onAddCustomGroup={addCustomUserGroup}
+        />
 
         {/* Advanced Options */}
         <Button
           variant="ghost"
           size="sm"
           type="button"
-          onClick={() => dispatch({ type: 'SET_FIELD', field: 'showAdvanced', value: !showAdvanced })}
+          onClick={() => setField('showAdvanced', !showAdvanced)}
           className="text-sm text-muted-foreground hover:text-foreground"
           aria-expanded={showAdvanced}
         >
           {showAdvanced ? t('rbac.hideAdvanced') : t('rbac.showAdvanced')}
         </Button>
 
-        {showAdvanced && (
-          <div className="text-xs text-muted-foreground p-3 bg-secondary/30 rounded-lg">
-            <p className="font-medium mb-2">{t('rbac.commonApiGroupsTitle')}</p>
-            <ul className="space-y-1">
-              <li><code className="text-blue-400">""</code> - {t('rbac.apiGroupCoreDesc')}</li>
-              <li><code className="text-blue-400">apps</code> - {t('rbac.apiGroupAppsDesc')}</li>
-              <li><code className="text-blue-400">rbac.authorization.k8s.io</code> - {t('rbac.apiGroupRbacDesc')}</li>
-              <li><code className="text-blue-400">batch</code> - {t('rbac.apiGroupBatchDesc')}</li>
-              <li><code className="text-blue-400">networking.k8s.io</code> - {t('rbac.apiGroupNetworkingDesc')}</li>
-            </ul>
-          </div>
-        )}
+        {showAdvanced && <AdvancedApiGroupsHelp />}
 
         {/* Check Button */}
         <div className="flex gap-2">
@@ -537,70 +281,13 @@ function CanICheckerContent() {
           )}
         </div>
 
-        {/* Result — uses the frozen snapshot captured at Check time so the
-            displayed verb/resource/namespace match what was actually checked
-            (Issue 9268). */}
         {result && checkedSnapshot && (
-          <div
-            className={`p-4 rounded-lg border ${
-              result.allowed
-                ? 'bg-green-500/10 border-green-500/30'
-                : 'bg-red-500/10 border-red-500/30'
-            }`}
-            data-testid="can-i-result"
-          >
-            <div className="flex items-center gap-2">
-              {result.allowed ? (
-                <>
-                  <Check className="w-5 h-5 text-green-500" />
-                  <span className="font-medium text-green-500">{t('rbac.allowed')}</span>
-                </>
-              ) : (
-                <>
-                  <X className="w-5 h-5 text-red-500" />
-                  <span className="font-medium text-red-500">{t('rbac.denied')}</span>
-                </>
-              )}
-            </div>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {t(result.allowed ? 'rbac.youCan' : 'rbac.youCannot')}{' '}
-              <code className="px-1 py-0.5 rounded bg-secondary">{checkedSnapshot.verb}</code>{' '}
-              <code className="px-1 py-0.5 rounded bg-secondary">{checkedSnapshot.resource}</code>
-              {checkedSnapshot.namespace && (
-                <>
-                  {' '}{t('rbac.inNamespace')} <code className="px-1 py-0.5 rounded bg-secondary">{checkedSnapshot.namespace}</code>
-                </>
-              )}
-            </p>
-            {result.reason && (
-              <p className="mt-1 text-xs text-muted-foreground">{result.reason}</p>
-            )}
-          </div>
+          <CanIResultPanel result={result} snapshot={checkedSnapshot} />
         )}
 
-        {/* Error */}
-        {error && (
-          <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/30" data-testid="can-i-error">
-            <div className="flex items-center gap-2">
-              <AlertCircle className="w-5 h-5 text-red-500" />
-              <span className="font-medium text-red-500">{t('common.error')}</span>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">{error}</p>
-          </div>
-        )}
+        {error && <CanIErrorPanel error={error} />}
 
-        {/* No clusters warning */}
-        {clusters.length === 0 && (
-          <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/30">
-            <div className="flex items-center gap-2">
-              <AlertCircle className="w-5 h-5 text-yellow-500" />
-              <span className="font-medium text-yellow-500">{t('rbac.noClustersAvailable')}</span>
-            </div>
-            <p className="mt-1 text-sm text-muted-foreground">
-              {t('rbac.connectToCluster')}
-            </p>
-          </div>
-        )}
+        {clusters.length === 0 && <NoClustersWarning />}
       </div>
     </div>
   )


### PR DESCRIPTION
Fixes #21795

## What

Splits `web/src/components/rbac/CanIChecker.tsx` (615 lines) into four focused modules.

| File | Lines | Contents |
|------|-------|----------|
| `CanIChecker.tsx` | **302** | container: state wiring, `handleCheck`/`handleReset`, layout |
| `CanIChecker.parts.tsx` | 267 | `LabeledSelect`, `CustomValueInput`, `UserGroupsField`, `AdvancedApiGroupsHelp`, `CanIResultPanel`, `CanIErrorPanel`, `NoClustersWarning` |
| `CanIChecker.constants.ts` | 81 | `COMMON_VERBS`, `COMMON_RESOURCES`, `COMMON_API_GROUPS`, `COMMON_USER_GROUPS`, `RESOURCE_API_GROUPS` |
| `CanIChecker.state.ts` | 75 | `FormState`, `CheckedSnapshot`, `INITIAL_FORM_STATE`, `FormAction`, `formReducer` |

## Acceptance criteria

- [x] `CanIChecker.tsx` below 350 lines (615 → 302)
- [x] `CanIChecker.test.tsx` passes **without modification** — 40/40 green locally
- [x] No behaviour change — pure move; every `data-testid`, i18n key, class name and the Issue 9268 snapshot semantics are preserved
- [x] 4 files changed (≤ 5)
- [x] No magic numbers introduced (repeated Tailwind class strings hoisted to named constants)
- [x] Build + lint validated by CI on the PR

## Notes

The four `no-restricted-syntax` warnings on raw `<select>`/`<input>` in `CanIChecker.parts.tsx` are pre-existing (they moved with the markup); migrating to `components/ui/Select.tsx` would be a behaviour-affecting change and is out of scope for this split.

## Remaining scope

This is one child of #21778 / #21768. The rest of the batch (#21788–#21811) remains open and is tracked in the decomposition comments on the parent issues.
