### PR TITLE
[scanner] fix: stabilize failing coverage suite tests on main

### DIFF
--- a/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
+++ b/web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx
@@ -15,16 +15,12 @@ vi.mock('react-i18next', () => ({
   initReactI18next: { type: '3rdParty', init: () => {} },
   useTranslation: () => ({
     t: (key: string, optsOrDefault?: { defaultValue?: string; count?: number } | string, extraOpts?: Record<string, unknown>) => {
-      // Handle t(key, defaultValue, options) — interpolate the default value string
-      if (typeof optsOrDefault === 'string') {
-        const options = extraOpts ?? {}
-        return Object.entries(options).reduce(
-          (s, [k, v]) => s.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v ?? '')),
-          optsOrDefault,
-        )
-      }
-      const opts = optsOrDefault
-      if (opts?.defaultValue) return String(opts.defaultValue)
+      // Normalize both the legacy t(key, options) and current t(key, defaultValue, options)
+      // i18next call signatures into a single { defaultValue, opts } shape before applying
+      // the key-based overrides below, so both forms produce identical fixture strings.
+      const defaultValue = typeof optsOrDefault === 'string' ? optsOrDefault : optsOrDefault?.defaultValue
+      const opts = typeof optsOrDefault === 'string' ? extraOpts : optsOrDefault
+
       if (key.includes('allHealthy')) return 'All Healthy'
       if (key.includes('gpuIssues')) return 'GPU Issues'
       if (key.includes('predicted')) return 'Predicted'
@@ -33,6 +29,12 @@ vi.mock('react-i18next', () => ({
       }
       if (key.includes('unhealthy')) return 'Unhealthy'
       if (key.includes('offline')) return 'Offline'
+      if (defaultValue) {
+        return Object.entries(opts ?? {}).reduce(
+          (s, [k, v]) => s.replace(new RegExp(`\\{\\{${k}\\}\\}`, 'g'), String(v ?? '')),
+          defaultValue,
+        )
+      }
       return key
     },
   }),

--- a/web/src/components/gpu/__tests__/ReservationFormModal.utils.test.ts
+++ b/web/src/components/gpu/__tests__/ReservationFormModal.utils.test.ts
@@ -65,8 +65,10 @@ describe('toRFC3339StartDate', () => {
 
     const [, sign, hh, mm] = match!
     const signedMinutes = (sign === '+' ? 1 : -1) * (Number(hh) * 60 + Number(mm))
-    // toRFC3339StartDate flips the sign of getTimezoneOffset() (minutes-west-of-UTC → offset-east-of-UTC)
-    expect(signedMinutes).toBe(-new Date().getTimezoneOffset())
+    // toRFC3339StartDate flips the sign of getTimezoneOffset() (minutes-west-of-UTC → offset-east-of-UTC).
+    // Adding 0 normalizes a possible -0 (e.g. in UTC, where the offset is zero) to +0 so the
+    // comparison doesn't fail due to Object.is distinguishing -0 from 0.
+    expect(signedMinutes + 0).toBe(-new Date().getTimezoneOffset() + 0)
   })
 
   it('zero-pads single-digit hour and minute components of the offset', () => {


### PR DESCRIPTION
Fixes #21851

## Summary

Fixes 4 failing tests from Coverage Suite run 30456448867 (head sha af029c8f5477416a7311e3cc109b5dc57e8f25d1):

1. **`ReservationFormModal.utils.test.ts` — `toRFC3339StartDate produces an offset consistent with Date#getTimezoneOffset()`**
   Root cause: the assertion compared `signedMinutes` (computed as `1 * 0 = +0`) to `-new Date().getTimezoneOffset()` (`-0` when running in the UTC timezone). Vitest's `toBe()` uses `Object.is()`, which treats `+0` and `-0` as distinct, so the test failed whenever the CI runner's local timezone offset was exactly zero. Fixed by adding `+ 0` to both sides of the comparison to normalize `-0` to `+0`.

2. **`ConsoleOfflineDetectionCard.test.tsx` — 3 failures in "online/offline status summary"**
   Root cause: a prior TypeScript-build-stabilization commit (`040139daf5`) updated `OfflineStatusDisplay.tsx` to call `t(key, defaultValue, options)` (3-arg i18next form) instead of `t(key, options)` (2-arg form). The test file's local `react-i18next` mock only implemented key-based overrides (e.g. returning `"N cluster issues"` for the issues tooltip) for the 2-arg form, so with the 3-arg form it fell through to interpolating the raw default string (`"N issues detected"`) instead, breaking `getByTitle('N cluster issues')` lookups. Fixed by normalizing both call signatures in the mock before applying the key-based overrides.

## Changes
- `web/src/components/gpu/__tests__/ReservationFormModal.utils.test.ts`
- `web/src/components/cards/console-missions/__tests__/ConsoleOfflineDetectionCard.test.tsx`

Both changes are test-only; no production code was modified. Verified locally with `TZ=UTC` and `TZ=America/New_York` for the GPU test, and confirmed all 13 `ConsoleOfflineDetectionCard` tests plus all 16 `ReservationFormModal.utils` tests pass.

Per repo convention, build/lint are validated by CI on this PR.
