### PR TITLE
🐛 fix: ensure capabilities is defined before accessing add property

### DIFF
--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -145,7 +145,8 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
 
           // Capabilities not dropped
           if (sc.capabilities?.drop?.length === 0 || !sc.capabilities?.drop) {
-            if (sc.capabilities && sc.capabilities.add?.length > 0) {
+            const addCapabilities = sc.capabilities?.add
+            if (Array.isArray(addCapabilities) && addCapabilities.length > 0) {
               issues.push({ name: podName, namespace: podNs, cluster: name, issue: 'Capabilities not dropped', severity: 'medium', details: 'Container not dropping all capabilities' })
             }
           }

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -145,7 +145,7 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
 
           // Capabilities not dropped
           if (sc.capabilities?.drop?.length === 0 || !sc.capabilities?.drop) {
-            if (sc.capabilities?.add?.length > 0) {
+            if (sc.capabilities && sc.capabilities.add?.length > 0) {
               issues.push({ name: podName, namespace: podNs, cluster: name, issue: 'Capabilities not dropped', severity: 'medium', details: 'Container not dropping all capabilities' })
             }
           }


### PR DESCRIPTION
Fixes #21850

## Root Cause

TypeScript error in useCachedCoreWorkloads.ts when checking if capabilities.add has items. The optional chaining wasn't sufficient for type narrowing; an explicit null check is required.

## Fix

Add explicit `sc.capabilities` check before accessing the `add` property to satisfy TypeScript's type narrowing requirements.

Changes:
- web/src/hooks/useCachedCoreWorkloads.ts: Add null check before accessing capabilities.add

Signed-off-by: Scanner <scanner@kubestellar.io>
Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>