### PR TITLE
🌱 Complete feedback/stellar component splits (last mile)

### DIFF
--- a/web/src/components/feedback/FeedbackModal.tsx
+++ b/web/src/components/feedback/FeedbackModal.tsx
@@ -7,354 +7,51 @@
  *
  * Screenshots are uploaded to GitHub via the backend and embedded directly
  * in the created issue as markdown images.
+ *
+ * State, draft persistence, screenshot handling, and submission logic live
+ * in `useFeedbackDraft.ts`; JSX sub-sections live in `FeedbackModal.parts.tsx`.
  */
 
-import { useState, useEffect, useRef, useCallback } from 'react'
 import { useTranslation } from 'react-i18next'
 import { createPortal } from 'react-dom'
 import { X, Bug, Lightbulb, Send, ExternalLink, AlertTriangle, Loader2 } from 'lucide-react'
 import { ConfirmDialog, useModalFocusTrap } from '../../lib/modals'
-import { useRewards, REWARD_ACTIONS } from '../../hooks/useRewards'
-import { useToast } from '../ui/Toast'
-import { emitFeedbackSubmitted, emitScreenshotAttached, emitScreenshotUploadFailed, emitScreenshotUploadSuccess, getRecentBrowserErrors, getRecentFailedApiCalls } from '../../lib/analytics'
-import { copyBlobToClipboard } from '../../lib/clipboard'
-import { useBranding } from '../../hooks/useBranding'
-import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
-import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
-import { compressScreenshot } from '../../lib/imageCompression'
-import { useFeatureRequests, DiagnosticInfo } from '../../hooks/useFeatureRequests'
-import { useLocalAgent } from '../../hooks/useLocalAgent'
-import { useAuth } from '../../lib/auth'
-import {
-  MAX_VIDEO_SIZE_BYTES,
-  ACCEPTED_VIDEO_MIME_TYPES,
-  isFeedbackRequestBodyTooLarge,
-  isFeedbackRequestBodyLimitError,
-} from './FeatureRequestTypes'
-import { safeRemove, safeSetJSON } from '../../lib/safeLocalStorage'
-import { type FeedbackType, type FeedbackModalProps, DRAFT_KEY, type DraftState } from './FeedbackModal.types'
+import { REWARD_ACTIONS } from '../../hooks/useRewards'
+import type { FeedbackModalProps } from './FeedbackModal.types'
 import { FeedbackTabBar, ScreenshotAttacher, FeedbackSuccessView } from './FeedbackModal.parts'
