### PR TITLE
[scanner] fix: address auto-qa quality findings batch

### DIFF
--- a/web/src/components/cards/drasi/DrasiNodeCard.tsx
+++ b/web/src/components/cards/drasi/DrasiNodeCard.tsx
@@ -113,7 +113,7 @@ export function NodeControls({
 export function StatusDot({ status, isStopped }: { status: 'ready' | 'error' | 'pending'; isStopped: boolean }) {
   const color = isStopped
     ? 'bg-slate-500'
-    : status === 'ready' ? 'bg-green-500' : status === 'error' ? 'bg-red-500' : 'bg-yellow-500'
+    : status === 'ready' ? 'bg-status-success' : status === 'error' ? 'bg-status-error' : 'bg-status-warning'
   return (
     <motion.div
       className={`w-2 h-2 rounded-full ${color}`}

--- a/web/src/components/cards/drasi/__tests__/DrasiNodeCard.test.tsx
+++ b/web/src/components/cards/drasi/__tests__/DrasiNodeCard.test.tsx
@@ -22,29 +22,29 @@ vi.mock('framer-motion', () => ({
 describe('StatusDot', () => {
   it('renders a green dot for ready status when not stopped', () => {
     const { container } = render(<StatusDot status="ready" isStopped={false} />)
-    expect(container.querySelector('.bg-green-500')).not.toBeNull()
+    expect(container.querySelector('.bg-status-success')).not.toBeNull()
   })
 
   it('renders a red dot for error status when not stopped', () => {
     const { container } = render(<StatusDot status="error" isStopped={false} />)
-    expect(container.querySelector('.bg-red-500')).not.toBeNull()
+    expect(container.querySelector('.bg-status-error')).not.toBeNull()
   })
 
   it('renders a yellow dot for pending status when not stopped', () => {
     const { container } = render(<StatusDot status="pending" isStopped={false} />)
-    expect(container.querySelector('.bg-yellow-500')).not.toBeNull()
+    expect(container.querySelector('.bg-status-warning')).not.toBeNull()
   })
 
   it('renders a slate dot when isStopped overrides any status', () => {
     const { container } = render(<StatusDot status="ready" isStopped={true} />)
     expect(container.querySelector('.bg-slate-500')).not.toBeNull()
-    expect(container.querySelector('.bg-green-500')).toBeNull()
+    expect(container.querySelector('.bg-status-success')).toBeNull()
   })
 
   it('renders a slate dot for error status when stopped', () => {
     const { container } = render(<StatusDot status="error" isStopped={true} />)
     expect(container.querySelector('.bg-slate-500')).not.toBeNull()
-    expect(container.querySelector('.bg-red-500')).toBeNull()
+    expect(container.querySelector('.bg-status-error')).toBeNull()
   })
 })
 

--- a/web/src/components/clusters/add-cluster/ConnectTab.constants.ts
+++ b/web/src/components/clusters/add-cluster/ConnectTab.constants.ts
@@ -1,0 +1,39 @@
+import type { CloudProvider } from './types'
+
+// Cloud provider IAM auth commands — two steps: authenticate, then register cluster
+export const CLOUD_IAM_COMMANDS: Record<CloudProvider, { auth: string; register: string; cliName: string }> = {
+  eks: {
+    cliName: 'aws',
+    auth: 'aws sso login',
+    register: 'aws eks update-kubeconfig --name <CLUSTER> --region <REGION>',
+  },
+  gke: {
+    cliName: 'gcloud',
+    auth: 'gcloud auth login',
+    register: 'gcloud container clusters get-credentials <CLUSTER> --zone <ZONE> --project <PROJECT>',
+  },
+  aks: {
+    cliName: 'az',
+    auth: 'az login',
+    register: 'az aks get-credentials --resource-group <RG> --name <CLUSTER>',
+  },
+  openshift: {
+    cliName: 'oc',
+    auth: 'oc login <API_SERVER_URL>',
+    register: '', // oc login already sets up kubeconfig
+  },
+}
+
+/** Maps a CloudProvider id to its i18n translation-key suffix, e.g. 'eks' -> 'AWS'. */
+export function getCloudIAMProviderKey(provider: CloudProvider): 'AWS' | 'GKE' | 'AKS' | 'OpenShift' {
+  switch (provider) {
+    case 'eks':
+      return 'AWS'
+    case 'gke':
+      return 'GKE'
+    case 'aks':
+      return 'AKS'
+    case 'openshift':
+      return 'OpenShift'
+  }
+}

--- a/web/src/components/clusters/add-cluster/ConnectTab.tsx
+++ b/web/src/components/clusters/add-cluster/ConnectTab.tsx
@@ -7,30 +7,8 @@ import type { ConnectStep, CloudProvider } from './types'
 import { Button } from '../../ui/Button'
 import { Input } from '../../ui/Input'
 import { TextArea } from '../../ui/TextArea'
+import { CLOUD_IAM_COMMANDS, getCloudIAMProviderKey } from './ConnectTab.constants'
 
-// Cloud provider IAM auth commands — two steps: authenticate, then register cluster
-const CLOUD_IAM_COMMANDS: Record<CloudProvider, { auth: string; register: string; cliName: string }> = {
-  eks: {
-    cliName: 'aws',
-    auth: 'aws sso login',
-    register: 'aws eks update-kubeconfig --name <CLUSTER> --region <REGION>',
-  },
-  gke: {
-    cliName: 'gcloud',
-    auth: 'gcloud auth login',
-    register: 'gcloud container clusters get-credentials <CLUSTER> --zone <ZONE> --project <PROJECT>',
-  },
-  aks: {
-    cliName: 'az',
-    auth: 'az login',
-    register: 'az aks get-credentials --resource-group <RG> --name <CLUSTER>',
-  },
-  openshift: {
-    cliName: 'oc',
-    auth: 'oc login <API_SERVER_URL>',
-    register: '', // oc login already sets up kubeconfig
-  },
-}
 
 export function ConnectTab() {
   const { t } = useTranslation()
@@ -224,7 +202,7 @@ export function ConnectTab() {
                         key={p}
                         onClick={() => setSelectedCloudProvider(p)}
                         aria-label={t('actions.selectCloudProviderAria', {
-                          provider: t(`cluster.cloudIAMProvider${p.toUpperCase() === 'EKS' ? 'AWS' : p.toUpperCase() === 'GKE' ? 'GKE' : p.toUpperCase() === 'AKS' ? 'AKS' : 'OpenShift'}`),
+                          provider: t(`cluster.cloudIAMProvider${getCloudIAMProviderKey(p)}`),
                         })}
                         variant="ghost"
                         className={`flex flex-col items-center gap-1.5 p-3 rounded-lg border text-xs transition-colors ${
@@ -234,7 +212,7 @@ export function ConnectTab() {
                         }`}
                       >
                         <CloudProviderIcon provider={p} size={20} />
-                        {t(`cluster.cloudIAMProvider${p.toUpperCase() === 'EKS' ? 'AWS' : p.toUpperCase() === 'GKE' ? 'GKE' : p.toUpperCase() === 'AKS' ? 'AKS' : 'OpenShift'}`)}
+                        {t(`cluster.cloudIAMProvider${getCloudIAMProviderKey(p)}`)}
                       </Button>
                     ))}
                   </div>

--- a/web/src/components/clusters/add-cluster/__tests__/ConnectTab.constants.test.ts
+++ b/web/src/components/clusters/add-cluster/__tests__/ConnectTab.constants.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { CLOUD_IAM_COMMANDS, getCloudIAMProviderKey } from '../ConnectTab.constants'
+import type { CloudProvider } from '../types'
+
+describe('ConnectTab.constants', () => {
+  describe('CLOUD_IAM_COMMANDS', () => {
+    it.each([
+      ['eks', 'aws'],
+      ['gke', 'gcloud'],
+      ['aks', 'az'],
+      ['openshift', 'oc'],
+    ] as [CloudProvider, string][])('defines cliName %s -> %s', (provider, cliName) => {
+      expect(CLOUD_IAM_COMMANDS[provider].cliName).toBe(cliName)
+    })
+
+    it('provides a non-empty auth command for every provider', () => {
+      for (const provider of Object.keys(CLOUD_IAM_COMMANDS) as CloudProvider[]) {
+        expect(CLOUD_IAM_COMMANDS[provider].auth.length).toBeGreaterThan(0)
+      }
+    })
+
+    it('leaves openshift register command empty since oc login sets up kubeconfig', () => {
+      expect(CLOUD_IAM_COMMANDS.openshift.register).toBe('')
+    })
+
+    it('provides a non-empty register command for eks, gke, aks', () => {
+      expect(CLOUD_IAM_COMMANDS.eks.register.length).toBeGreaterThan(0)
+      expect(CLOUD_IAM_COMMANDS.gke.register.length).toBeGreaterThan(0)
+      expect(CLOUD_IAM_COMMANDS.aks.register.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('getCloudIAMProviderKey', () => {
+    it.each([
+      ['eks', 'AWS'],
+      ['gke', 'GKE'],
+      ['aks', 'AKS'],
+      ['openshift', 'OpenShift'],
+    ] as [CloudProvider, string][])('maps %s -> %s', (provider, expected) => {
+      expect(getCloudIAMProviderKey(provider)).toBe(expected)
+    })
+  })
+})

--- a/web/src/components/mission-control/ClusterReadinessCard.test.tsx
+++ b/web/src/components/mission-control/ClusterReadinessCard.test.tsx
@@ -6,7 +6,7 @@ import type { ClusterInfo } from '../../hooks/mcp/types'
 
 vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
-  useTranslation: () => ({ t: (key: string) => key }),
+  useTranslation: () => ({ t: (key: string, defaultValue?: string) => defaultValue ?? key }),
 }))
 
 const mockCluster: ClusterInfo = {

--- a/web/src/components/mission-control/ClusterReadinessCard.tsx
+++ b/web/src/components/mission-control/ClusterReadinessCard.tsx
@@ -106,7 +106,7 @@ export function ClusterReadinessCard({
                 'w-2 h-2 rounded-full shrink-0',
                 cluster.healthy ? 'bg-status-success' : 'bg-status-error'
               )}
-              title={cluster.healthy ? 'Healthy' : 'Unhealthy'}
+              title={cluster.healthy ? t('labels.healthy', 'Healthy') : t('labels.unhealthy', 'Unhealthy')}
             />
           </div>
           <div className="flex items-center gap-3 text-xs text-muted-foreground">

--- a/web/src/components/mission-control/ClusterReadinessCard.tsx
+++ b/web/src/components/mission-control/ClusterReadinessCard.tsx
@@ -104,7 +104,7 @@ export function ClusterReadinessCard({
             <span
               className={cn(
                 'w-2 h-2 rounded-full shrink-0',
-                cluster.healthy ? 'bg-green-500' : 'bg-red-500'
+                cluster.healthy ? 'bg-status-success' : 'bg-status-error'
               )}
               title={cluster.healthy ? 'Healthy' : 'Unhealthy'}
             />

--- a/web/src/hooks/__tests__/usePersistence.test.ts
+++ b/web/src/hooks/__tests__/usePersistence.test.ts
@@ -22,6 +22,11 @@ vi.mock('../../lib/auth', () => ({
   useAuth: () => ({ token: mockToken }),
 }))
 
+const showToastMock = vi.fn()
+vi.mock('../../components/ui/Toast', () => ({
+  useToast: () => ({ showToast: showToastMock }),
+}))
+
 // Make authFetch delegate to global.fetch so per-test fetch mocks are intercepted
 vi.mock('../../lib/api', () => ({
   authFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
@@ -370,6 +375,10 @@ describe('usePersistence', () => {
 
     expect(testResult!.success).toBe(false)
     expect(testResult!.cluster).toBe('failing-cluster')
+    expect(showToastMock).toHaveBeenCalledWith(
+      'Failed to test connection to failing-cluster',
+      'error'
+    )
   })
 
   // -------------------------------------------------------------------------

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useLocalAgent } from './useLocalAgent'
 import { useAuth } from '../lib/auth'
 import { authFetch } from '../lib/api'
@@ -61,6 +62,7 @@ export function usePersistence() {
   const { status: agentStatus } = useLocalAgent()
   const { token } = useAuth()
   const { showToast } = useToast()
+  const { t } = useTranslation()
   const [config, setConfig] = useState<PersistenceConfig>(DEFAULT_CONFIG)
   const [status, setStatus] = useState<PersistenceStatus>(DEFAULT_STATUS)
   const [loading, setLoading] = useState(true)
@@ -183,7 +185,10 @@ export function usePersistence() {
       }
     } catch (err: unknown) {
       console.error('[usePersistence] Failed to test connection:', err)
-      showToast(`Failed to test connection to ${cluster}`, 'error')
+      showToast(
+        t('settings.persistence.connectionFailedFor', 'Failed to test connection to {{cluster}}', { cluster }),
+        'error'
+      )
     }
 
     return { cluster, health: 'unknown', success: false }

--- a/web/src/hooks/usePersistence.ts
+++ b/web/src/hooks/usePersistence.ts
@@ -3,6 +3,7 @@ import { useLocalAgent } from './useLocalAgent'
 import { useAuth } from '../lib/auth'
 import { authFetch } from '../lib/api'
 import { FETCH_DEFAULT_TIMEOUT_MS, POLL_INTERVAL_MS } from '../lib/constants/network'
+import { useToast } from '../components/ui/Toast'
 
 // =============================================================================
 // Types
@@ -59,6 +60,7 @@ const DEFAULT_STATUS: PersistenceStatus = {
 export function usePersistence() {
   const { status: agentStatus } = useLocalAgent()
   const { token } = useAuth()
+  const { showToast } = useToast()
   const [config, setConfig] = useState<PersistenceConfig>(DEFAULT_CONFIG)
   const [status, setStatus] = useState<PersistenceStatus>(DEFAULT_STATUS)
   const [loading, setLoading] = useState(true)
@@ -181,6 +183,7 @@ export function usePersistence() {
       }
     } catch (err: unknown) {
       console.error('[usePersistence] Failed to test connection:', err)
+      showToast(`Failed to test connection to ${cluster}`, 'error')
     }
 
     return { cluster, health: 'unknown', success: false }

--- a/web/src/locales/en/common.json
+++ b/web/src/locales/en/common.json
@@ -890,6 +890,7 @@
       "testing": "Testing...",
       "connectionSuccess": "Connection successful",
       "connectionFailed": "Connection failed",
+      "connectionFailedFor": "Failed to test connection to {{cluster}}",
       "syncMode": "Sync Mode",
       "primaryOnly": "Primary Only",
       "activePassive": "Active-Passive",


### PR DESCRIPTION
Fixes #21762, Refs #21768, Fixes #21843, Fixes #21845

## Summary

This batch addresses the actionable, verified findings from the auto-QA quality issues:

### #21762 / #21768 — Extract pure logic + add tests (component split pattern)
- `ConnectTab.tsx` (441 lines) had an inline `CLOUD_IAM_COMMANDS` lookup table and a repeated provider-key ternary embedded directly in JSX.
- Extracted both into `ConnectTab.constants.ts` (new `CLOUD_IAM_COMMANDS` map + `getCloudIAMProviderKey()` helper), following the `*.constants.ts` split pattern already used by `CardWrapper`, `GPUDetailModal`, etc.
- Added `__tests__/ConnectTab.constants.test.ts` with table-driven Vitest tests covering the extracted pure logic (11 tests), per the pattern recommended in #21762 and used in #21757/#21782/#21819.

### #21843 — Color consistency
- `ClusterReadinessCard.tsx` and `DrasiNodeCard.tsx` used raw `bg-green-500`/`bg-red-500`/`bg-yellow-500` for health-state dots instead of the existing semantic `status-*` Tailwind tokens (`bg-status-success`/`bg-status-error`/`bg-status-warning`, defined in `tailwind.config.js` and backed by CSS vars in `index.css`). Updated both call sites and their tests accordingly.

### #21845 — Silent failure
- `usePersistence.testConnection()` caught fetch/network errors, logged to console, and returned an `unknown` health result with no user-facing feedback. Added a `useToast()` error toast (the hook already no-ops safely outside a `ToastProvider`, matching the pattern in `useClusterGroups.ts`).

## Investigation notes (no code changes needed)

- #21841 (navigation/routing) and #21842 (React efficiency) findings were verified against current `main` and appear to be scanner false positives.
- #21844’s two real namespace DOM violations are addressed in PR #21853; remaining hits were false positives.

## Testing
- `npx vitest run` targeted at touched/added test files passed.