### PR TITLE
[quality] test: 77 unit tests for drilldown summary helpers, pod cache, and feedback size guards

### DIFF
--- a/web/src/components/drilldown/views/multi-cluster-summary-drilldown/__tests__/helpers.test.ts
+++ b/web/src/components/drilldown/views/multi-cluster-summary-drilldown/__tests__/helpers.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+import { CheckCircle, XCircle, AlertTriangle, AlertCircle } from 'lucide-react'
+
+import {
+  computeSummaryStats,
+  getStatusBadge,
+  getViewConfig,
+} from '../helpers'
+import type { DrillDownViewType } from '../../../../../hooks/useDrillDown'
+
+const ALL_VIEW_TYPES: DrillDownViewType[] = [
+  'all-clusters',
+  'all-namespaces',
+  'all-deployments',
+  'all-pods',
+  'all-services',
+  'all-nodes',
+  'all-events',
+  'all-alerts',
+  'all-helm',
+  'all-operators',
+  'all-security',
+  'all-gpu',
+  'all-storage',
+  'all-jobs',
+]
+
+describe('getViewConfig', () => {
+  it('returns a distinct config for every known view type', () => {
+    for (const view of ALL_VIEW_TYPES) {
+      const cfg = getViewConfig(view)
+      expect(cfg.icon).toBeDefined()
+      expect(cfg.color).toMatch(/^text-/)
+      expect(cfg.bgColor).toMatch(/^bg-/)
+      expect(cfg.dataKey.length).toBeGreaterThan(0)
+      expect(cfg.nameKey.length).toBeGreaterThan(0)
+      expect(typeof cfg.getStatus).toBe('function')
+    }
+  })
+
+  it('returns a fallback config for an unknown view type', () => {
+    const cfg = getViewConfig('mystery-view' as DrillDownViewType)
+    expect(cfg.dataKey).toBe('items')
+    expect(cfg.nameKey).toBe('name')
+    expect(cfg.color).toBe('text-muted-foreground')
+    expect(cfg.getStatus({} as never)).toBe('unknown')
+  })
+
+  it('all-clusters getStatus prefers healthy=true → "healthy" else falls back to status', () => {
+    const cfg = getViewConfig('all-clusters')
+    expect(cfg.getStatus({ healthy: true, status: 'ignored' } as never)).toBe('healthy')
+    expect(cfg.getStatus({ healthy: false, status: 'unreachable' } as never)).toBe('unreachable')
+    expect(cfg.getStatus({ healthy: false } as never)).toBe('unknown')
+  })
+
+  it('all-namespaces getStatus always returns "active"', () => {
+    expect(getViewConfig('all-namespaces').getStatus({} as never)).toBe('active')
+  })
+
+  it('all-deployments getStatus compares readyReplicas to replicas', () => {
+    const gs = getViewConfig('all-deployments').getStatus
+    expect(gs({ readyReplicas: 3, replicas: 3 } as never)).toBe('healthy')
+    expect(gs({ readyReplicas: 2, replicas: 3 } as never)).toBe('unhealthy')
+    expect(gs({} as never)).toBe('healthy') // undefined === undefined
+  })
+
+  it('all-pods getStatus prefers status, then phase, else unknown', () => {
+    const gs = getViewConfig('all-pods').getStatus
+    expect(gs({ status: 'Running' } as never)).toBe('Running')
+    expect(gs({ phase: 'Pending' } as never)).toBe('Pending')
+    expect(gs({} as never)).toBe('unknown')
+  })
+
+  it('all-nodes getStatus is "Ready" unless ready=false or status="NotReady"', () => {
+    const gs = getViewConfig('all-nodes').getStatus
+    expect(gs({ ready: true } as never)).toBe('Ready')
+    expect(gs({} as never)).toBe('Ready')
+    expect(gs({ ready: false } as never)).toBe('NotReady')
+    expect(gs({ status: 'NotReady' } as never)).toBe('NotReady')
+  })
+
+  it('all-events getStatus defaults to "Normal"', () => {
+    const gs = getViewConfig('all-events').getStatus
+    expect(gs({} as never)).toBe('Normal')
+    expect(gs({ type: 'Warning' } as never)).toBe('Warning')
+  })
+
+  it('all-gpu getStatus is "available" when available>0 else "busy"', () => {
+    const gs = getViewConfig('all-gpu').getStatus
+    expect(gs({ available: 4 } as never)).toBe('available')
+    expect(gs({ available: 0 } as never)).toBe('busy')
+    expect(gs({} as never)).toBe('busy')
+  })
+
+  it('exposes canonical dataKeys for well-known views', () => {
+    expect(getViewConfig('all-clusters').dataKey).toBe('clusters')
+    expect(getViewConfig('all-helm').dataKey).toBe('helmReleases')
+    expect(getViewConfig('all-security').dataKey).toBe('securityIssues')
+    expect(getViewConfig('all-storage').dataKey).toBe('pvcs')
+    expect(getViewConfig('all-gpu').dataKey).toBe('gpuNodes')
+  })
+})
+
+describe('getStatusBadge', () => {
+  it.each(['Running', 'HEALTHY', 'ready', 'active', 'deployed', 'succeeded', 'available', 'normal'])(
+    'maps healthy status %s to a green CheckCircle badge',
+    (status) => {
+      const b = getStatusBadge(status)
+      expect(b.icon).toBe(CheckCircle)
+      expect(b.color).toContain('green')
+    },
+  )
+
+  it.each(['pending', 'Progressing', 'waiting', 'BUSY', 'Warning'])(
+    'maps warning status %s to a yellow AlertTriangle badge',
+    (status) => {
+      const b = getStatusBadge(status)
+      expect(b.icon).toBe(AlertTriangle)
+      expect(b.color).toContain('yellow')
+    },
+  )
+
+  it.each(['Failed', 'ERROR', 'unhealthy', 'NotReady', 'critical', 'CrashLoopBackOff', 'ImagePullBackOff'])(
+    'maps failure status %s to a red XCircle badge',
+    (status) => {
+      const b = getStatusBadge(status)
+      expect(b.icon).toBe(XCircle)
+      expect(b.color).toContain('red')
+    },
+  )
+
+  it('returns a neutral fallback for unknown statuses', () => {
+    const b = getStatusBadge('mystery')
+    expect(b.icon).toBe(AlertCircle)
+    expect(b.color).toBe('text-muted-foreground')
+    expect(b.bg).toBe('bg-secondary')
+  })
+
+  it('tolerates null/undefined/empty status without throwing', () => {
+    expect(getStatusBadge(undefined as unknown as string).icon).toBe(AlertCircle)
+    expect(getStatusBadge(null as unknown as string).icon).toBe(AlertCircle)
+    expect(getStatusBadge('').icon).toBe(AlertCircle)
+  })
+})
+
+describe('computeSummaryStats', () => {
+  const getStatus = (item: { status?: string }) => item.status || ''
+  const baseOpts = {
+    searchQuery: '',
+    statusFilter: 'all',
+    clusterFilter: 'all',
+    viewType: 'all-pods' as DrillDownViewType,
+    expectedNodeCountFromClusters: 0,
+    expectedPodCountFromClusters: 0,
+  }
+
+  it('counts healthy items using HEALTHY_STATUSES case-insensitively', () => {
+    const items = [
+      { status: 'Running' }, { status: 'healthy' }, { status: 'crashloopbackoff' }, { status: 'pending' },
+    ]
+    const s = computeSummaryStats(items, getStatus, baseOpts)
+    expect(s.total).toBe(4)
+    expect(s.healthy).toBe(2)
+    expect(s.issues).toBe(2)
+  })
+
+  it('counts firing and resolved separately', () => {
+    const items = [
+      { status: 'firing' }, { status: 'firing' }, { status: 'resolved' }, { status: 'running' },
+    ]
+    const s = computeSummaryStats(items, getStatus, baseOpts)
+    expect(s.firing).toBe(2)
+    expect(s.resolved).toBe(1)
+  })
+
+  it('uses expectedNodeCountFromClusters as total when list is empty and filters are unset (all-nodes)', () => {
+    const s = computeSummaryStats([], getStatus, {
+      ...baseOpts, viewType: 'all-nodes', expectedNodeCountFromClusters: 12,
+    })
+    expect(s.total).toBe(12)
+    expect(s.healthy).toBe(0)
+    expect(s.issues).toBe(12)
+  })
+
+  it('uses expectedPodCountFromClusters as total when list is empty and filters are unset (all-pods)', () => {
+    const s = computeSummaryStats([], getStatus, {
+      ...baseOpts, viewType: 'all-pods', expectedPodCountFromClusters: 42,
+    })
+    expect(s.total).toBe(42)
+  })
+
+  it('does NOT substitute the expected count when a search query is set', () => {
+    const s = computeSummaryStats([], getStatus, {
+      ...baseOpts, viewType: 'all-nodes', expectedNodeCountFromClusters: 5, searchQuery: 'foo',
+    })
+    expect(s.total).toBe(0)
+  })
+
+  it('does NOT substitute when statusFilter or clusterFilter is set', () => {
+    expect(computeSummaryStats([], getStatus, { ...baseOpts, viewType: 'all-nodes', expectedNodeCountFromClusters: 5, statusFilter: 'healthy' }).total).toBe(0)
+    expect(computeSummaryStats([], getStatus, { ...baseOpts, viewType: 'all-nodes', expectedNodeCountFromClusters: 5, clusterFilter: 'prod' }).total).toBe(0)
+  })
+
+  it('does NOT substitute for viewTypes other than all-nodes/all-pods', () => {
+    const s = computeSummaryStats([], getStatus, {
+      ...baseOpts, viewType: 'all-deployments', expectedNodeCountFromClusters: 5, expectedPodCountFromClusters: 5,
+    })
+    expect(s.total).toBe(0)
+  })
+
+  it('tolerates items whose getStatus returns undefined/null', () => {
+    const items = [{ status: undefined }, { status: 'running' }]
+    const s = computeSummaryStats(items, getStatus, baseOpts)
+    expect(s.healthy).toBe(1)
+    expect(s.issues).toBe(1)
+  })
+
+  it('returns an all-zero summary for an empty list with no expected counts', () => {
+    const s = computeSummaryStats([], getStatus, baseOpts)
+    expect(s).toEqual({ total: 0, healthy: 0, issues: 0, firing: 0, resolved: 0 })
+  })
+})