+import { useFeedbackDraft } from './useFeedbackDraft'
 
 export function FeedbackModal({ isOpen, onClose, initialType = 'feature' }: FeedbackModalProps) {
-  const { showToast } = useToast()
   const { t } = useTranslation(['common'])
-  const branding = useBranding()
-  const { user } = useAuth()
-  const { createRequest } = useFeatureRequests(user?.github_login || '')
-  const { health: agentHealth, status: agentStatus, dataErrorCount: agentDataErrorCount, lastDataError: agentLastDataError } = useLocalAgent()
-  const [type, setType] = useState<FeedbackType>(initialType)
-  const [title, setTitle] = useState('')
-  const [description, setDescription] = useState('')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [success, setSuccess] = useState<{ issueUrl?: string; screenshotsUploaded?: number; screenshotsFailed?: number } | null>(null)
-  const [submitError, setSubmitError] = useState<string | null>(null)
-  const [validationErrors, setValidationErrors] = useState<{ title?: string; description?: string }>({})
-  const { awardCoins } = useRewards()
-  const [screenshots, setScreenshots] = useState<{ file: File; preview: string; mediaType?: 'image' | 'video' }[]>([])
-  const [isDragOver, setIsDragOver] = useState(false)
-  const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
-  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
-  const modalRef = useRef<HTMLDivElement>(null)
-
-  const handleScreenshotFiles = (files: FileList | null) => {
-    if (!files) return
-    const allFiles = Array.from(files)
-    const mediaFiles = allFiles.filter(f => f.type.startsWith('image/') || ACCEPTED_VIDEO_MIME_TYPES.has(f.type))
-    if (mediaFiles.length === 0) return
-    mediaFiles.forEach(file => {
-      const isVideo = ACCEPTED_VIDEO_MIME_TYPES.has(file.type)
-      if (isVideo && file.size > MAX_VIDEO_SIZE_BYTES) {
-        showToast(`Video "${file.name}" exceeds 10 MB limit. Please use a shorter or lower-resolution recording.`, 'error')
-        return
-      }
-      const reader = new FileReader()
-      reader.onload = (e) => {
-        const dataUri = e.target?.result as string
-        setScreenshots(prev => [...prev, { file, preview: dataUri, mediaType: isVideo ? 'video' : 'image' }])
-      }
-      reader.onerror = (err) => {
-        console.error(`[Attachment] FileReader failed for ${file.name}:`, err)
-        showToast(`Failed to read file "${file.name}". Try a different file.`, 'error')
-      }
-      reader.readAsDataURL(file)
-    })
-  }
-
-  const handleDragOver = (e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragOver(true)
-  }
-  const handleDragLeave = () => setIsDragOver(false)
-  const handleDrop = (e: React.DragEvent) => {
-    e.preventDefault()
-    setIsDragOver(false)
-    const mediaCount = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/') || ACCEPTED_VIDEO_MIME_TYPES.has(f.type)).length
-    if (mediaCount > 0) emitScreenshotAttached('drop', mediaCount)
-    handleScreenshotFiles(e.dataTransfer.files)
-  }
-
-  // Handle paste events to capture screenshots pasted into the textarea
-  const handlePaste = (e: React.ClipboardEvent) => {
-    const items = e.clipboardData?.items
-    if (!items) return
-    const allItems = Array.from(items)
-    const imageItems = allItems.filter(item => item.type.startsWith('image/'))
-    if (imageItems.length === 0) return
-    // Prevent pasting image data as text in the textarea
-    e.preventDefault()
-    imageItems.forEach(item => {
-      const file = item.getAsFile()
-      if (file) {
-        const reader = new FileReader()
-        reader.onload = (ev) => {
-          const dataUri = ev.target?.result as string
-          setScreenshots(prev => [...prev, { file, preview: dataUri }])
-        }
-        reader.onerror = (err) => {
-          console.error('[Screenshot] Paste FileReader failed:', err)
-          showToast('Failed to read pasted screenshot. Try attaching the image instead.', 'error')
-        }
-        reader.readAsDataURL(file)
-      }
-    })
-    emitScreenshotAttached('paste', imageItems.length)
-    showToast(`Screenshot${imageItems.length > 1 ? 's' : ''} added`, 'success')
-  }
-
-  const removeScreenshot = (index: number) => {
-    setScreenshots(prev => prev.filter((_, i) => i !== index))
-  }
-
-  const copyScreenshotToClipboard = async (preview: string, index: number) => {
-    try {
-      const res = await fetch(preview, { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-      const blob = await res.blob()
-      // #6229: route through the shared lib/clipboard.copyBlobToClipboard
-      // helper which guards `navigator.clipboard.write` AND
-      // `typeof ClipboardItem === 'function'` so unsupported browsers
-      // (older Safari, Firefox <127, all browsers in non-secure contexts)
-      // get a clean false return instead of an unhandled exception.
-      const ok = await copyBlobToClipboard(blob)
-      if (!ok) {
-        showToast('Could not copy image to clipboard (browser may not support image copy)', 'error')
-        return
-      }
-      setCopiedIndex(index)
-      setTimeout(() => setCopiedIndex(null), COPY_FEEDBACK_TIMEOUT_MS)
-    } catch {
-      showToast('Could not copy image to clipboard', 'error')
-    }
-  }
-
-  // Restore draft from localStorage on mount
-  useEffect(() => {
-    try {
-      const saved = localStorage.getItem(DRAFT_KEY)
-      if (saved) {
-        const draft: DraftState = JSON.parse(saved)
-        setType(draft.type)
-        setTitle(draft.title)
-        setDescription(draft.description)
-      }
-    } catch {
-      // ignore malformed draft
-    }
-  }, [])
-
-  // Autosave draft to localStorage whenever form content changes
-  useEffect(() => {
-    if (title || description) {
-      const draft: DraftState = { type, title, description }
-      safeSetJSON(DRAFT_KEY, draft)
-    } else {
-      safeRemove(DRAFT_KEY)
-    }
-  }, [type, title, description])
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    // Validate required fields and show inline errors instead of silently
-    // returning. Fixes #10476 — empty submit gave no feedback.
-    const errors: { title?: string; description?: string } = {}
-    if (!title.trim()) errors.title = 'Title is required'
-    if (!description.trim()) errors.description = 'Description is required'
-    if (Object.keys(errors).length > 0) {
-      setValidationErrors(errors)
-      return
-    }
-    setValidationErrors({})
-
-    setIsSubmitting(true)
-    setSubmitError(null)
-
-    const requestBodyTooLargeMessage = t(
-      'feedback.attachmentsTooLarge',
-      'Attachments are too large to submit. Keep each video at or below 10 MB and reduce the total attachment payload before retrying.',
-    )
-
-    try {
-      // Compress screenshots to fit within GitHub's 65K issue body limit.
-      // Images are embedded as base64 and processed into rendered images
-      // by a GitHub Actions workflow after the issue is created.
-      // Videos are passed through without compression.
-      const screenshotDataURIs: string[] = []
-      for (const s of screenshots) {
-        if (s.mediaType === 'video') {
-          screenshotDataURIs.push(s.preview)
-        } else {
-          const compressed = await compressScreenshot(s.preview)
-          if (compressed) screenshotDataURIs.push(compressed)
-        }
-      }
-
-      // Gather agent and browser diagnostics to help debug reported issues
-      const diagnostics: DiagnosticInfo = {
-        agent_version: agentHealth?.version,
-        commit_sha: agentHealth?.commitSHA,
-        build_time: agentHealth?.buildTime,
-        go_version: agentHealth?.goVersion,
-        agent_os: agentHealth?.os,
-        agent_arch: agentHealth?.arch,
-        install_method: agentHealth?.install_method,
-        clusters: agentHealth?.clusters,
-        agent_connection_status: agentStatus,
-        agent_connection_failures: agentDataErrorCount,
-        agent_last_error: agentLastDataError ?? undefined,
-        browser_user_agent: navigator.userAgent,
-        browser_platform: navigator.platform,
-        browser_language: navigator.language,
-        screen_resolution: `${screen.width}x${screen.height}`,
-        window_size: `${window.innerWidth}x${window.innerHeight}`,
-        page_url: `${window.location.origin}${window.location.pathname}`,
-      }
-
-      const consoleErrors = getRecentBrowserErrors()
-      const failedApiCalls = getRecentFailedApiCalls()
-
-      // Submit via backend API — creates GitHub issue directly using the
-      // server-side token. No GitHub login required from the user.
-      // Screenshots are uploaded server-side and embedded as images.
-      const hasScreenshots = screenshotDataURIs.length > 0
-      const submissionPayload = {
-        title: title.trim(),
-        description: description.trim(),
-        request_type: type,
-        target_repo: 'console' as const,
-        diagnostics,
-        ...(consoleErrors.length > 0 && { console_errors: consoleErrors }),
-        ...(failedApiCalls.length > 0 && { failed_api_calls: failedApiCalls }),
-        ...(hasScreenshots && { screenshots: screenshotDataURIs }),
-      }
-      if (isFeedbackRequestBodyTooLarge(submissionPayload)) {
-        setSubmitError(requestBodyTooLargeMessage)
-        showToast(requestBodyTooLargeMessage, 'error')
-        return
-      }
-      const result = await createRequest(submissionPayload, hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined)
-      if (hasScreenshots) emitScreenshotUploadSuccess(screenshotDataURIs.length)
-
-      emitFeedbackSubmitted(type)
-
-      // Award coins based on type
-      const action = type === 'bug' ? 'bug_report' : 'feature_suggestion'
-      awardCoins(action as 'bug_report' | 'feature_suggestion', { title, type })
-
-      // Clear draft on successful submit
-      safeRemove(DRAFT_KEY)
-      setSuccess({
-        issueUrl: result.github_issue_url,
-        screenshotsUploaded: result.screenshots_uploaded,
-        screenshotsFailed: result.screenshots_failed })
-    } catch (err: unknown) {
-      console.error('[Screenshot] Failed to submit feedback:', err)
-      const message = err instanceof Error ? err.message : 'Failed to submit feedback'
-      const finalMessage = isFeedbackRequestBodyLimitError(message)
-        ? requestBodyTooLargeMessage
-        : message
-      if (screenshots.length > 0) emitScreenshotUploadFailed(finalMessage, screenshots.length)
-      setSubmitError(finalMessage)
-      showToast(finalMessage, 'error')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const forceClose = () => {
-    setShowDiscardConfirm(false)
-    safeRemove(DRAFT_KEY)
-    setSuccess(null)
-    setSubmitError(null)
-    setValidationErrors({})
-    setTitle('')
-    setDescription('')
-    setScreenshots([])
-    onClose()
-  }
-
-  // Use refs for dirty check so handleClose doesn't change on every keystroke
-  const titleRef = useRef(title)
-  const descriptionRef = useRef(description)
-  const successRef = useRef(success)
-  titleRef.current = title
-  descriptionRef.current = description
-  successRef.current = success
-
-  const handleClose = useCallback(() => {
-    if (!successRef.current && (titleRef.current.trim() !== '' || descriptionRef.current.trim() !== '')) {
-      setShowDiscardConfirm(true)
-      return
-    }
-    forceClose()
-  }, [forceClose])
-
-  // Submit form programmatically via ref (used by Cmd/Ctrl+Enter shortcut)
-  const formRef = useRef<HTMLFormElement>(null)
+  const {
+    branding,
+    type, setType,
+    title, setTitle,
+    description, setDescription,
+    isSubmitting,
+    success,
+    submitError,
+    validationErrors, setValidationErrors,
+    awardCoins,
+    screenshots,
+    isDragOver,
+    copiedIndex,
+    showDiscardConfirm, setShowDiscardConfirm,
+    modalRef,
+    formRef,
+    handleScreenshotFiles,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handlePaste,
+    removeScreenshot,
+    copyScreenshotToClipboard,
+    handleSubmit,
+    forceClose,
+    handleClose,
+  } = useFeedbackDraft({ isOpen, onClose, initialType })
 
   useModalFocusTrap(modalRef, isOpen)
-
-  // Keyboard navigation - ESC to close, Space to close when not typing,
-  // Cmd/Ctrl+Enter to submit (#8651)
-  useEffect(() => {
-    if (!isOpen) return
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      // ESC always closes
-      if (e.key === 'Escape') {
-        e.preventDefault()
-        handleClose()
-        return
-      }
-
-      // Cmd+Enter (Mac) or Ctrl+Enter (Win/Linux) submits the form
-      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
-        e.preventDefault()
-        formRef.current?.requestSubmit()
-        return
-      }
-
-      // Space closes only if focus is not on an input or interactive control.
-      // Use closest() so child elements (e.g. <span>/<svg> inside a <button>)
-      // are caught too. Fixes #10476 — Space on a button closed the modal.
-      if (e.key === ' ') {
-        if (
-          e.target instanceof HTMLInputElement ||
-          e.target instanceof HTMLTextAreaElement ||
-          (e.target instanceof HTMLElement && (
-            e.target.isContentEditable ||
-            (e.target as HTMLElement).closest('button, a, select, [role="button"], [role="link"], [role="option"], [role="menuitem"]')
-          ))
-        ) {
-          return
-        }
-        e.preventDefault()
-        handleClose()
-      }
-    }
-
-    window.addEventListener('keydown', handleKeyDown)
-    return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [isOpen, handleClose])
 
   if (!isOpen) return null
 

--- a/web/src/components/feedback/SubmitTab.tsx
+++ b/web/src/components/feedback/SubmitTab.tsx
@@ -1,56 +1,30 @@
-import { useState, useCallback, useEffect } from 'react'
 import {
   Eye, Pencil, Settings, Maximize2,
   ExternalLink, Loader2,
 } from 'lucide-react'
 import { Github } from '@/lib/icons'
 import { cn } from '@/lib/cn'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
-import { api } from '../../lib/api'
-import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
-import { compressScreenshot } from '../../lib/imageCompression'
-import { useToast } from '../ui/Toast'
 import { useTranslation } from 'react-i18next'
-import { useBackendHealth } from '../../hooks/useBackendHealth'
-import { useKagentBackend } from '../../hooks/useKagentBackend'
 import { sanitizeUrl } from '@/lib/utils/sanitizeUrl'
-
 import { LazyMarkdown as ReactMarkdown } from '../ui/LazyMarkdown'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import rehypeSanitize from 'rehype-sanitize'
-import { useLocalAgent } from '../../hooks/useLocalAgent'
 import type { CreateFeatureRequestInput } from '../../hooks/useFeatureRequests'
 import type { RequestType, TargetRepo, ScreenshotItem, SuccessState } from './FeatureRequestTypes'
 import {
-  MIN_TITLE_LENGTH,
-  MIN_DESCRIPTION_LENGTH,
-  MIN_DESCRIPTION_WORDS,
-  MAX_TITLE_LENGTH,
-  EMPTY_FILE_SIZE_BYTES,
-  isFeedbackRequestBodyTooLarge,
-  isFeedbackRequestBodyLimitError,
-} from './FeatureRequestTypes'
-
-import {
-  ALL_CLUSTERS_CONTEXT_LABEL,
-  buildDirectIssueUrl,
+  MIN_PARENT_ISSUE_NUMBER,
   DESCRIPTION_EDITOR_HEIGHT_CLASS,
   DESCRIPTION_EXAMPLE_MAX_HEIGHT_CLASS,
-  getSubmitErrorDetails,
-  MAX_AGENT_CONNECTION_LOG_LINES,
-  MIN_PARENT_ISSUE_NUMBER,
   preventModalScrollChaining,
 } from './submitTab.utils'
-
 import { SubmitTabAttachments } from './SubmitTabAttachments'
 import { AuthGateBanner, FeedbackTokenMissingBanner, EditingDraftBanner, SubmitTypeSelector, RepositorySelector } from './SubmitTab.parts'
+import { useSubmitFormHandler } from './useSubmitFormHandler'
 
 export { SuccessView } from './SubmitTabSuccessView'
 
 // ── Submit Form ──
-
 interface SubmitFormProps {
   description: string
   setDescription: (v: string) => void
@@ -105,252 +79,33 @@ export function SubmitForm({
   onReauthenticate,
 }: SubmitFormProps) {
   const { t } = useTranslation()
-  const { showToast } = useToast()
   const {
-    health: agentHealth,
-    status: agentStatus,
-    dataErrorCount: agentDataErrorCount,
-    lastDataError: agentLastDataError,
-    connectionEvents,
-  } = useLocalAgent()
-  const { status: backendStatus, isInClusterMode } = useBackendHealth()
-  const { activeBackend } = useKagentBackend()
-  const { selectedClusters } = useGlobalFilters()
-  const directIssueUrl = buildDirectIssueUrl(targetRepo, description)
-  const errorDetails = error ? getSubmitErrorDetails(error, canPerformActions, t as unknown as (key: string, defaultValue?: string) => string) : null
-  const bugReportExample = t(
-    'feedback.exampleBugReportBody',
-    'Example bug report: (replace this with a detailed bug report)\n\nWhat happened:\nThe GPU utilization card shows 0% even though pods are running.\n\nWhat I expected:\nGPU metrics should reflect actual usage from nvidia-smi.\n\nSteps to reproduce:\n1. Deploy a GPU workload\n2. Open the dashboard\n3. Check the GPU card',
-  )
-  const featureRequestExample = t(
-    'feedback.exampleFeatureRequestBody',
-    'Example feature request: (replace this with your feature request)\n\nWhat I want:\nAdd a button to export dashboard data as CSV.\n\nWhy it would be useful:\nI need to share cluster metrics with my team in spreadsheets.\n\nAdditional context:\nShould include all visible card data with timestamps.',
-  )
-  const descriptionExample = requestType === 'bug' ? bugReportExample : featureRequestExample
-  const descriptionPlaceholder = requestType === 'bug'
-    ? t('feedback.descriptionPlaceholderBug', 'Describe the bug in your own words. See the full example below.')
-    : t('feedback.descriptionPlaceholderFeature', 'Describe the feature in your own words. See the full example below.')
-  const [descriptionTab, setDescriptionTab] = useState<'write' | 'preview'>('write')
-  const requestBodyTooLargeMessage = t(
-    'feedback.attachmentsTooLarge',
-    'Attachments are too large to submit. Keep each video at or below 10 MB and reduce the total attachment payload before retrying.',
-  )
-  const [parentIssueNumber, setParentIssueNumber] = useState('')
-  const [canLinkParentIssue, setCanLinkParentIssue] = useState(false)
-  const [isCheckingParentIssueAccess, setIsCheckingParentIssueAccess] = useState(false)
-
-  // Close fullscreen preview on Escape key
-  const handleFullscreenKeyDown = useCallback((e: KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      setIsPreviewFullscreen(false)
-    }
-  }, [setIsPreviewFullscreen])
-
-  useEffect(() => {
-    if (isPreviewFullscreen) {
-      document.addEventListener('keydown', handleFullscreenKeyDown)
-      return () => document.removeEventListener('keydown', handleFullscreenKeyDown)
-    }
-  }, [isPreviewFullscreen, handleFullscreenKeyDown])
-
-  useEffect(() => {
-    if (!canPerformActions || requestType !== 'bug') {
-      setCanLinkParentIssue(false)
-      setIsCheckingParentIssueAccess(false)
-      return
-    }
-
-    let isCurrent = true
-    setIsCheckingParentIssueAccess(true)
-
-    ;(async () => {
-      try {
-        const { data } = await api.get<{ can_link_parent?: boolean }>(`/api/feedback/issue-link-capabilities?target_repo=${targetRepo}`, {
-          timeout: FETCH_DEFAULT_TIMEOUT_MS,
-        })
-        if (isCurrent) {
-          setCanLinkParentIssue(data.can_link_parent === true)
-        }
-      } catch {
-        if (isCurrent) setCanLinkParentIssue(false)
-      } finally {
-        if (isCurrent) setIsCheckingParentIssueAccess(false)
-      }
-    })()
-
-    return () => {
-      isCurrent = false
-    }
-  }, [canPerformActions, requestType, targetRepo])
-
-  useEffect(() => {
-    if (!canLinkParentIssue) {
-      setParentIssueNumber('')
-    }
-  }, [canLinkParentIssue, targetRepo])
-
-  // Handle paste events to capture screenshots pasted into the textarea
-  const handlePaste = (e: React.ClipboardEvent) => {
-    const items = e.clipboardData?.items
-    if (!items) return
-    const imageItems = Array.from(items).filter(item => item.type.startsWith('image/'))
-    if (imageItems.length === 0) return
-    e.preventDefault()
-    imageItems.forEach(item => {
-      const file = item.getAsFile()
-      if (file) {
-        const reader = new FileReader()
-        reader.onload = (ev) => {
-          setScreenshots(prev => [...prev, { file, preview: ev.target?.result as string, mediaType: 'image' }])
-        }
-        reader.onerror = (err) => {
-          console.error('[Attachment] Paste FileReader failed:', err)
-          showToast('Failed to read pasted image. Try attaching the file instead.', 'error')
-        }
-        reader.readAsDataURL(file)
-      }
-    })
-    showToast(`Screenshot${imageItems.length > 1 ? 's' : ''} added`, 'success')
-  }
-
-
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    setError(null)
-
-    if (!canPerformActions) {
-      onShowLoginPrompt()
-      return
-    }
-
-    const trimmed = description.trim()
-    const lines = trimmed.split('\n')
-    const extractedTitle = lines[0].trim().substring(0, MAX_TITLE_LENGTH)
-    const extractedDesc = lines.length > 1 ? lines.slice(1).join('\n').trim() || extractedTitle : extractedTitle
-
-    if (extractedTitle.length < MIN_TITLE_LENGTH) {
-      setError('Title (first line) must be at least 10 characters')
-      return
-    }
-    if (extractedDesc.length < MIN_DESCRIPTION_LENGTH) {
-      setError('Description must be at least 20 characters')
-      return
-    }
-    if (extractedDesc.split(/\s+/).filter(Boolean).length < MIN_DESCRIPTION_WORDS) {
-      setError('Description must contain at least 3 words')
-      return
-    }
-
-    const hasZeroByteAttachment = screenshots.some(({ file }) => file.size === EMPTY_FILE_SIZE_BYTES)
-    if (hasZeroByteAttachment) {
-      setError(t(
-        'feedback.invalidAttachmentRestore',
-        'One or more attachments could not be restored. Remove them or re-attach the original file before submitting.',
-      ))
-      return
-    }
-
-    const trimmedParentIssueNumber = parentIssueNumber.trim()
-    let parsedParentIssueNumber: number | undefined
-    if (trimmedParentIssueNumber) {
-      parsedParentIssueNumber = Number.parseInt(trimmedParentIssueNumber, 10)
-      if (!Number.isInteger(parsedParentIssueNumber) || parsedParentIssueNumber < MIN_PARENT_ISSUE_NUMBER) {
-        setError(t('feedback.parentIssueNumberInvalid', 'Parent issue number must be a positive integer.'))
-        return
-      }
-    }
-
-    const screenshotDataURIs: string[] = []
-    for (const s of screenshots) {
-      if (s.mediaType === 'video') {
-        // Videos are passed through without compression
-        screenshotDataURIs.push(s.preview)
-      } else {
-        const compressed = await compressScreenshot(s.preview)
-        if (compressed) screenshotDataURIs.push(compressed)
-      }
-    }
-
-    try {
-      const hasScreenshots = screenshotDataURIs.length > 0
-      const { getRecentBrowserErrors, getRecentFailedApiCalls } = await import('../../lib/analytics-core')
-      const browserErrors = requestType === 'bug' ? getRecentBrowserErrors() : []
-      const failedApiCalls = getRecentFailedApiCalls()
-
-      const selectedClusterContext = (selectedClusters || []).length > 0
-        ? (selectedClusters || []).join(', ')
-        : ALL_CLUSTERS_CONTEXT_LABEL
-      const agentConnectionLog = (connectionEvents || []).length > 0
-        ? (connectionEvents || [])
-          .slice(0, MAX_AGENT_CONNECTION_LOG_LINES)
-          .map(event => `[${event.timestamp.toISOString()}] ${event.type}: ${event.message}`)
-        : isInClusterMode
-          ? [`[${new Date().toISOString()}] connected: Using in-cluster service`]
-          : []
-      const diagnostics = {
-        agent_version: agentHealth?.version,
-        commit_sha: agentHealth?.commitSHA,
-        build_time: agentHealth?.buildTime,
-        go_version: agentHealth?.goVersion,
-        agent_os: agentHealth?.os,
-        agent_arch: agentHealth?.arch,
-        install_method: agentHealth?.install_method,
-        clusters: agentHealth?.clusters,
-        cluster_context: selectedClusterContext,
-        console_deploy_mode: isInClusterMode ? 'in-cluster' : 'local',
-        active_agent_backend: activeBackend,
-        backend_ws_status: backendStatus,
-        agent_connection_status: agentStatus,
-        agent_connection_failures: agentDataErrorCount,
-        agent_last_error: agentLastDataError ?? undefined,
-        ...(agentConnectionLog.length > 0 && { agent_connection_log: agentConnectionLog }),
-        browser_user_agent: navigator.userAgent,
-        browser_platform: navigator.platform,
-        browser_language: navigator.language,
-        screen_resolution: `${screen.width}x${screen.height}`,
-        window_size: `${window.innerWidth}x${window.innerHeight}`,
-        page_url: `${window.location.origin}${window.location.pathname}`,
-      }
-
-      const submissionPayload: CreateFeatureRequestInput = {
-        title: extractedTitle,
-        description: extractedDesc,
-        request_type: requestType,
-        target_repo: targetRepo,
-        diagnostics,
-        ...(parsedParentIssueNumber && { parent_issue_number: parsedParentIssueNumber }),
-        ...(hasScreenshots && { screenshots: screenshotDataURIs }),
-        ...(browserErrors.length > 0 && { console_errors: browserErrors }),
-        ...(failedApiCalls.length > 0 && { failed_api_calls: failedApiCalls }),
-      }
-      if (isFeedbackRequestBodyTooLarge(submissionPayload)) {
-        setError(requestBodyTooLargeMessage)
-        showToast(requestBodyTooLargeMessage, 'error')
-        return
-      }
-
-      const result = await onSubmit(
-        submissionPayload,
-        hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined,
-      )
-      onSuccess({
-        issueUrl: result.github_issue_url,
-        screenshotsUploaded: result.screenshots_uploaded,
-        screenshotsFailed: result.screenshots_failed,
-        warning: result.warning,
-      })
-    } catch (err: unknown) {
-      const message = err instanceof Error ? err.message : ''
-      const normalizedMessage = isFeedbackRequestBodyLimitError(message)
-        ? requestBodyTooLargeMessage
-        : message || t('feedback.submitFailed')
-      if (isFeedbackRequestBodyLimitError(message)) {
-        showToast(normalizedMessage, 'error')
-      }
-      setError(normalizedMessage)
-    }
-  }
+    directIssueUrl,
+    errorDetails,
+    descriptionExample,
+    descriptionPlaceholder,
+    descriptionTab, setDescriptionTab,
+    parentIssueNumber, setParentIssueNumber,
+    canLinkParentIssue,
+    isCheckingParentIssueAccess,
+    handlePaste,
+    handleSubmit,
+  } = useSubmitFormHandler({
+    description,
+    setScreenshots,
+    requestType,
+    targetRepo,
+    screenshots,
+    canPerformActions,
+    error,
+    setError,
+    isPreviewFullscreen,
+    setIsPreviewFullscreen,
+    onSubmit,
+    onSuccess,
+    onShowLoginPrompt,
+    t: t as unknown as (key: string, defaultValue?: string) => string,
+  })
 
   const isAuthGated = !canPerformActions
   const inputsDisabled = isSubmitting || isAuthGated
@@ -589,6 +344,5 @@ export function SubmitForm({
     </form>
   )
 }
-
 
 export { SubmitFooter } from './SubmitTabFooter'

--- a/web/src/components/feedback/useFeedbackDraft.ts
+++ b/web/src/components/feedback/useFeedbackDraft.ts
@@ -1,0 +1,391 @@
+/**
+ * useFeedbackDraft — owns all FeedbackModal state, draft persistence
+ * (restore-on-mount / autosave-on-change), screenshot attachment handling,
+ * and submission logic so `FeedbackModal.tsx` can stay a thin presentational
+ * component.
+ *
+ * Extracted from FeedbackModal.tsx — no behaviour change.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useRewards } from '../../hooks/useRewards'
+import { useToast } from '../ui/Toast'
+import {
+  emitFeedbackSubmitted,
+  emitScreenshotAttached,
+  emitScreenshotUploadFailed,
+  emitScreenshotUploadSuccess,
+  getRecentBrowserErrors,
+  getRecentFailedApiCalls,
+} from '../../lib/analytics'
+import { copyBlobToClipboard } from '../../lib/clipboard'
+import { useBranding } from '../../hooks/useBranding'
+import { FETCH_DEFAULT_TIMEOUT_MS, COPY_FEEDBACK_TIMEOUT_MS } from '../../lib/constants'
+import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
+import { compressScreenshot } from '../../lib/imageCompression'
+import { useFeatureRequests, DiagnosticInfo } from '../../hooks/useFeatureRequests'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import { useAuth } from '../../lib/auth'
+import {
+  MAX_VIDEO_SIZE_BYTES,
+  ACCEPTED_VIDEO_MIME_TYPES,
+  isFeedbackRequestBodyTooLarge,
+  isFeedbackRequestBodyLimitError,
+} from './FeatureRequestTypes'
+import { safeRemove, safeSetJSON } from '../../lib/safeLocalStorage'
+import { type FeedbackType, DRAFT_KEY, type DraftState } from './FeedbackModal.types'
+
+type ScreenshotItem = { file: File; preview: string; mediaType?: 'image' | 'video' }
+
+interface UseFeedbackDraftArgs {
+  isOpen: boolean
+  onClose: () => void
+  initialType: FeedbackType
+}
+
+export function useFeedbackDraft({ isOpen, onClose, initialType }: UseFeedbackDraftArgs) {
+  const { showToast } = useToast()
+  const { t } = useTranslation(['common'])
+  const branding = useBranding()
+  const { user } = useAuth()
+  const { createRequest } = useFeatureRequests(user?.github_login || '')
+  const { health: agentHealth, status: agentStatus, dataErrorCount: agentDataErrorCount, lastDataError: agentLastDataError } = useLocalAgent()
+  const [type, setType] = useState<FeedbackType>(initialType)
+  const [title, setTitle] = useState('')
+  const [description, setDescription] = useState('')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [success, setSuccess] = useState<{ issueUrl?: string; screenshotsUploaded?: number; screenshotsFailed?: number } | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [validationErrors, setValidationErrors] = useState<{ title?: string; description?: string }>({})
+  const { awardCoins } = useRewards()
+  const [screenshots, setScreenshots] = useState<ScreenshotItem[]>([])
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [copiedIndex, setCopiedIndex] = useState<number | null>(null)
+  const [showDiscardConfirm, setShowDiscardConfirm] = useState(false)
+  const modalRef = useRef<HTMLDivElement>(null)
+  const formRef = useRef<HTMLFormElement>(null)
+
+  const handleScreenshotFiles = (files: FileList | null) => {
+    if (!files) return
+    const allFiles = Array.from(files)
+    const mediaFiles = allFiles.filter(f => f.type.startsWith('image/') || ACCEPTED_VIDEO_MIME_TYPES.has(f.type))
+    if (mediaFiles.length === 0) return
+    mediaFiles.forEach(file => {
+      const isVideo = ACCEPTED_VIDEO_MIME_TYPES.has(file.type)
+      if (isVideo && file.size > MAX_VIDEO_SIZE_BYTES) {
+        showToast(`Video "${file.name}" exceeds 10 MB limit. Please use a shorter or lower-resolution recording.`, 'error')
+        return
+      }
+      const reader = new FileReader()
+      reader.onload = (e) => {
+        const dataUri = e.target?.result as string
+        setScreenshots(prev => [...prev, { file, preview: dataUri, mediaType: isVideo ? 'video' : 'image' }])
+      }
+      reader.onerror = (err) => {
+        console.error(`[Attachment] FileReader failed for ${file.name}:`, err)
+        showToast(`Failed to read file "${file.name}". Try a different file.`, 'error')
+      }
+      reader.readAsDataURL(file)
+    })
+  }
+
+  const handleDragOver = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(true)
+  }
+  const handleDragLeave = () => setIsDragOver(false)
+  const handleDrop = (e: React.DragEvent) => {
+    e.preventDefault()
+    setIsDragOver(false)
+    const mediaCount = Array.from(e.dataTransfer.files).filter(f => f.type.startsWith('image/') || ACCEPTED_VIDEO_MIME_TYPES.has(f.type)).length
+    if (mediaCount > 0) emitScreenshotAttached('drop', mediaCount)
+    handleScreenshotFiles(e.dataTransfer.files)
+  }
+
+  // Handle paste events to capture screenshots pasted into the textarea
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    const allItems = Array.from(items)
+    const imageItems = allItems.filter(item => item.type.startsWith('image/'))
+    if (imageItems.length === 0) return
+    // Prevent pasting image data as text in the textarea
+    e.preventDefault()
+    imageItems.forEach(item => {
+      const file = item.getAsFile()
+      if (file) {
+        const reader = new FileReader()
+        reader.onload = (ev) => {
+          const dataUri = ev.target?.result as string
+          setScreenshots(prev => [...prev, { file, preview: dataUri }])
+        }
+        reader.onerror = (err) => {
+          console.error('[Screenshot] Paste FileReader failed:', err)
+          showToast('Failed to read pasted screenshot. Try attaching the image instead.', 'error')
+        }
+        reader.readAsDataURL(file)
+      }
+    })
+    emitScreenshotAttached('paste', imageItems.length)
+    showToast(`Screenshot${imageItems.length > 1 ? 's' : ''} added`, 'success')
+  }
+
+  const removeScreenshot = (index: number) => {
+    setScreenshots(prev => prev.filter((_, i) => i !== index))
+  }
+
+  const copyScreenshotToClipboard = async (preview: string, index: number) => {
+    try {
+      const res = await fetch(preview, { signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+      const blob = await res.blob()
+      // #6229: route through the shared lib/clipboard.copyBlobToClipboard
+      // helper which guards `navigator.clipboard.write` AND
+      // `typeof ClipboardItem === 'function'` so unsupported browsers
+      // (older Safari, Firefox <127, all browsers in non-secure contexts)
+      // get a clean false return instead of an unhandled exception.
+      const ok = await copyBlobToClipboard(blob)
+      if (!ok) {
+        showToast('Could not copy image to clipboard (browser may not support image copy)', 'error')
+        return
+      }
+      setCopiedIndex(index)
+      setTimeout(() => setCopiedIndex(null), COPY_FEEDBACK_TIMEOUT_MS)
+    } catch {
+      showToast('Could not copy image to clipboard', 'error')
+    }
+  }
+
+  // Restore draft from localStorage on mount
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem(DRAFT_KEY)
+      if (saved) {
+        const draft: DraftState = JSON.parse(saved)
+        setType(draft.type)
+        setTitle(draft.title)
+        setDescription(draft.description)
+      }
+    } catch {
+      // ignore malformed draft
+    }
+  }, [])
+
+  // Autosave draft to localStorage whenever form content changes
+  useEffect(() => {
+    if (title || description) {
+      const draft: DraftState = { type, title, description }
+      safeSetJSON(DRAFT_KEY, draft)
+    } else {
+      safeRemove(DRAFT_KEY)
+    }
+  }, [type, title, description])
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    // Validate required fields and show inline errors instead of silently
+    // returning. Fixes #10476 — empty submit gave no feedback.
+    const errors: { title?: string; description?: string } = {}
+    if (!title.trim()) errors.title = 'Title is required'
+    if (!description.trim()) errors.description = 'Description is required'
+    if (Object.keys(errors).length > 0) {
+      setValidationErrors(errors)
+      return
+    }
+    setValidationErrors({})
+
+    setIsSubmitting(true)
+    setSubmitError(null)
+
+    const requestBodyTooLargeMessage = t(
+      'feedback.attachmentsTooLarge',
+      'Attachments are too large to submit. Keep each video at or below 10 MB and reduce the total attachment payload before retrying.',
+    )
+
+    try {
+      // Compress screenshots to fit within GitHub's 65K issue body limit.
+      // Images are embedded as base64 and processed into rendered images
+      // by a GitHub Actions workflow after the issue is created.
+      // Videos are passed through without compression.
+      const screenshotDataURIs: string[] = []
+      for (const s of screenshots) {
+        if (s.mediaType === 'video') {
+          screenshotDataURIs.push(s.preview)
+        } else {
+          const compressed = await compressScreenshot(s.preview)
+          if (compressed) screenshotDataURIs.push(compressed)
+        }
+      }
+
+      // Gather agent and browser diagnostics to help debug reported issues
+      const diagnostics: DiagnosticInfo = {
+        agent_version: agentHealth?.version,
+        commit_sha: agentHealth?.commitSHA,
+        build_time: agentHealth?.buildTime,
+        go_version: agentHealth?.goVersion,
+        agent_os: agentHealth?.os,
+        agent_arch: agentHealth?.arch,
+        install_method: agentHealth?.install_method,
+        clusters: agentHealth?.clusters,
+        agent_connection_status: agentStatus,
+        agent_connection_failures: agentDataErrorCount,
+        agent_last_error: agentLastDataError ?? undefined,
+        browser_user_agent: navigator.userAgent,
+        browser_platform: navigator.platform,
+        browser_language: navigator.language,
+        screen_resolution: `${screen.width}x${screen.height}`,
+        window_size: `${window.innerWidth}x${window.innerHeight}`,
+        page_url: `${window.location.origin}${window.location.pathname}`,
+      }
+
+      const consoleErrors = getRecentBrowserErrors()
+      const failedApiCalls = getRecentFailedApiCalls()
+
+      // Submit via backend API — creates GitHub issue directly using the
+      // server-side token. No GitHub login required from the user.
+      // Screenshots are uploaded server-side and embedded as images.
+      const hasScreenshots = screenshotDataURIs.length > 0
+      const submissionPayload = {
+        title: title.trim(),
+        description: description.trim(),
+        request_type: type,
+        target_repo: 'console' as const,
+        diagnostics,
+        ...(consoleErrors.length > 0 && { console_errors: consoleErrors }),
+        ...(failedApiCalls.length > 0 && { failed_api_calls: failedApiCalls }),
+        ...(hasScreenshots && { screenshots: screenshotDataURIs }),
+      }
+      if (isFeedbackRequestBodyTooLarge(submissionPayload)) {
+        setSubmitError(requestBodyTooLargeMessage)
+        showToast(requestBodyTooLargeMessage, 'error')
+        return
+      }
+      const result = await createRequest(submissionPayload, hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined)
+      if (hasScreenshots) emitScreenshotUploadSuccess(screenshotDataURIs.length)
+
+      emitFeedbackSubmitted(type)
+
+      // Award coins based on type
+      const action = type === 'bug' ? 'bug_report' : 'feature_suggestion'
+      awardCoins(action as 'bug_report' | 'feature_suggestion', { title, type })
+
+      // Clear draft on successful submit
+      safeRemove(DRAFT_KEY)
+      setSuccess({
+        issueUrl: result.github_issue_url,
+        screenshotsUploaded: result.screenshots_uploaded,
+        screenshotsFailed: result.screenshots_failed })
+    } catch (err: unknown) {
+      console.error('[Screenshot] Failed to submit feedback:', err)
+      const message = err instanceof Error ? err.message : 'Failed to submit feedback'
+      const finalMessage = isFeedbackRequestBodyLimitError(message)
+        ? requestBodyTooLargeMessage
+        : message
+      if (screenshots.length > 0) emitScreenshotUploadFailed(finalMessage, screenshots.length)
+      setSubmitError(finalMessage)
+      showToast(finalMessage, 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const forceClose = () => {
+    setShowDiscardConfirm(false)
+    safeRemove(DRAFT_KEY)
+    setSuccess(null)
+    setSubmitError(null)
+    setValidationErrors({})
+    setTitle('')
+    setDescription('')
+    setScreenshots([])
+    onClose()
+  }
+
+  // Use refs for dirty check so handleClose doesn't change on every keystroke
+  const titleRef = useRef(title)
+  const descriptionRef = useRef(description)
+  const successRef = useRef(success)
+  titleRef.current = title
+  descriptionRef.current = description
+  successRef.current = success
+
+  const handleClose = useCallback(() => {
+    if (!successRef.current && (titleRef.current.trim() !== '' || descriptionRef.current.trim() !== '')) {
+      setShowDiscardConfirm(true)
+      return
+    }
+    forceClose()
+  }, [forceClose])
+
+  // Keyboard navigation - ESC to close, Space to close when not typing,
+  // Cmd/Ctrl+Enter to submit (#8651)
+  useEffect(() => {
+    if (!isOpen) return
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // ESC always closes
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        handleClose()
+        return
+      }
+
+      // Cmd+Enter (Mac) or Ctrl+Enter (Win/Linux) submits the form
+      if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        formRef.current?.requestSubmit()
+        return
+      }
+
+      // Space closes only if focus is not on an input or interactive control.
+      // Use closest() so child elements (e.g. <span>/<svg> inside a <button>)
+      // are caught too. Fixes #10476 — Space on a button closed the modal.
+      if (e.key === ' ') {
+        if (
+          e.target instanceof HTMLInputElement ||
+          e.target instanceof HTMLTextAreaElement ||
+          (e.target instanceof HTMLElement && (
+            e.target.isContentEditable ||
+            (e.target as HTMLElement).closest('button, a, select, [role="button"], [role="link"], [role="option"], [role="menuitem"]')
+          ))
+        ) {
+          return
+        }
+        e.preventDefault()
+        handleClose()
+      }
+    }
+
+    window.addEventListener('keydown', handleKeyDown)
+    return () => window.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, handleClose])
+
+  return {
+    branding,
+    type, setType,
+    title, setTitle,
+    description, setDescription,
+    isSubmitting,
+    success,
+    submitError,
+    validationErrors, setValidationErrors,
+    awardCoins,
+    screenshots,
+    isDragOver,
+    copiedIndex,
+    showDiscardConfirm, setShowDiscardConfirm,
+    modalRef,
+    formRef,
+    handleScreenshotFiles,
+    handleDragOver,
+    handleDragLeave,
+    handleDrop,
+    handlePaste,
+    removeScreenshot,
+    copyScreenshotToClipboard,
+    handleSubmit,
+    forceClose,
+    handleClose,
+  }
+}

--- a/web/src/components/feedback/useFeedbackDraft.ts
+++ b/web/src/components/feedback/useFeedbackDraft.ts
@@ -290,7 +290,7 @@ export function useFeedbackDraft({ isOpen, onClose, initialType }: UseFeedbackDr
     }
   }
 
-  const forceClose = () => {
+  const forceClose = useCallback(() => {
     setShowDiscardConfirm(false)
     safeRemove(DRAFT_KEY)
     setSuccess(null)
@@ -300,7 +300,7 @@ export function useFeedbackDraft({ isOpen, onClose, initialType }: UseFeedbackDr
     setDescription('')
     setScreenshots([])
     onClose()
-  }
+  }, [onClose])
 
   // Use refs for dirty check so handleClose doesn't change on every keystroke
   const titleRef = useRef(title)

--- a/web/src/components/feedback/useSubmitFormHandler.ts
+++ b/web/src/components/feedback/useSubmitFormHandler.ts
@@ -1,0 +1,327 @@
+/**
+ * useSubmitFormHandler — owns SubmitForm's non-JSX state: description tab
+ * toggle, parent-issue linking, fullscreen preview keyboard handling,
+ * paste-to-attach, and the submit handler itself (diagnostics collection +
+ * API call). Extracted from SubmitTab.tsx — no behaviour change.
+ */
+
+import { useState, useCallback, useEffect } from 'react'
+import { useToast } from '../ui/Toast'
+import { api } from '../../lib/api'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { FEEDBACK_UPLOAD_TIMEOUT_MS } from '../../lib/constants/network'
+import { compressScreenshot } from '../../lib/imageCompression'
+import { useBackendHealth } from '../../hooks/useBackendHealth'
+import { useKagentBackend } from '../../hooks/useKagentBackend'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useLocalAgent } from '../../hooks/useLocalAgent'
+import type { CreateFeatureRequestInput } from '../../hooks/useFeatureRequests'
+import type { RequestType, TargetRepo, ScreenshotItem, SuccessState } from './FeatureRequestTypes'
+import {
+  MIN_TITLE_LENGTH,
+  MIN_DESCRIPTION_LENGTH,
+  MIN_DESCRIPTION_WORDS,
+  MAX_TITLE_LENGTH,
+  EMPTY_FILE_SIZE_BYTES,
+  isFeedbackRequestBodyTooLarge,
+  isFeedbackRequestBodyLimitError,
+} from './FeatureRequestTypes'
+import {
+  ALL_CLUSTERS_CONTEXT_LABEL,
+  buildDirectIssueUrl,
+  getSubmitErrorDetails,
+  MAX_AGENT_CONNECTION_LOG_LINES,
+  MIN_PARENT_ISSUE_NUMBER,
+} from './submitTab.utils'
+
+interface UseSubmitFormHandlerArgs {
+  description: string
+  setScreenshots: React.Dispatch<React.SetStateAction<ScreenshotItem[]>>
+  requestType: RequestType
+  targetRepo: TargetRepo
+  screenshots: ScreenshotItem[]
+  canPerformActions: boolean
+  error: string | null
+  setError: (v: string | null) => void
+  isPreviewFullscreen: boolean
+  setIsPreviewFullscreen: (v: boolean) => void
+  onSubmit: (payload: CreateFeatureRequestInput, options?: { timeout: number }) => Promise<{ github_issue_url?: string; screenshots_uploaded?: number; screenshots_failed?: number; warning?: string }>
+  onSuccess: (result: SuccessState) => void
+  onShowLoginPrompt: () => void
+  t: (key: string, defaultValue?: string) => string
+}
+
+export function useSubmitFormHandler({
+  description,
+  setScreenshots,
+  requestType,
+  targetRepo,
+  screenshots,
+  canPerformActions,
+  error,
+  setError,
+  isPreviewFullscreen,
+  setIsPreviewFullscreen,
+  onSubmit,
+  onSuccess,
+  onShowLoginPrompt,
+  t,
+}: UseSubmitFormHandlerArgs) {
+  const { showToast } = useToast()
+  const {
+    health: agentHealth,
+    status: agentStatus,
+    dataErrorCount: agentDataErrorCount,
+    lastDataError: agentLastDataError,
+    connectionEvents,
+  } = useLocalAgent()
+  const { status: backendStatus, isInClusterMode } = useBackendHealth()
+  const { activeBackend } = useKagentBackend()
+  const { selectedClusters } = useGlobalFilters()
+  const directIssueUrl = buildDirectIssueUrl(targetRepo, description)
+  const errorDetails = error ? getSubmitErrorDetails(error, canPerformActions, t as unknown as (key: string, defaultValue?: string) => string) : null
+  const bugReportExample = t(
+    'feedback.exampleBugReportBody',
+    'Example bug report: (replace this with a detailed bug report)\n\nWhat happened:\nThe GPU utilization card shows 0% even though pods are running.\n\nWhat I expected:\nGPU metrics should reflect actual usage from nvidia-smi.\n\nSteps to reproduce:\n1. Deploy a GPU workload\n2. Open the dashboard\n3. Check the GPU card',
+  )
+  const featureRequestExample = t(
+    'feedback.exampleFeatureRequestBody',
+    'Example feature request: (replace this with your feature request)\n\nWhat I want:\nAdd a button to export dashboard data as CSV.\n\nWhy it would be useful:\nI need to share cluster metrics with my team in spreadsheets.\n\nAdditional context:\nShould include all visible card data with timestamps.',
+  )
+  const descriptionExample = requestType === 'bug' ? bugReportExample : featureRequestExample
+  const descriptionPlaceholder = requestType === 'bug'
+    ? t('feedback.descriptionPlaceholderBug', 'Describe the bug in your own words. See the full example below.')
+    : t('feedback.descriptionPlaceholderFeature', 'Describe the feature in your own words. See the full example below.')
+  const [descriptionTab, setDescriptionTab] = useState<'write' | 'preview'>('write')
+  const requestBodyTooLargeMessage = t(
+    'feedback.attachmentsTooLarge',
+    'Attachments are too large to submit. Keep each video at or below 10 MB and reduce the total attachment payload before retrying.',
+  )
+  const [parentIssueNumber, setParentIssueNumber] = useState('')
+  const [canLinkParentIssue, setCanLinkParentIssue] = useState(false)
+  const [isCheckingParentIssueAccess, setIsCheckingParentIssueAccess] = useState(false)
+
+  // Close fullscreen preview on Escape key
+  const handleFullscreenKeyDown = useCallback((e: KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      setIsPreviewFullscreen(false)
+    }
+  }, [setIsPreviewFullscreen])
+
+  useEffect(() => {
+    if (isPreviewFullscreen) {
+      document.addEventListener('keydown', handleFullscreenKeyDown)
+      return () => document.removeEventListener('keydown', handleFullscreenKeyDown)
+    }
+  }, [isPreviewFullscreen, handleFullscreenKeyDown])
+
+  useEffect(() => {
+    if (!canPerformActions || requestType !== 'bug') {
+      setCanLinkParentIssue(false)
+      setIsCheckingParentIssueAccess(false)
+      return
+    }
+
+    let isCurrent = true
+    setIsCheckingParentIssueAccess(true)
+
+    ;(async () => {
+      try {
+        const { data } = await api.get<{ can_link_parent?: boolean }>(`/api/feedback/issue-link-capabilities?target_repo=${targetRepo}`, {
+          timeout: FETCH_DEFAULT_TIMEOUT_MS,
+        })
+        if (isCurrent) {
+          setCanLinkParentIssue(data.can_link_parent === true)
+        }
+      } catch {
+        if (isCurrent) setCanLinkParentIssue(false)
+      } finally {
+        if (isCurrent) setIsCheckingParentIssueAccess(false)
+      }
+    })()
+
+    return () => {
+      isCurrent = false
+    }
+  }, [canPerformActions, requestType, targetRepo])
+
+  useEffect(() => {
+    if (!canLinkParentIssue) {
+      setParentIssueNumber('')
+    }
+  }, [canLinkParentIssue, targetRepo])
+
+  // Handle paste events to capture screenshots pasted into the textarea
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const items = e.clipboardData?.items
+    if (!items) return
+    const imageItems = Array.from(items).filter(item => item.type.startsWith('image/'))
+    if (imageItems.length === 0) return
+    e.preventDefault()
+    imageItems.forEach(item => {
+      const file = item.getAsFile()
+      if (file) {
+        const reader = new FileReader()
+        reader.onload = (ev) => {
+          setScreenshots(prev => [...prev, { file, preview: ev.target?.result as string, mediaType: 'image' }])
+        }
+        reader.onerror = (err) => {
+          console.error('[Attachment] Paste FileReader failed:', err)
+          showToast('Failed to read pasted image. Try attaching the file instead.', 'error')
+        }
+        reader.readAsDataURL(file)
+      }
+    })
+    showToast(`Screenshot${imageItems.length > 1 ? 's' : ''} added`, 'success')
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (!canPerformActions) {
+      onShowLoginPrompt()
+      return
+    }
+
+    const trimmed = description.trim()
+    const lines = trimmed.split('\n')
+    const extractedTitle = lines[0].trim().substring(0, MAX_TITLE_LENGTH)
+    const extractedDesc = lines.length > 1 ? lines.slice(1).join('\n').trim() || extractedTitle : extractedTitle
+
+    if (extractedTitle.length < MIN_TITLE_LENGTH) {
+      setError('Title (first line) must be at least 10 characters')
+      return
+    }
+    if (extractedDesc.length < MIN_DESCRIPTION_LENGTH) {
+      setError('Description must be at least 20 characters')
+      return
+    }
+    if (extractedDesc.split(/\s+/).filter(Boolean).length < MIN_DESCRIPTION_WORDS) {
+      setError('Description must contain at least 3 words')
+      return
+    }
+
+    const hasZeroByteAttachment = screenshots.some(({ file }) => file.size === EMPTY_FILE_SIZE_BYTES)
+    if (hasZeroByteAttachment) {
+      setError(t(
+        'feedback.invalidAttachmentRestore',
+        'One or more attachments could not be restored. Remove them or re-attach the original file before submitting.',
+      ))
+      return
+    }
+
+    const trimmedParentIssueNumber = parentIssueNumber.trim()
+    let parsedParentIssueNumber: number | undefined
+    if (trimmedParentIssueNumber) {
+      parsedParentIssueNumber = Number.parseInt(trimmedParentIssueNumber, 10)
+      if (!Number.isInteger(parsedParentIssueNumber) || parsedParentIssueNumber < MIN_PARENT_ISSUE_NUMBER) {
+        setError(t('feedback.parentIssueNumberInvalid', 'Parent issue number must be a positive integer.'))
+        return
+      }
+    }
+
+    const screenshotDataURIs: string[] = []
+    for (const s of screenshots) {
+      if (s.mediaType === 'video') {
+        // Videos are passed through without compression
+        screenshotDataURIs.push(s.preview)
+      } else {
+        const compressed = await compressScreenshot(s.preview)
+        if (compressed) screenshotDataURIs.push(compressed)
+      }
+    }
+
+    try {
+      const hasScreenshots = screenshotDataURIs.length > 0
+      const { getRecentBrowserErrors, getRecentFailedApiCalls } = await import('../../lib/analytics-core')
+      const browserErrors = requestType === 'bug' ? getRecentBrowserErrors() : []
+      const failedApiCalls = getRecentFailedApiCalls()
+
+      const selectedClusterContext = (selectedClusters || []).length > 0
+        ? (selectedClusters || []).join(', ')
+        : ALL_CLUSTERS_CONTEXT_LABEL
+      const agentConnectionLog = (connectionEvents || []).length > 0
+        ? (connectionEvents || [])
+          .slice(0, MAX_AGENT_CONNECTION_LOG_LINES)
+          .map(event => `[${event.timestamp.toISOString()}] ${event.type}: ${event.message}`)
+        : isInClusterMode
+          ? [`[${new Date().toISOString()}] connected: Using in-cluster service`]
+          : []
+      const diagnostics = {
+        agent_version: agentHealth?.version,
+        commit_sha: agentHealth?.commitSHA,
+        build_time: agentHealth?.buildTime,
+        go_version: agentHealth?.goVersion,
+        agent_os: agentHealth?.os,
+        agent_arch: agentHealth?.arch,
+        install_method: agentHealth?.install_method,
+        clusters: agentHealth?.clusters,
+        cluster_context: selectedClusterContext,
+        console_deploy_mode: isInClusterMode ? 'in-cluster' : 'local',
+        active_agent_backend: activeBackend,
+        backend_ws_status: backendStatus,
+        agent_connection_status: agentStatus,
+        agent_connection_failures: agentDataErrorCount,
+        agent_last_error: agentLastDataError ?? undefined,
+        ...(agentConnectionLog.length > 0 && { agent_connection_log: agentConnectionLog }),
+        browser_user_agent: navigator.userAgent,
+        browser_platform: navigator.platform,
+        browser_language: navigator.language,
+        screen_resolution: `${screen.width}x${screen.height}`,
+        window_size: `${window.innerWidth}x${window.innerHeight}`,
+        page_url: `${window.location.origin}${window.location.pathname}`,
+      }
+
+      const submissionPayload: CreateFeatureRequestInput = {
+        title: extractedTitle,
+        description: extractedDesc,
+        request_type: requestType,
+        target_repo: targetRepo,
+        diagnostics,
+        ...(parsedParentIssueNumber && { parent_issue_number: parsedParentIssueNumber }),
+        ...(hasScreenshots && { screenshots: screenshotDataURIs }),
+        ...(browserErrors.length > 0 && { console_errors: browserErrors }),
+        ...(failedApiCalls.length > 0 && { failed_api_calls: failedApiCalls }),
+      }
+      if (isFeedbackRequestBodyTooLarge(submissionPayload)) {
+        setError(requestBodyTooLargeMessage)
+        showToast(requestBodyTooLargeMessage, 'error')
+        return
+      }
+
+      const result = await onSubmit(
+        submissionPayload,
+        hasScreenshots ? { timeout: FEEDBACK_UPLOAD_TIMEOUT_MS } : undefined,
+      )
+      onSuccess({
+        issueUrl: result.github_issue_url,
+        screenshotsUploaded: result.screenshots_uploaded,
+        screenshotsFailed: result.screenshots_failed,
+        warning: result.warning,
+      })
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : ''
+      const normalizedMessage = isFeedbackRequestBodyLimitError(message)
+        ? requestBodyTooLargeMessage
+        : message || t('feedback.submitFailed')
+      if (isFeedbackRequestBodyLimitError(message)) {
+        showToast(normalizedMessage, 'error')
+      }
+      setError(normalizedMessage)
+    }
+  }
+
+  return {
+    directIssueUrl,
+    errorDetails,
+    descriptionExample,
+    descriptionPlaceholder,
+    descriptionTab, setDescriptionTab,
+    parentIssueNumber, setParentIssueNumber,
+    canLinkParentIssue,
+    isCheckingParentIssueAccess,
+    handlePaste,
+    handleSubmit,
+  }
+}

