### PR TITLE
🐛 fix: resolve remaining TypeScript build errors

### DIFF
--- a/web/src/components/cards/DeploymentIssues.tsx
+++ b/web/src/components/cards/DeploymentIssues.tsx
@@ -59,7 +59,7 @@ const CARD_SKELETON_ROWS = 3
 const CARD_SKELETON_ROW_HEIGHT = 100
 const REFRESH_STALE_THRESHOLD_MINUTES = 5
 
-const getIssueIcon = (status: string, t: TFunction<readonly ['cards', 'common']>): { icon: typeof AlertCircle; tooltip: string } => {
+const getIssueIcon = (status: string, t: TFunction<['cards', 'common']>): { icon: typeof AlertCircle; tooltip: string } => {
   if (status.includes('Unavailable')) return { icon: AlertCircle, tooltip: t('deploymentIssues.tooltipUnavailable') }
   if (status.includes('Progressing')) return { icon: Clock, tooltip: t('deploymentIssues.tooltipProgressing') }
   if (status.includes('ReplicaFailure')) return { icon: Scale, tooltip: t('deploymentIssues.tooltipReplicaFailure') }

--- a/web/src/components/cards/StockMarketTicker.tsx
+++ b/web/src/components/cards/StockMarketTicker.tsx
@@ -249,7 +249,7 @@ async function searchStocks(query: string): Promise<StockSearchResult[]> {
 // Default stock symbols to track (keeping for backwards compatibility)
 
 // Market status
-function getMarketStatus(t: TFunction<readonly ['cards', 'common']>): { isOpen: boolean; statusText: string } {
+function getMarketStatus(t: TFunction<['cards', 'common']>): { isOpen: boolean; statusText: string } {
   const now = new Date()
   const hour = now.getHours()
   const minutes = now.getMinutes()

--- a/web/src/components/cards/llmd/KVCacheMonitor.types.ts
+++ b/web/src/components/cards/llmd/KVCacheMonitor.types.ts
@@ -7,7 +7,7 @@ import type { KVCacheStats } from '../../../lib/llmd/mockData'
 export type MetricType = 'util' | 'hitRate'
 export type AggregationMode = 'aggregated' | 'disaggregated'
 export type ViewMode = 'gauges' | 'horseshoe' | 'heatmap'
-export type CardsCommonTFunction = TFunction<readonly ['cards', 'common']>
+export type CardsCommonTFunction = TFunction<['cards', 'common']>
 
 export interface PodMetricHistory {
   util: number[]

--- a/web/src/components/settings/sections/LocalClustersSection.tsx
+++ b/web/src/components/settings/sections/LocalClustersSection.tsx
@@ -320,7 +320,7 @@ After installation, ask:
                     <span className="text-xl">{getToolIcon(tool.name)}</span>
                     <div>
                       <p className="font-medium text-foreground">{tool.name}</p>
-                      <p className="text-xs text-muted-foreground">v{tool.version}</p>
+                      <p className="text-xs text-muted-foreground">v{tool.version ?? "?"}</p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
Fixes #21833
Fixes #21834
Fixes #21835
Fixes #21848
Fixes #21849
Fixes #21850

## Changes
- Remove `readonly` from TFunction generic parameters (DeploymentIssues.tsx, StockMarketTicker.tsx, KVCacheMonitor.types.ts)
- Fix optional version type in LocalClustersSection.tsx by adding nullish coalescing operator

These fixes resolve TypeScript compilation errors cascading from PR #21783, #21821, #21819.