--- a/web/src/components/drilldown/views/pod-drilldown/__tests__/podCache.test.ts
+++ b/web/src/components/drilldown/views/pod-drilldown/__tests__/podCache.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  RAPID_REOPEN_THRESHOLD_MS,
+  cleanupPodCache,
+  getPodCache,
+  setPodCache,
+} from '../podCache'
+
+// The cache is a module-level Map. Each test clears it up-front to isolate.
+function clearAll() {
+  // Use a far-future "now" to force cleanupPodCache() to drop every entry.
+  vi.setSystemTime(new Date(2100, 0, 1))
+  cleanupPodCache()
+  vi.useRealTimers()
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  clearAll()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('constants', () => {
+  it('RAPID_REOPEN_THRESHOLD_MS is 10 seconds', () => {
+    expect(RAPID_REOPEN_THRESHOLD_MS).toBe(10_000)
+  })
+})
+
+describe('setPodCache / getPodCache', () => {
+  it('returns undefined for a key that has never been written', () => {
+    expect(getPodCache('c', 'n', 'p')).toBeUndefined()
+  })
+
+  it('round-trips a value under the (cluster, namespace, pod) composite key', () => {
+    setPodCache('c1', 'ns1', 'pod-a', { lastOpened: 1_700_000_000_000, openCount: 3 })
+    expect(getPodCache('c1', 'ns1', 'pod-a')).toEqual({ lastOpened: 1_700_000_000_000, openCount: 3 })
+  })
+
+  it('isolates entries by cluster, namespace, and pod name', () => {
+    setPodCache('c1', 'ns', 'p', { openCount: 1 })
+    setPodCache('c2', 'ns', 'p', { openCount: 2 })
+    setPodCache('c1', 'other', 'p', { openCount: 3 })
+    setPodCache('c1', 'ns', 'other', { openCount: 4 })
+    expect(getPodCache('c1', 'ns', 'p')?.openCount).toBe(1)
+    expect(getPodCache('c2', 'ns', 'p')?.openCount).toBe(2)
+    expect(getPodCache('c1', 'other', 'p')?.openCount).toBe(3)
+    expect(getPodCache('c1', 'ns', 'other')?.openCount).toBe(4)
+  })
+
+  it('merges partial updates into the existing entry rather than replacing it', () => {
+    setPodCache('c', 'n', 'p', { lastOpened: 1, openCount: 5 })
+    setPodCache('c', 'n', 'p', { openCount: 6 })
+    const entry = getPodCache('c', 'n', 'p')
+    expect(entry?.openCount).toBe(6)
+    expect(entry?.lastOpened).toBe(1)
+  })
+
+  it('seeds new entries with a lastOpened defaulted to the current time', () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0))
+    const now = Date.now()
+    setPodCache('c', 'n', 'p', { openCount: 1 })
+    const entry = getPodCache('c', 'n', 'p')
+    expect(entry?.lastOpened).toBe(now)
+    expect(entry?.openCount).toBe(1)
+  })
+
+  it('seeds new entries with openCount defaulted to 0 when caller does not set it', () => {
+    setPodCache('c', 'n', 'p', { lastOpened: 42 })
+    expect(getPodCache('c', 'n', 'p')).toEqual({ lastOpened: 42, openCount: 0 })
+  })
+})
+
+describe('cleanupPodCache', () => {
+  it('drops entries whose lastOpened is older than 5 minutes', () => {
+    // Freeze the initial "write" time.
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0))
+    setPodCache('c', 'n', 'old', { lastOpened: Date.now(), openCount: 1 })
+
+    // Advance the clock past the 5-minute TTL, then write a fresh entry.
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 4, 59))
+    setPodCache('c', 'n', 'fresh', { lastOpened: Date.now(), openCount: 1 })
+
+    // Move past the TTL for the "old" entry only.
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 5, 1))
+    cleanupPodCache()
+
+    expect(getPodCache('c', 'n', 'old')).toBeUndefined()
+    expect(getPodCache('c', 'n', 'fresh')).toBeDefined()
+  })
+
+  it('keeps entries whose lastOpened is exactly 5 minutes ago (boundary)', () => {
+    vi.setSystemTime(new Date(2026, 0, 1, 12, 0, 0))
+    const t0 = Date.now()
+    setPodCache('c', 'n', 'edge', { lastOpened: t0, openCount: 1 })
+
+    vi.setSystemTime(new Date(t0 + 5 * 60 * 1000))
+    cleanupPodCache()
+
+    expect(getPodCache('c', 'n', 'edge')).toBeDefined()
+  })
+
+  it('is a no-op when the cache is empty', () => {
+    expect(() => cleanupPodCache()).not.toThrow()
+  })
+})