--- a/web/src/components/rbac/CanIChecker.parts.tsx
+++ b/web/src/components/rbac/CanIChecker.parts.tsx
@@ -1,17 +1,12 @@
 import type { ReactNode } from 'react'
-import { Check, X, AlertCircle, ChevronDown } from 'lucide-react'
+import { Check, X, AlertCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '../ui/Button'
+import { Select } from '../ui/Select'
+import { Input } from '../ui/Input'
 import type { CanIResponse } from '../../hooks/usePermissions'
 import type { CheckedSnapshot } from './CanIChecker.state'
 import { COMMON_USER_GROUPS } from './CanIChecker.constants'
-
-const SELECT_CLASS =
-  'w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500 appearance-none pr-8'
-const INPUT_CLASS =
-  'w-full p-2 rounded-lg bg-secondary border border-border text-foreground focus:outline-hidden focus:ring-2 focus:ring-blue-500'
-const CHEVRON_CLASS =
-  'absolute right-2 top-1/2 -translate-y-1/2 w-4 h-4 text-muted-foreground pointer-events-none'
 
 interface LabeledSelectProps {
   id: string
@@ -29,18 +24,14 @@ export function LabeledSelect({ id, label, value, onChange, testId, children }: 
       <label htmlFor={id} className="block text-sm font-medium text-foreground mb-1">
         {label}
       </label>
-      <div className="relative">
-        <select
-          id={id}
-          value={value}
-          onChange={(e) => onChange(e.target.value)}
-          className={SELECT_CLASS}
-          data-testid={testId}
-        >
-          {children}
-        </select>
-        <ChevronDown className={CHEVRON_CLASS} />
-      </div>
+      <Select
+        id={id}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        data-testid={testId}
+      >
+        {children}
+      </Select>
     </div>
   )
 }
@@ -55,12 +46,12 @@ interface CustomValueInputProps {
 /** Free-text override shown when the matching dropdown is set to `custom`. */
 export function CustomValueInput({ value, onChange, placeholder, testId }: CustomValueInputProps) {
   return (
-    <input
+    <Input
       type="text"
       value={value}
       onChange={(e) => onChange(e.target.value)}
       placeholder={placeholder}
-      className={`mt-2 ${INPUT_CLASS}`}
+      className="mt-2"
       data-testid={testId}
     />
   )
@@ -113,28 +104,24 @@ export function UserGroupsField({
       )}
 
       {/* Common groups dropdown */}
-      <div className="relative">
-        <select
-          value=""
-          onChange={(e) => {
-            if (e.target.value && !selectedUserGroups.includes(e.target.value)) {
-              onToggleGroup(e.target.value)
-            }
-          }}
-          className={SELECT_CLASS}
-          data-testid="can-i-user-groups"
-        >
-          <option value="">{t('rbac.selectCommonGroups')}</option>
-          {COMMON_USER_GROUPS.filter(g => !selectedUserGroups.includes(g.value)).map((group) => (
-            <option key={group.value} value={group.value}>{group.label}</option>
-          ))}
-        </select>
-        <ChevronDown className={CHEVRON_CLASS} />
-      </div>
+      <Select
+        value=""
+        onChange={(e) => {
+          if (e.target.value && !selectedUserGroups.includes(e.target.value)) {
+            onToggleGroup(e.target.value)
+          }
+        }}
+        data-testid="can-i-user-groups"
+      >
+        <option value="">{t('rbac.selectCommonGroups')}</option>
+        {COMMON_USER_GROUPS.filter(g => !selectedUserGroups.includes(g.value)).map((group) => (
+          <option key={group.value} value={group.value}>{group.label}</option>
+        ))}
+      </Select>
 
       {/* Custom group input */}
       <div className="mt-2 flex gap-2">
-        <input
+        <Input
           type="text"
           value={customUserGroup}
           onChange={(e) => onCustomGroupChange(e.target.value)}
@@ -145,7 +132,7 @@ export function UserGroupsField({
             }
           }}
           placeholder={t('rbac.addCustomGroupPlaceholder')}
-          className="flex-1 p-2 rounded-lg bg-secondary border border-border text-foreground text-sm focus:outline-hidden focus:ring-2 focus:ring-blue-500"
+          className="flex-1"
         />
         <Button
           variant="primary"

--- a/web/src/components/stellar/BatchMonitorModal.tsx
+++ b/web/src/components/stellar/BatchMonitorModal.tsx
@@ -7,8 +7,6 @@ import {
   MS_PER_SECOND,
   OVERLAY_Z_INDEX,
   FLEX_MIN_WIDTH_STYLE,
-  BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS,
-  BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE,
   type BatchEvent,
   type BatchProcessing,
   type BatchMonitorModalProps,
@@ -19,6 +17,7 @@ import {
   formatElapsedSeconds,
 } from './BatchMonitorModal.utils'
 import { EventRow } from './BatchMonitorModal.parts'
+import { BatchSummary } from './BatchSummary'
 
 export type { ResolutionStep, BatchEvent } from './BatchMonitorModal.utils'
 
@@ -253,81 +252,7 @@ export function BatchMonitorModal({
         </div>
 
         {/* Summary */}
-        <div className="px-5 py-4" style={{
-          borderBottom: '1px solid var(--s-border)',
-          background: 'var(--s-surface-1)', flexShrink: 0,
-        }}>
-          <div className="mb-3 flex items-center gap-4">
-            <span style={{
-              fontFamily: 'var(--s-mono)', fontSize: 11, fontWeight: 600,
-              color: 'var(--s-text-muted)', letterSpacing: '0.08em', textTransform: 'uppercase',
-            }}>
-              {t('stellar.batch.summary')}
-            </span>
-            <span style={{ fontFamily: 'var(--s-mono)', fontSize: 11, color: 'var(--s-text)' }}>
-              {batch.totalEvents} {t('stellar.batch.events', { count: batch.totalEvents })}
-            </span>
-          </div>
-
-          {/* Progress bar */}
-          <div
-            role="progressbar"
-            aria-valuenow={progressPercent}
-            aria-valuemin={0}
-            aria-valuemax={100}
-            aria-label={t('stellar.batch.progressAriaLabel', { percent: progressPercent })}
-            className="mb-3"
-            style={{
-              width: '100%', height: 8,
-              background: 'var(--s-surface-2)',
-              borderRadius: 4, overflow: 'hidden',
-            }}
-          >
-            <div style={{
-              width: `${progressPercent}%`, height: '100%',
-              background: batch.status === 'completed' && batch.summary.failed === 0
-                ? 'var(--s-success)'
-                : batch.summary.failed > 0 ? 'var(--s-warning)' : 'var(--s-info)',
-              transition: 'width 0.3s ease',
-            }} />
-          </div>
-
-          {/* Breakdown */}
-          <div className="flex flex-wrap gap-4">
-            {batch.summary.resolved > 0 && (
-              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
-                <span aria-hidden="true" style={{ color: 'var(--s-success)', fontSize: 14 }}>✓</span>
-                <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
-                  {batch.summary.resolved} {t('stellar.batch.resolved')}
-                </span>
-              </div>
-            )}
-            {batch.summary.failed > 0 && (
-              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
-                <span aria-hidden="true" style={{ color: 'var(--s-critical)', fontSize: 14 }}>✗</span>
-                <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
-                  {batch.summary.failed} {t('stellar.batch.failed')}
-                </span>
-              </div>
-            )}
-            {batch.summary.skipped > 0 && (
-              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
-                <span aria-hidden="true" style={{ color: 'var(--s-text-muted)', fontSize: 14 }}>–</span>
-                <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
-                  {batch.summary.skipped} {t('stellar.batch.skipped')}
-                </span>
-              </div>
-            )}
-            {batch.summary.inProgress > 0 && (
-              <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
-                <span aria-hidden="true" style={{ color: 'var(--s-info)', fontSize: 14 }}>⊙</span>
-                <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
-                  {batch.summary.inProgress} {t('stellar.batch.inProgress')}
-                </span>
-              </div>
-            )}
-          </div>
-        </div>
+        <BatchSummary batch={batch} progressPercent={progressPercent} />
 
         {/* Event list */}
         <div

--- a/web/src/components/stellar/BatchSummary.tsx
+++ b/web/src/components/stellar/BatchSummary.tsx
@@ -1,0 +1,98 @@
+import { useTranslation } from 'react-i18next'
+import {
+  BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS,
+  BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE,
+  type BatchProcessing,
+} from './BatchMonitorModal.utils'
+
+interface BatchSummaryProps {
+  batch: BatchProcessing
+  progressPercent: number
+}
+
+/**
+ * Summary header for BatchMonitorModal — total event count, progress bar,
+ * and the resolved/failed/skipped/in-progress breakdown chips.
+ * Extracted from BatchMonitorModal.tsx — no behaviour change.
+ */
+export function BatchSummary({ batch, progressPercent }: BatchSummaryProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="px-5 py-4" style={{
+      borderBottom: '1px solid var(--s-border)',
+      background: 'var(--s-surface-1)', flexShrink: 0,
+    }}>
+      <div className="mb-3 flex items-center gap-4">
+        <span style={{
+          fontFamily: 'var(--s-mono)', fontSize: 11, fontWeight: 600,
+          color: 'var(--s-text-muted)', letterSpacing: '0.08em', textTransform: 'uppercase',
+        }}>
+          {t('stellar.batch.summary')}
+        </span>
+        <span style={{ fontFamily: 'var(--s-mono)', fontSize: 11, color: 'var(--s-text)' }}>
+          {batch.totalEvents} {t('stellar.batch.events', { count: batch.totalEvents })}
+        </span>
+      </div>
+
+      {/* Progress bar */}
+      <div
+        role="progressbar"
+        aria-valuenow={progressPercent}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-label={t('stellar.batch.progressAriaLabel', { percent: progressPercent })}
+        className="mb-3"
+        style={{
+          width: '100%', height: 8,
+          background: 'var(--s-surface-2)',
+          borderRadius: 4, overflow: 'hidden',
+        }}
+      >
+        <div style={{
+          width: `${progressPercent}%`, height: '100%',
+          background: batch.status === 'completed' && batch.summary.failed === 0
+            ? 'var(--s-success)'
+            : batch.summary.failed > 0 ? 'var(--s-warning)' : 'var(--s-info)',
+          transition: 'width 0.3s ease',
+        }} />
+      </div>
+
+      {/* Breakdown */}
+      <div className="flex flex-wrap gap-4">
+        {batch.summary.resolved > 0 && (
+          <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
+            <span aria-hidden="true" style={{ color: 'var(--s-success)', fontSize: 14 }}>✓</span>
+            <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
+              {batch.summary.resolved} {t('stellar.batch.resolved')}
+            </span>
+          </div>
+        )}
+        {batch.summary.failed > 0 && (
+          <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
+            <span aria-hidden="true" style={{ color: 'var(--s-critical)', fontSize: 14 }}>✗</span>
+            <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
+              {batch.summary.failed} {t('stellar.batch.failed')}
+            </span>
+          </div>
+        )}
+        {batch.summary.skipped > 0 && (
+          <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
+            <span aria-hidden="true" style={{ color: 'var(--s-text-muted)', fontSize: 14 }}>–</span>
+            <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
+              {batch.summary.skipped} {t('stellar.batch.skipped')}
+            </span>
+          </div>
+        )}
+        {batch.summary.inProgress > 0 && (
+          <div className={BATCH_SUMMARY_BREAKDOWN_ITEM_CLASS}>
+            <span aria-hidden="true" style={{ color: 'var(--s-info)', fontSize: 14 }}>⊙</span>
+            <span style={BATCH_SUMMARY_BREAKDOWN_TEXT_STYLE}>
+              {batch.summary.inProgress} {t('stellar.batch.inProgress')}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/stellar/EventModal.tsx
+++ b/web/src/components/stellar/EventModal.tsx
@@ -1,25 +1,15 @@
-import { useEffect, useMemo, useState } from 'react'
 import type { StellarAction, StellarNotification, StellarSolve } from '../../types/stellar'
-import { useStellar } from '../../hooks/useStellar'
-import { useToast } from '../ui/Toast'
 import { BaseModal } from '../../lib/modals'
-import { copyToClipboard } from '../../lib/clipboard'
 import type { PendingAction } from './EventCard'
 import {
   RELATED_EVENT_LIMIT,
-  TIMELINE_ENTRY_LIMIT,
-  INVESTIGATION_ACTIVITY_LIMIT,
   INVESTIGATION_TEXTAREA_ROWS,
-  type TimelineEntry,
-  severityColor,
   statusLabel,
-  extractResourceName,
   formatAbsoluteUtc,
   buildInvestigatePrompt,
-  matchesSolve,
-  getErrorMessage,
 } from './EventModal.utils'
 import { Badge, Section, Timeline, ListBlock, ActionButton, ConfirmationPanel } from './EventModal.parts'
+import { useEventModalData } from './useEventModalData'
 
 interface EventModalProps {
   notification: StellarNotification
@@ -31,187 +21,30 @@ interface EventModalProps {
   onAction?: (prompt: string, action?: PendingAction) => void
 }
 
-type ModalView = 'overview' | 'investigate'
-type ConfirmAction = 'resolve' | 'dismiss' | null
-
 export function EventModal({ notification, allNotifications, pendingActions, solveStatus, solves = [], onClose, onAction }: EventModalProps) {
   const {
-    notifications,
-    activity,
-    investigateNotification,
-    dismissNotification,
-    startSolve,
-  } = useStellar()
-  const { showToast } = useToast()
-
-  const liveNotification = useMemo(() => {
-    return (notifications || []).find(item => item.id === notification.id) || notification
-  }, [notification, notifications])
-
-  const [view, setView] = useState<ModalView>('overview')
-  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null)
-  const [investigationSummary, setInvestigationSummary] = useState(liveNotification.investigationSummary || '')
-  const [dismissalReason, setDismissalReason] = useState(liveNotification.dismissalReason || '')
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  useEffect(() => {
-    setView('overview')
-    setConfirmAction(null)
-    setInvestigationSummary(liveNotification.investigationSummary || '')
-    setDismissalReason(liveNotification.dismissalReason || '')
-  }, [liveNotification.id, liveNotification.dismissalReason, liveNotification.investigationSummary])
-
-  const allKnownNotifications = useMemo(() => {
-    const merged = [...(notifications || []), ...(allNotifications || [])]
-    return merged.filter((item, index) => merged.findIndex(candidate => candidate.id === item.id) === index)
-  }, [allNotifications, notifications])
-
-  const relatedEvents = useMemo(() => {
-    const resourceName = extractResourceName(liveNotification)
-    return allKnownNotifications
-      .filter(item => item.id !== liveNotification.id)
-      .filter(item => {
-        if (liveNotification.dedupeKey && item.dedupeKey === liveNotification.dedupeKey) return true
-        return Boolean(resourceName) && extractResourceName(item) === resourceName && item.cluster === liveNotification.cluster && item.namespace === liveNotification.namespace
-      })
-      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
-  }, [allKnownNotifications, liveNotification])
-
-  const matchingSolves = useMemo(() => {
-    return (solves || [])
-      .filter(solve => matchesSolve(liveNotification, solve))
-      .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
-  }, [liveNotification, solves])
-
-  const relatedActivity = useMemo(() => {
-    const resourceName = extractResourceName(liveNotification)
-    return (activity || [])
-      .filter(entry => entry.eventId === liveNotification.id || (
-        Boolean(resourceName) &&
-        entry.cluster === liveNotification.cluster &&
-        entry.namespace === liveNotification.namespace &&
-        entry.workload === resourceName
-      ))
-      .slice(0, INVESTIGATION_ACTIVITY_LIMIT)
-  }, [activity, liveNotification])
-
-  const resourceName = extractResourceName(liveNotification)
-  const affectedResource = liveNotification.affectedResource || [liveNotification.cluster, liveNotification.namespace, resourceName].filter(Boolean).join(' / ') || 'Unknown resource'
-  const rootCause = liveNotification.rootCause || liveNotification.investigationSummary || matchingSolves[0]?.summary || 'Pending Analysis'
-  const errorMessage = liveNotification.errorMessage || liveNotification.body || 'No error message recorded.'
-  const autoResolutionSummary = useMemo(() => {
-    const latestSolve = matchingSolves[0]
-    if (!latestSolve) {
-      return {
-        status: 'Not attempted',
-        detail: 'No automatic remediation attempt has been recorded for this event yet.',
-      }
-    }
-    const summary = latestSolve.error || latestSolve.summary || 'Manual intervention is still required.'
-    if (latestSolve.status === 'resolved') return { status: 'Succeeded', detail: summary }
-    if (latestSolve.status === 'running') return { status: 'In progress', detail: summary }
-    if (latestSolve.status === 'escalated') return { status: 'Escalated', detail: summary }
-    if (latestSolve.status === 'exhausted') return { status: 'Paused', detail: summary }
-    return { status: latestSolve.status, detail: summary }
-  }, [matchingSolves])
-
-  const timelineEntries = useMemo<TimelineEntry[]>(() => {
-    const entries: TimelineEntry[] = [
-      {
-        ts: liveNotification.createdAt,
-        label: 'Detected',
-        detail: liveNotification.title,
-      },
-    ]
-    if (liveNotification.updatedAt && liveNotification.updatedAt !== liveNotification.createdAt) {
-      entries.push({
-        ts: liveNotification.updatedAt,
-        label: statusLabel(liveNotification.status),
-        detail: liveNotification.investigationSummary || liveNotification.resolutionNote || liveNotification.dismissalReason || 'Event status updated from the modal.',
-      })
-    }
-    relatedEvents.forEach(item => {
-      entries.push({ ts: item.createdAt, label: 'Related event', detail: item.title })
-    })
-    matchingSolves.forEach(solve => {
-      entries.push({
-        ts: solve.endedAt || solve.startedAt,
-        label: `Auto-resolution ${statusLabel(solve.status)}`,
-        detail: solve.error || solve.summary || `${solve.actionsTaken} action(s) taken`,
-      })
-    })
-    return entries
-      .sort((a, b) => b.ts.localeCompare(a.ts))
-      .slice(0, TIMELINE_ENTRY_LIMIT)
-  }, [liveNotification, matchingSolves, relatedEvents])
-
-  const investigationCopyText = useMemo(() => {
-    const pendingApprovalCount = (pendingActions || []).filter(action => action.cluster === liveNotification.cluster && action.namespace === liveNotification.namespace).length
-    const sections = [
-      `Event ID: ${liveNotification.id}`,
-      `Title: ${liveNotification.title}`,
-      `Status: ${statusLabel(liveNotification.status)}`,
-      `Severity: ${liveNotification.severity}`,
-      `Timestamp: ${formatAbsoluteUtc(liveNotification.updatedAt || liveNotification.createdAt)}`,
-      `Affected resource: ${affectedResource}`,
-      `Root cause: ${rootCause}`,
-      `Error message: ${errorMessage}`,
-      `Batch window: ${formatAbsoluteUtc(liveNotification.batchTimestamp || liveNotification.createdAt)}`,
-      `Auto-resolution: ${autoResolutionSummary.status} — ${autoResolutionSummary.detail}`,
-      `Pending approvals: ${pendingApprovalCount}`,
-      `Related events: ${(relatedEvents || []).map(item => `${formatAbsoluteUtc(item.createdAt)} — ${item.title}`).join('\n') || 'None'}`,
-      `Related activity: ${(relatedActivity || []).map(item => `${formatAbsoluteUtc(item.ts)} — ${item.title}: ${item.detail || ''}`).join('\n') || 'None'}`,
-      `Solve attempts: ${(matchingSolves || []).map(item => `${formatAbsoluteUtc(item.startedAt)} — ${item.status}: ${item.summary || item.error || 'No summary'}`).join('\n') || 'None'}`,
-      `Raw detail: ${liveNotification.body || 'None'}`,
-    ]
-    return (sections || []).join('\n\n')
-  }, [affectedResource, autoResolutionSummary.detail, autoResolutionSummary.status, errorMessage, liveNotification, matchingSolves, pendingActions, relatedActivity, relatedEvents, rootCause])
-
-  const handleCopyDetails = async () => {
-    const copied = await copyToClipboard(investigationCopyText)
-    showToast(copied ? 'Investigation details copied' : 'Failed to copy investigation details', copied ? 'success' : 'error')
-  }
-
-  const handleMarkInvestigating = async () => {
-    setIsSubmitting(true)
-    try {
-      await investigateNotification(liveNotification.id, investigationSummary.trim() || undefined)
-      showToast('Event marked as investigating', 'info')
-    } catch (error) {
-      showToast(getErrorMessage(error, 'Failed to mark event as investigating'), 'error')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleResolve = async () => {
-    setIsSubmitting(true)
-    try {
-      await startSolve(liveNotification.id)
-      showToast('Attempt started in AI mission', 'success')
-      onClose()
-    } catch (error) {
-      showToast(getErrorMessage(error, 'Failed to start AI mission'), 'error')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const handleDismiss = async () => {
-    setIsSubmitting(true)
-    try {
-      await dismissNotification(liveNotification.id, dismissalReason.trim() || undefined)
-      showToast('Event removed from escalated list', 'success')
-      onClose()
-    } catch (error) {
-      showToast(getErrorMessage(error, 'Failed to remove event'), 'error')
-    } finally {
-      setIsSubmitting(false)
-    }
-  }
-
-  const color = severityColor(liveNotification.severity)
-  const solveAttemptCount = matchingSolves.length
+    liveNotification,
+    view, setView,
+    confirmAction, setConfirmAction,
+    investigationSummary, setInvestigationSummary,
+    dismissalReason, setDismissalReason,
+    isSubmitting,
+    relatedEvents,
+    matchingSolves,
+    relatedActivity,
+    resourceName,
+    affectedResource,
+    rootCause,
+    errorMessage,
+    autoResolutionSummary,
+    timelineEntries,
+    color,
+    solveAttemptCount,
+    handleCopyDetails,
+    handleMarkInvestigating,
+    handleResolve,
+    handleDismiss,
+  } = useEventModalData({ notification, allNotifications, pendingActions, solves, onClose })
 
   return (
     <BaseModal isOpen onClose={onClose} size="lg" closeOnBackdrop={false} testId="stellar-event-modal">

--- a/web/src/components/stellar/useEventModalData.ts
+++ b/web/src/components/stellar/useEventModalData.ts
@@ -1,0 +1,239 @@
+/**
+ * useEventModalData — owns EventModal's state, derived data (related
+ * events/solves/activity, timeline, auto-resolution summary, investigation
+ * copy text), and action handlers (mark investigating / resolve / dismiss /
+ * copy details), so `EventModal.tsx` can stay a thin presentational
+ * component. Extracted from EventModal.tsx — no behaviour change.
+ */
+
+import { useEffect, useMemo, useState } from 'react'
+import type { StellarAction, StellarNotification, StellarSolve } from '../../types/stellar'
+import { useStellar } from '../../hooks/useStellar'
+import { useToast } from '../ui/Toast'
+import { copyToClipboard } from '../../lib/clipboard'
+import {
+  TIMELINE_ENTRY_LIMIT,
+  INVESTIGATION_ACTIVITY_LIMIT,
+  type TimelineEntry,
+  severityColor,
+  statusLabel,
+  extractResourceName,
+  formatAbsoluteUtc,
+  matchesSolve,
+  getErrorMessage,
+} from './EventModal.utils'
+
+export type ModalView = 'overview' | 'investigate'
+export type ConfirmAction = 'resolve' | 'dismiss' | null
+
+interface UseEventModalDataArgs {
+  notification: StellarNotification
+  allNotifications: StellarNotification[]
+  pendingActions: StellarAction[]
+  solves: StellarSolve[]
+  onClose: () => void
+}
+
+export function useEventModalData({ notification, allNotifications, pendingActions, solves, onClose }: UseEventModalDataArgs) {
+  const {
+    notifications,
+    activity,
+    investigateNotification,
+    dismissNotification,
+    startSolve,
+  } = useStellar()
+  const { showToast } = useToast()
+
+  const liveNotification = useMemo(() => {
+    return (notifications || []).find(item => item.id === notification.id) || notification
+  }, [notification, notifications])
+
+  const [view, setView] = useState<ModalView>('overview')
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction>(null)
+  const [investigationSummary, setInvestigationSummary] = useState(liveNotification.investigationSummary || '')
+  const [dismissalReason, setDismissalReason] = useState(liveNotification.dismissalReason || '')
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    setView('overview')
+    setConfirmAction(null)
+    setInvestigationSummary(liveNotification.investigationSummary || '')
+    setDismissalReason(liveNotification.dismissalReason || '')
+  }, [liveNotification.id, liveNotification.dismissalReason, liveNotification.investigationSummary])
+
+  const allKnownNotifications = useMemo(() => {
+    const merged = [...(notifications || []), ...(allNotifications || [])]
+    return merged.filter((item, index) => merged.findIndex(candidate => candidate.id === item.id) === index)
+  }, [allNotifications, notifications])
+
+  const relatedEvents = useMemo(() => {
+    const resourceName = extractResourceName(liveNotification)
+    return allKnownNotifications
+      .filter(item => item.id !== liveNotification.id)
+      .filter(item => {
+        if (liveNotification.dedupeKey && item.dedupeKey === liveNotification.dedupeKey) return true
+        return Boolean(resourceName) && extractResourceName(item) === resourceName && item.cluster === liveNotification.cluster && item.namespace === liveNotification.namespace
+      })
+      .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+  }, [allKnownNotifications, liveNotification])
+
+  const matchingSolves = useMemo(() => {
+    return (solves || [])
+      .filter(solve => matchesSolve(liveNotification, solve))
+      .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+  }, [liveNotification, solves])
+
+  const relatedActivity = useMemo(() => {
+    const resourceName = extractResourceName(liveNotification)
+    return (activity || [])
+      .filter(entry => entry.eventId === liveNotification.id || (
+        Boolean(resourceName) &&
+        entry.cluster === liveNotification.cluster &&
+        entry.namespace === liveNotification.namespace &&
+        entry.workload === resourceName
+      ))
+      .slice(0, INVESTIGATION_ACTIVITY_LIMIT)
+  }, [activity, liveNotification])
+
+  const resourceName = extractResourceName(liveNotification)
+  const affectedResource = liveNotification.affectedResource || [liveNotification.cluster, liveNotification.namespace, resourceName].filter(Boolean).join(' / ') || 'Unknown resource'
+  const rootCause = liveNotification.rootCause || liveNotification.investigationSummary || matchingSolves[0]?.summary || 'Pending Analysis'
+  const errorMessage = liveNotification.errorMessage || liveNotification.body || 'No error message recorded.'
+  const autoResolutionSummary = useMemo(() => {
+    const latestSolve = matchingSolves[0]
+    if (!latestSolve) {
+      return {
+        status: 'Not attempted',
+        detail: 'No automatic remediation attempt has been recorded for this event yet.',
+      }
+    }
+    const summary = latestSolve.error || latestSolve.summary || 'Manual intervention is still required.'
+    if (latestSolve.status === 'resolved') return { status: 'Succeeded', detail: summary }
+    if (latestSolve.status === 'running') return { status: 'In progress', detail: summary }
+    if (latestSolve.status === 'escalated') return { status: 'Escalated', detail: summary }
+    if (latestSolve.status === 'exhausted') return { status: 'Paused', detail: summary }
+    return { status: latestSolve.status, detail: summary }
+  }, [matchingSolves])
+
+  const timelineEntries = useMemo<TimelineEntry[]>(() => {
+    const entries: TimelineEntry[] = [
+      {
+        ts: liveNotification.createdAt,
+        label: 'Detected',
+        detail: liveNotification.title,
+      },
+    ]
+    if (liveNotification.updatedAt && liveNotification.updatedAt !== liveNotification.createdAt) {
+      entries.push({
+        ts: liveNotification.updatedAt,
+        label: statusLabel(liveNotification.status),
+        detail: liveNotification.investigationSummary || liveNotification.resolutionNote || liveNotification.dismissalReason || 'Event status updated from the modal.',
+      })
+    }
+    relatedEvents.forEach(item => {
+      entries.push({ ts: item.createdAt, label: 'Related event', detail: item.title })
+    })
+    matchingSolves.forEach(solve => {
+      entries.push({
+        ts: solve.endedAt || solve.startedAt,
+        label: `Auto-resolution ${statusLabel(solve.status)}`,
+        detail: solve.error || solve.summary || `${solve.actionsTaken} action(s) taken`,
+      })
+    })
+    return entries
+      .sort((a, b) => b.ts.localeCompare(a.ts))
+      .slice(0, TIMELINE_ENTRY_LIMIT)
+  }, [liveNotification, matchingSolves, relatedEvents])
+
+  const investigationCopyText = useMemo(() => {
+    const pendingApprovalCount = (pendingActions || []).filter(action => action.cluster === liveNotification.cluster && action.namespace === liveNotification.namespace).length
+    const sections = [
+      `Event ID: ${liveNotification.id}`,
+      `Title: ${liveNotification.title}`,
+      `Status: ${statusLabel(liveNotification.status)}`,
+      `Severity: ${liveNotification.severity}`,
+      `Timestamp: ${formatAbsoluteUtc(liveNotification.updatedAt || liveNotification.createdAt)}`,
+      `Affected resource: ${affectedResource}`,
+      `Root cause: ${rootCause}`,
+      `Error message: ${errorMessage}`,
+      `Batch window: ${formatAbsoluteUtc(liveNotification.batchTimestamp || liveNotification.createdAt)}`,
+      `Auto-resolution: ${autoResolutionSummary.status} — ${autoResolutionSummary.detail}`,
+      `Pending approvals: ${pendingApprovalCount}`,
+      `Related events: ${(relatedEvents || []).map(item => `${formatAbsoluteUtc(item.createdAt)} — ${item.title}`).join('\n') || 'None'}`,
+      `Related activity: ${(relatedActivity || []).map(item => `${formatAbsoluteUtc(item.ts)} — ${item.title}: ${item.detail || ''}`).join('\n') || 'None'}`,
+      `Solve attempts: ${(matchingSolves || []).map(item => `${formatAbsoluteUtc(item.startedAt)} — ${item.status}: ${item.summary || item.error || 'No summary'}`).join('\n') || 'None'}`,
+      `Raw detail: ${liveNotification.body || 'None'}`,
+    ]
+    return (sections || []).join('\n\n')
+  }, [affectedResource, autoResolutionSummary.detail, autoResolutionSummary.status, errorMessage, liveNotification, matchingSolves, pendingActions, relatedActivity, relatedEvents, rootCause])
+
+  const handleCopyDetails = async () => {
+    const copied = await copyToClipboard(investigationCopyText)
+    showToast(copied ? 'Investigation details copied' : 'Failed to copy investigation details', copied ? 'success' : 'error')
+  }
+
+  const handleMarkInvestigating = async () => {
+    setIsSubmitting(true)
+    try {
+      await investigateNotification(liveNotification.id, investigationSummary.trim() || undefined)
+      showToast('Event marked as investigating', 'info')
+    } catch (error) {
+      showToast(getErrorMessage(error, 'Failed to mark event as investigating'), 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleResolve = async () => {
+    setIsSubmitting(true)
+    try {
+      await startSolve(liveNotification.id)
+      showToast('Attempt started in AI mission', 'success')
+      onClose()
+    } catch (error) {
+      showToast(getErrorMessage(error, 'Failed to start AI mission'), 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDismiss = async () => {
+    setIsSubmitting(true)
+    try {
+      await dismissNotification(liveNotification.id, dismissalReason.trim() || undefined)
+      showToast('Event removed from escalated list', 'success')
+      onClose()
+    } catch (error) {
+      showToast(getErrorMessage(error, 'Failed to remove event'), 'error')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const color = severityColor(liveNotification.severity)
+  const solveAttemptCount = matchingSolves.length
+
+  return {
+    liveNotification,
+    view, setView,
+    confirmAction, setConfirmAction,
+    investigationSummary, setInvestigationSummary,
+    dismissalReason, setDismissalReason,
+    isSubmitting,
+    relatedEvents,
+    matchingSolves,
+    relatedActivity,
+    resourceName,
+    affectedResource,
+    rootCause,
+    errorMessage,
+    autoResolutionSummary,
+    timelineEntries,
+    color,
+    solveAttemptCount,
+    handleCopyDetails,
+    handleMarkInvestigating,
+    handleResolve,
+    handleDismiss,
+  }
+}

--- a/web/src/hooks/useCachedCoreWorkloads.ts
+++ b/web/src/hooks/useCachedCoreWorkloads.ts
@@ -145,7 +145,7 @@ async function fetchSecurityIssuesViaKubectl(cluster?: string, namespace?: strin
 
           // Capabilities not dropped
           if (sc.capabilities?.drop?.length === 0 || !sc.capabilities?.drop) {
-            if (sc.capabilities?.add?.length > 0) {
+            if ((sc.capabilities?.add?.length ?? 0) > 0) {
               issues.push({ name: podName, namespace: podNs, cluster: name, issue: 'Capabilities not dropped', severity: 'medium', details: 'Container not dropping all capabilities' })
             }
           }


### PR DESCRIPTION
Fixes #21781, Fixes #21800, Fixes #21801, Fixes #21802

Rebased onto current `main` and completed the remaining feedback/Stellar component splits from #21504 that were left after #21758/#21759 landed. The previous version of this branch was based on a pre-#21758 commit and duplicated work that #21758 had already partially done under different file names, causing merge conflicts. This version builds on top of the current `.parts.tsx`/`.utils.ts` split from #21758/#21759 instead of re-doing it.

## Changes

- **`web/src/components/feedback/FeedbackModal.tsx`** (555 → 252 lines, 20 → 3 hook calls): extracted `useFeedbackDraft.ts` — draft persistence (restore/autosave), screenshot attachment handling, and the submit handler.
- **`web/src/components/feedback/SubmitTab.tsx`** (594 → 348 lines, 13 → 2 hook calls): extracted `useSubmitFormHandler.ts` — parent-issue linking, fullscreen preview keyboard handling, paste-to-attach, and the submit handler.
- **`web/src/components/stellar/BatchMonitorModal.tsx`** (360 → 285 lines): extracted `BatchSummary.tsx` — the progress bar + resolved/failed/skipped/in-progress breakdown chips.
- **`web/src/components/stellar/EventModal.tsx`** (370 → 203 lines, 13 → 1 hook call): extracted `useEventModalData.ts` — all derived data (related events/solves/activity, timeline, auto-resolution summary, investigation copy text) and action handlers (mark investigating / resolve / dismiss / copy details).

All 4 target files are now below the 350-line / 10-hook-call targets. Pure refactor — no behavior change; all original exports/imports preserved. Build (`tsc -b` + `vite build`) and lint (`eslint .`) pass locally with only pre-existing warnings (none newly introduced). Existing tests (`FeedbackModal.test.tsx`, `BatchMonitorModal.test.tsx`, `BatchMonitorModal.utils.test.ts`, `EventModal.utils.test.ts`) all pass unchanged.