--- a/web/src/components/feedback/__tests__/FeatureRequestTypes.test.ts
+++ b/web/src/components/feedback/__tests__/FeatureRequestTypes.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BYTES_PER_MEBIBYTE,
+  FEEDBACK_ATTACHMENT_MAX_FILE_BYTES,
+  FEEDBACK_REQUEST_BODY_LIMIT_BYTES,
+  MAX_VIDEO_SIZE_BYTES,
+  MAX_VIDEO_SIZE_MIB,
+  estimateFeedbackRequestBodyBytes,
+  getStatusInfo,
+  isFeedbackRequestBodyLimitError,
+  isFeedbackRequestBodyTooLarge,
+} from '../FeatureRequestTypes'
+
+describe('feedback size constants', () => {
+  it('BYTES_PER_MEBIBYTE is 1 MiB', () => {
+    expect(BYTES_PER_MEBIBYTE).toBe(1024 * 1024)
+  })
+
+  it('MAX_VIDEO_SIZE_MIB=10 and MAX_VIDEO_SIZE_BYTES equal FEEDBACK_ATTACHMENT_MAX_FILE_BYTES', () => {
+    expect(MAX_VIDEO_SIZE_MIB).toBe(10)
+    expect(MAX_VIDEO_SIZE_BYTES).toBe(10 * BYTES_PER_MEBIBYTE)
+    expect(MAX_VIDEO_SIZE_BYTES).toBe(FEEDBACK_ATTACHMENT_MAX_FILE_BYTES)
+  })
+
+  it('FEEDBACK_REQUEST_BODY_LIMIT_BYTES exceeds the raw attachment cap after base64 expansion', () => {
+    // Base64 expands ~4/3× and the module adds a 1 MiB slack, so the limit
+    // must be strictly larger than the raw attachment cap.
+    expect(FEEDBACK_REQUEST_BODY_LIMIT_BYTES).toBeGreaterThan(FEEDBACK_ATTACHMENT_MAX_FILE_BYTES)
+    const expected =
+      Math.ceil(FEEDBACK_ATTACHMENT_MAX_FILE_BYTES / 3) * 4 + BYTES_PER_MEBIBYTE
+    expect(FEEDBACK_REQUEST_BODY_LIMIT_BYTES).toBe(expected)
+  })
+})
+
+describe('estimateFeedbackRequestBodyBytes', () => {
+  it('returns the UTF-8 byte length of the JSON serialization', () => {
+    expect(estimateFeedbackRequestBodyBytes('abc')).toBe(new TextEncoder().encode('"abc"').length)
+    expect(estimateFeedbackRequestBodyBytes({ a: 1 })).toBe(new TextEncoder().encode('{"a":1}').length)
+  })
+
+  it('counts multi-byte UTF-8 characters correctly', () => {
+    const emoji = '😀'
+    const bytes = estimateFeedbackRequestBodyBytes(emoji)
+    // JSON.stringify wraps in quotes; emoji is a surrogate pair → 4 UTF-8 bytes + 2 quotes.
+    expect(bytes).toBe(6)
+  })
+
+  it('returns 0-adjacent length for null/undefined payloads', () => {
+    // JSON.stringify(undefined) → undefined; TextEncoder → empty
+    expect(estimateFeedbackRequestBodyBytes(undefined)).toBe(0)
+    // JSON.stringify(null) → 'null'
+    expect(estimateFeedbackRequestBodyBytes(null)).toBe(4)
+  })
+})
+
+describe('isFeedbackRequestBodyTooLarge', () => {
+  it('is false for small payloads', () => {
+    expect(isFeedbackRequestBodyTooLarge({ title: 'hi', body: 'small' })).toBe(false)
+  })
+
+  it('is true for payloads larger than the request-body limit', () => {
+    // Construct a string whose JSON encoding exceeds the limit. The +100
+    // cushion accounts for JSON's surrounding quotes.
+    const oversized = 'x'.repeat(FEEDBACK_REQUEST_BODY_LIMIT_BYTES + 100)
+    expect(isFeedbackRequestBodyTooLarge(oversized)).toBe(true)
+  })
+})
+
+describe('isFeedbackRequestBodyLimitError', () => {
+  it.each([
+    'Request entity too large',
+    'request body too large',
+    'PAYLOAD TOO LARGE for upload',
+    'HTTP 413: request entity too large.',
+  ])('matches known "too large" phrasing (%s)', (msg) => {
+    expect(isFeedbackRequestBodyLimitError(msg)).toBe(true)
+  })
+
+  it.each([
+    '',
+    'timeout',
+    'unrelated error',
+    'entity too small',
+  ])('does not match unrelated errors (%s)', (msg) => {
+    expect(isFeedbackRequestBodyLimitError(msg)).toBe(false)
+  })
+})
+
+describe('getStatusInfo', () => {
+  it('returns a label and color/bgColor pair for open', () => {
+    const info = getStatusInfo('open')
+    expect(info.label.length).toBeGreaterThan(0)
+    expect(info.color).toContain('blue')
+    expect(info.bgColor).toContain('blue')
+  })
+
+  it('overrides closed label to "Closed by You" when closedByUser=true', () => {
+    expect(getStatusInfo('closed', true).label).toBe('Closed by You')
+  })
+
+  it('does NOT override the label for non-closed statuses even if closedByUser=true', () => {
+    const info = getStatusInfo('open', true)
+    expect(info.label).not.toBe('Closed by You')
+  })
+
+  it('uses the default closed label when closedByUser is false/omitted', () => {
+    const info = getStatusInfo('closed')
+    expect(info.label).not.toBe('Closed by You')
+    expect(info.color).toBe('text-muted-foreground')
+  })
+
+  it.each([
+    ['needs_triage', 'yellow'],
+    ['triage_accepted', 'cyan'],
+    ['feasibility_study', 'purple'],
+    ['fix_ready', 'green'],
+    ['fix_complete', 'green'],
+    ['unable_to_fix', 'orange'],
+  ] as const)('maps %s to a %s color', (status, color) => {
+    const info = getStatusInfo(status)
+    expect(info.color).toContain(color)
+    expect(info.bgColor).toContain(color)
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds Vitest unit-test coverage for three previously-untested pure-logic modules (tracked by #21762):

| Module | Tests | Coverage highlights |
|---|---|---|
| `drilldown/views/multi-cluster-summary-drilldown/helpers.ts` | 41 | `getViewConfig` — every `DrillDownViewType` returns a distinct config; per-view `getStatus` rules (healthy vs status, readyReplicas match, status→phase fallback, ready/NotReady, GPU available count); default fallback. `getStatusBadge` — HEALTHY_STATUSES → green, warning set → yellow, failure set → red, unknown → neutral. `computeSummaryStats` — firing/resolved counts, expected-count substitution for `all-nodes`/`all-pods`, filter-set suppression, empty-list zero case. |
| `drilldown/views/pod-drilldown/podCache.ts` | 10 | `RAPID_REOPEN_THRESHOLD_MS=10_000`; get/set round-trip; key isolation across `(cluster, namespace, pod)`; partial-update merge (`{...existing, ...data}`); new-entry defaults (`lastOpened=now`, `openCount=0`); `cleanupPodCache` 5-minute TTL including the exact-boundary case. |
| `feedback/FeatureRequestTypes.ts` | 26 | Body-size constants (base64 4/3 expansion + 1 MiB slack); `estimateFeedbackRequestBodyBytes` UTF-8 including emoji surrogate pairs and null/undefined; `isFeedbackRequestBodyTooLarge` threshold; `isFeedbackRequestBodyLimitError` case-insensitive token matching; `getStatusInfo` label overrides for `closed`+`closedByUser`. |

**Total: 77 new tests**, all passing locally (`npx vitest run <files>`).

All modules are pure functions — no React DOM harness, no MSW. `podCache.ts` uses `vi.useFakeTimers()` + `vi.setSystemTime()` to exercise the TTL boundary deterministically.

Refs #21762

---
*Filed by quality agent (ACMM L4/L6 — full mode)*