### PR TITLE
[quality] test: 65 unit tests for scanner-extracted missions helpers (#21857)

### DIFF
--- a/web/src/components/missions/__tests__/MissionDetailView.helpers.test.ts
+++ b/web/src/components/missions/__tests__/MissionDetailView.helpers.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractCodeBlocks } from '../MissionDetailView.helpers'
+
+describe('extractCodeBlocks', () => {
+  it('returns a single "before" block with the full text when there are no code fences', () => {
+    const text = 'This is a plain paragraph with no code.'
+    expect(extractCodeBlocks(text)).toEqual([{ before: text, code: '', after: '' }])
+  })
+
+  it('extracts a single fenced code block and preserves surrounding text', () => {
+    const text = 'Before code\n```\nkubectl get pods\n```\nAfter code'
+    const parts = extractCodeBlocks(text)
+    expect(parts).toHaveLength(1)
+    expect(parts[0].before).toBe('Before code')
+    expect(parts[0].code).toBe('kubectl get pods')
+    expect(parts[0].after).toBe('After code')
+  })
+
+  it('supports language tags on the opening fence', () => {
+    const text = 'Try this:\n```bash\nkubectl apply -f x.yaml\n```\n'
+    const parts = extractCodeBlocks(text)
+    expect(parts[0].code).toBe('kubectl apply -f x.yaml')
+  })
+
+  it('extracts multiple sequential code blocks with per-block "before" and only the last block gets "after"', () => {
+    const text = 'Intro\n```\nfirst\n```\nMiddle\n```\nsecond\n```\nTail text'
+    const parts = extractCodeBlocks(text)
+    expect(parts).toHaveLength(2)
+    expect(parts[0]).toEqual({ before: 'Intro', code: 'first', after: '' })
+    expect(parts[1].before).toBe('Middle')
+    expect(parts[1].code).toBe('second')
+    expect(parts[1].after).toBe('Tail text')
+  })
+
+  it('trims surrounding whitespace on before/code/after', () => {
+    const text = '  intro  \n```\n  cmd  \n```\n  outro  '
+    const parts = extractCodeBlocks(text)
+    expect(parts[0].before).toBe('intro')
+    expect(parts[0].code).toBe('cmd')
+    expect(parts[0].after).toBe('outro')
+  })
+
+  it('handles a code block at the very start of the text (empty before)', () => {
+    const text = '```\nhello\n```'
+    const parts = extractCodeBlocks(text)
+    expect(parts[0].before).toBe('')
+    expect(parts[0].code).toBe('hello')
+    expect(parts[0].after).toBe('')
+  })
+
+  it('emits empty "after" when the text ends with the closing fence', () => {
+    const text = 'x\n```\ncmd\n```'
+    const parts = extractCodeBlocks(text)
+    expect(parts[0].after).toBe('')
+  })
+
+  it('handles empty string input', () => {
+    expect(extractCodeBlocks('')).toEqual([{ before: '', code: '', after: '' }])
+  })
+
+  it('handles an empty fenced block (no body)', () => {
+    const text = '```\n```'
+    const parts = extractCodeBlocks(text)
+    expect(parts[0].code).toBe('')
+  })
+})

--- a/web/src/components/missions/__tests__/MissionLandingPage.api.test.ts
+++ b/web/src/components/missions/__tests__/MissionLandingPage.api.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPreferredPaths } from '../MissionLandingPage.api'
+
+describe('getPreferredPaths', () => {
+  it('routes install-* slugs to cncf-install then platform-install', () => {
+    expect(getPreferredPaths('install-karmada')).toEqual([
+      'fixes/cncf-install/install-karmada.json',
+      'fixes/platform-install/install-karmada.json',
+    ])
+  })
+
+  it('routes platform-* slugs only to platform-install', () => {
+    expect(getPreferredPaths('platform-kubestellar')).toEqual([
+      'fixes/platform-install/platform-kubestellar.json',
+    ])
+  })
+
+  it('routes other slugs by prefix into cncf-generated first, then the generic fixture buckets', () => {
+    expect(getPreferredPaths('karmada-1234-issue')).toEqual([
+      'fixes/cncf-generated/karmada/karmada-1234-issue.json',
+      'fixes/security/karmada-1234-issue.json',
+      'fixes/troubleshoot/karmada-1234-issue.json',
+      'fixes/llm-d/karmada-1234-issue.json',
+      'fixes/multi-cluster/karmada-1234-issue.json',
+    ])
+  })
+
+  it('uses the whole slug as the "project" hint when there is no hyphen', () => {
+    expect(getPreferredPaths('istio')).toEqual([
+      'fixes/cncf-generated/istio/istio.json',
+      'fixes/security/istio.json',
+      'fixes/troubleshoot/istio.json',
+      'fixes/llm-d/istio.json',
+      'fixes/multi-cluster/istio.json',
+    ])
+  })
+
+  it('every returned path is a fixes/*.json string', () => {
+    for (const slug of ['install-x', 'platform-y', 'foo-bar-baz']) {
+      for (const p of getPreferredPaths(slug)) {
+        expect(p.startsWith('fixes/')).toBe(true)
+        expect(p.endsWith('.json')).toBe(true)
+      }
+    }
+  })
+})

--- a/web/src/components/missions/__tests__/MissionLandingPage.constants.test.ts
+++ b/web/src/components/missions/__tests__/MissionLandingPage.constants.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_TYPE_COLOR,
+  FETCH_TIMEOUT_MS,
+  MAX_PREVIEW_STEPS,
+  TABS,
+  TYPE_COLORS,
+} from '../MissionLandingPage.constants'
+import type { MissionExport } from '../../../lib/missions/types'
+
+describe('MissionLandingPage constants', () => {
+  it('FETCH_TIMEOUT_MS is 10s', () => {
+    expect(FETCH_TIMEOUT_MS).toBe(10_000)
+  })
+
+  it('MAX_PREVIEW_STEPS is 5', () => {
+    expect(MAX_PREVIEW_STEPS).toBe(5)
+  })
+
+  it('TYPE_COLORS covers the six documented mission types', () => {
+    for (const t of ['repair', 'troubleshoot', 'deploy', 'upgrade', 'analyze', 'custom']) {
+      expect(TYPE_COLORS[t]).toMatch(/^bg-\w+-500\/20\b/)
+    }
+  })
+
+  it('DEFAULT_TYPE_COLOR matches the "custom" style so unknown types render gracefully', () => {
+    expect(DEFAULT_TYPE_COLOR).toBe(TYPE_COLORS.custom)
+  })
+})
+
+describe('TABS', () => {
+  it('exposes exactly the four canonical tab ids in order', () => {
+    expect(TABS.map((t) => t.id)).toEqual(['install', 'uninstall', 'upgrade', 'troubleshoot'])
+  })
+
+  it('every tab has a non-empty label, an icon, and a distinct empty message', () => {
+    const messages = new Set<string>()
+    for (const tab of TABS) {
+      expect(tab.label.length).toBeGreaterThan(0)
+      expect(typeof tab.icon).toBe('string')
+      expect(tab.icon.length).toBeGreaterThan(0)
+      expect(tab.emptyMessage.length).toBeGreaterThan(0)
+      messages.add(tab.emptyMessage)
+    }
+    expect(messages.size).toBe(TABS.length)
+  })
+
+  it('install tab pulls from mission.steps', () => {
+    const install = TABS.find((t) => t.id === 'install')!
+    const mission = { steps: [{ command: 'kubectl apply' }] } as unknown as MissionExport
+    expect(install.getSteps(mission)).toEqual([{ command: 'kubectl apply' }])
+  })
+
+  it('uninstall tab pulls from mission.uninstall', () => {
+    const tab = TABS.find((t) => t.id === 'uninstall')!
+    const mission = { uninstall: [{ command: 'helm uninstall' }] } as unknown as MissionExport
+    expect(tab.getSteps(mission)).toEqual([{ command: 'helm uninstall' }])
+  })
+
+  it('upgrade tab pulls from mission.upgrade', () => {
+    const tab = TABS.find((t) => t.id === 'upgrade')!
+    const mission = { upgrade: [{ command: 'helm upgrade' }] } as unknown as MissionExport
+    expect(tab.getSteps(mission)).toEqual([{ command: 'helm upgrade' }])
+  })
+
+  it('troubleshoot tab pulls from mission.troubleshooting', () => {
+    const tab = TABS.find((t) => t.id === 'troubleshoot')!
+    const mission = { troubleshooting: [{ command: 'kubectl logs' }] } as unknown as MissionExport
+    expect(tab.getSteps(mission)).toEqual([{ command: 'kubectl logs' }])
+  })
+
+  it('every getSteps returns an empty array when the mission omits the section', () => {
+    const emptyMission = {} as MissionExport
+    for (const tab of TABS) {
+      expect(tab.getSteps(emptyMission)).toEqual([])
+    }
+  })
+})

--- a/web/src/components/missions/__tests__/StandaloneOrbitDialog.helpers.test.ts
+++ b/web/src/components/missions/__tests__/StandaloneOrbitDialog.helpers.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { CADENCE_OPTIONS, buildScopeString } from '../StandaloneOrbitDialog.helpers'
+import type { OrbitResourceFilter } from '../../../lib/missions/types'
+
+describe('CADENCE_OPTIONS', () => {
+  it('exposes daily, weekly, monthly in a stable order', () => {
+    expect(CADENCE_OPTIONS).toEqual(['daily', 'weekly', 'monthly'])
+  })
+})
+
+describe('buildScopeString', () => {
+  it('returns empty string when there are no filters', () => {
+    expect(buildScopeString({})).toBe('')
+  })
+
+  it('returns empty string when every cluster maps to an empty filter list', () => {
+    expect(buildScopeString({ prod: [], stage: [] })).toBe('')
+  })
+
+  it('formats a single namespaced-resource filter', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Pod', namespaces: ['default'] } as OrbitResourceFilter],
+    }
+    const out = buildScopeString(filters)
+    expect(out).toBe('\n\nFocus on:\n- prod: Pod in namespaces: default')
+  })
+
+  it('joins multiple namespaces with a comma-space separator', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Deployment', namespaces: ['a', 'b', 'c'] } as OrbitResourceFilter],
+    }
+    expect(buildScopeString(filters)).toContain('Deployment in namespaces: a, b, c')
+  })
+
+  it('marks cluster-scoped resources explicitly', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'ClusterRole', clusterScoped: true } as OrbitResourceFilter],
+    }
+    expect(buildScopeString(filters)).toContain('- prod: ClusterRole (cluster-scoped)')
+  })
+
+  it('marks namespaced resources with an empty namespaces array as "(all namespaces)"', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Pod', namespaces: [] } as OrbitResourceFilter],
+    }
+    expect(buildScopeString(filters)).toContain('- prod: Pod (all namespaces)')
+  })
+
+  it('treats an omitted namespaces field the same as empty', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Pod' } as OrbitResourceFilter],
+    }
+    expect(buildScopeString(filters)).toContain('- prod: Pod (all namespaces)')
+  })
+
+  it('joins multiple resource filters within one cluster using semicolons', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [
+        { kind: 'Pod', namespaces: ['default'] } as OrbitResourceFilter,
+        { kind: 'Service', namespaces: ['default'] } as OrbitResourceFilter,
+      ],
+    }
+    expect(buildScopeString(filters)).toContain(
+      '- prod: Pod in namespaces: default; Service in namespaces: default',
+    )
+  })
+
+  it('emits one line per cluster (newline-separated)', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Pod', namespaces: ['ns1'] } as OrbitResourceFilter],
+      dev: [{ kind: 'Service', clusterScoped: false, namespaces: ['ns2'] } as OrbitResourceFilter],
+    }
+    const out = buildScopeString(filters)
+    expect(out).toContain('- prod: Pod in namespaces: ns1')
+    expect(out).toContain('- dev: Service in namespaces: ns2')
+    // Two distinct lines under the "Focus on:" header.
+    expect(out.split('\n').filter((l) => l.startsWith('- '))).toHaveLength(2)
+  })
+
+  it('skips clusters that have an empty filter list even when other clusters have filters', () => {
+    const filters: Record<string, OrbitResourceFilter[]> = {
+      prod: [{ kind: 'Pod', namespaces: ['ns1'] } as OrbitResourceFilter],
+      stage: [],
+    }
+    const out = buildScopeString(filters)
+    expect(out).toContain('- prod:')
+    expect(out).not.toContain('- stage:')
+  })
+})

--- a/web/src/components/missions/__tests__/SubmitToKBDialog.helpers.test.ts
+++ b/web/src/components/missions/__tests__/SubmitToKBDialog.helpers.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  CNCF_PROJECT_KEYWORDS,
+  CONSOLE_KB_BRANCH,
+  CONSOLE_KB_OWNER,
+  CONSOLE_KB_REPO,
+  MAX_GITHUB_URL_LENGTH,
+  detectCNCFProject,
+  generateFilename,
+  resolutionToKBFormat,
+} from '../SubmitToKBDialog.helpers'
+import type { Resolution } from '../../../hooks/useResolutions'
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────
+
+function makeResolution(overrides: Partial<Resolution> = {}): Resolution {
+  return {
+    id: 'r-1',
+    missionId: 'm-1',
+    userId: 'user@example.com',
+    title: 'Fix crashing pods',
+    visibility: 'private',
+    issueSignature: {
+      type: 'CrashLoopBackOff',
+      errorPattern: 'Back-off restarting failed container',
+      resourceKind: 'Pod',
+      namespace: 'default',
+    },
+    resolution: {
+      summary: 'Increase memory limits',
+      steps: ['kubectl top pod', 'kubectl edit deploy web'],
+      yaml: undefined,
+    },
+    context: {
+      cluster: 'prod',
+      operators: [],
+      k8sVersion: '1.29',
+    },
+    effectiveness: { timesUsed: 0, timesSuccessful: 0 },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-02T00:00:00Z',
+    ...overrides,
+  } as Resolution
+}
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+describe('kb constants', () => {
+  it('point at the kubestellar/console-kb repo on the master branch', () => {
+    expect(CONSOLE_KB_OWNER).toBe('kubestellar')
+    expect(CONSOLE_KB_REPO).toBe('console-kb')
+    expect(CONSOLE_KB_BRANCH).toBe('master')
+  })
+
+  it('MAX_GITHUB_URL_LENGTH is 7500 (under the ~8000 browser ceiling)', () => {
+    expect(MAX_GITHUB_URL_LENGTH).toBe(7500)
+    expect(MAX_GITHUB_URL_LENGTH).toBeLessThan(8000)
+  })
+
+  it('CNCF_PROJECT_KEYWORDS contains canonical entries for key CNCF projects', () => {
+    expect(CNCF_PROJECT_KEYWORDS.kyverno).toBe('Kyverno')
+    expect(CNCF_PROJECT_KEYWORDS.istio).toBe('Istio')
+    expect(CNCF_PROJECT_KEYWORDS.argocd).toBe('Argo CD')
+    expect(CNCF_PROJECT_KEYWORDS['argo cd']).toBe('Argo CD')
+    expect(CNCF_PROJECT_KEYWORDS.kubestellar).toBe('KubeStellar')
+    expect(CNCF_PROJECT_KEYWORDS['open policy agent']).toBe('OPA')
+    expect(CNCF_PROJECT_KEYWORDS.gatekeeper).toBe('OPA Gatekeeper')
+  })
+})
+
+// ─── detectCNCFProject ─────────────────────────────────────────────────────
+
+describe('detectCNCFProject', () => {
+  it('returns empty string when no keyword matches', () => {
+    const r = makeResolution({ title: 'Nothing here', context: { operators: [] } })
+    expect(detectCNCFProject(r)).toBe('')
+  })
+
+  it('detects from the operators list (exact match, case-insensitive)', () => {
+    const r = makeResolution({ title: 'Random title', context: { operators: ['Kyverno'] } })
+    expect(detectCNCFProject(r)).toBe('Kyverno')
+  })
+
+  it('detects from an operator via substring match', () => {
+    const r = makeResolution({ title: 'Random title', context: { operators: ['istio-system-controller'] } })
+    expect(detectCNCFProject(r)).toBe('Istio')
+  })
+
+  it('detects Argo CD from the "argocd" alias in the title', () => {
+    const r = makeResolution({ title: 'ArgoCD sync failed', context: { operators: [] } })
+    expect(detectCNCFProject(r)).toBe('Argo CD')
+  })
+
+  it('detects from the namespace when the title has no keyword', () => {
+    const r = makeResolution({
+      title: 'Generic issue',
+      issueSignature: { type: 'X', namespace: 'cert-manager' },
+      context: { operators: [] },
+    })
+    expect(detectCNCFProject(r)).toBe('cert-manager')
+  })
+
+  it('detects from resolution.summary when title/namespace do not match', () => {
+    const r = makeResolution({
+      title: 'Generic issue',
+      issueSignature: { type: 'X' },
+      resolution: { summary: 'The prometheus scrape config is broken', steps: [] },
+      context: { operators: [] },
+    })
+    expect(detectCNCFProject(r)).toBe('Prometheus')
+  })
+
+  it('detects from resolution.steps when nothing else matches', () => {
+    const r = makeResolution({
+      title: 'Generic issue',
+      issueSignature: { type: 'X' },
+      resolution: { summary: 'Fix', steps: ['helm upgrade grafana grafana/grafana'] },
+      context: { operators: [] },
+    })
+    expect(detectCNCFProject(r)).toBe('Grafana')
+  })
+
+  it('is case-insensitive across all detection paths', () => {
+    const r = makeResolution({ title: 'FLUX reconciliation stuck', context: { operators: [] } })
+    expect(detectCNCFProject(r)).toBe('Flux')
+  })
+})
+
+// ─── resolutionToKBFormat ───────────────────────────────────────────────────
+
+describe('resolutionToKBFormat', () => {
+  it('emits kc-mission-v1 envelope with steps mapped to {title, description}', () => {
+    const r = makeResolution({
+      resolution: { summary: 'Do the thing', steps: ['one', 'two'], yaml: undefined },
+    })
+    const out = resolutionToKBFormat(r, 'fixer', 'Kyverno') as Record<string, unknown>
+    expect(out.version).toBe('kc-mission-v1')
+    expect(out.title).toBe('Fix crashing pods')
+    expect(out.description).toBe('Do the thing')
+    expect(out.type).toBe('troubleshoot')
+    expect(out.category).toBe('troubleshooting')
+    expect(out.missionClass).toBe('fixer')
+    expect(out.cncfProject).toBe('Kyverno')
+    const mission = out.mission as Record<string, unknown>
+    expect(mission.steps).toEqual([
+      { title: 'Step 1', description: 'one' },
+      { title: 'Step 2', description: 'two' },
+    ])
+  })
+
+  it('uses "deploy"/"installation" type for missionClass=install', () => {
+    const out = resolutionToKBFormat(makeResolution(), 'install', 'Kyverno') as Record<string, unknown>
+    expect(out.type).toBe('deploy')
+    expect(out.category).toBe('installation')
+  })
+
+  it('adds a troubleshooting entry when missionClass=fixer AND summary is present', () => {
+    const r = makeResolution({
+      issueSignature: { type: 'CrashLoopBackOff' },
+      resolution: { summary: 'Some summary', steps: ['a'] },
+    })
+    const out = resolutionToKBFormat(r, 'fixer', '') as Record<string, unknown>
+    const mission = out.mission as Record<string, unknown>
+    expect(mission.troubleshooting).toEqual([{ title: 'CrashLoopBackOff', description: 'Some summary' }])
+  })
+
+  it('omits troubleshooting when missionClass=install even with a summary', () => {
+    const r = makeResolution({ resolution: { summary: 'summary', steps: ['a'] } })
+    const out = resolutionToKBFormat(r, 'install', '') as Record<string, unknown>
+    const mission = out.mission as Record<string, unknown>
+    expect(mission.troubleshooting).toBeUndefined()
+  })
+
+  it('omits the cncfProject key entirely when no project was detected', () => {
+    const out = resolutionToKBFormat(makeResolution(), 'fixer', '') as Record<string, unknown>
+    expect(out.cncfProject).toBeUndefined()
+  })
+
+  it('includes yaml when the resolution carries one', () => {
+    const r = makeResolution({ resolution: { summary: 's', steps: ['a'], yaml: 'kind: Deployment' } })
+    const out = resolutionToKBFormat(r, 'fixer', 'Kyverno') as Record<string, unknown>
+    const mission = out.mission as Record<string, unknown>
+    const resolution = mission.resolution as Record<string, unknown>
+    expect(resolution.yaml).toBe('kind: Deployment')
+  })
+
+  it('omits mission.resolution when summary is empty and steps are empty', () => {
+    const r = makeResolution({ resolution: { summary: '', steps: [] } })
+    const out = resolutionToKBFormat(r, 'fixer', '') as Record<string, unknown>
+    const mission = out.mission as Record<string, unknown>
+    expect(mission.resolution).toBeUndefined()
+  })
+
+  it('builds tags from issue type + resourceKind + cncfProject (dedup falsy)', () => {
+    const r = makeResolution({
+      issueSignature: { type: 'CrashLoopBackOff', resourceKind: 'Pod' },
+    })
+    const out = resolutionToKBFormat(r, 'fixer', 'Kyverno') as Record<string, unknown>
+    expect(out.tags).toEqual(['CrashLoopBackOff', 'Pod', 'Kyverno'])
+  })
+
+  it('drops resourceKind and cncfProject from tags when they are empty', () => {
+    const r = makeResolution({ issueSignature: { type: 'CrashLoopBackOff' } })
+    const out = resolutionToKBFormat(r, 'fixer', '') as Record<string, unknown>
+    expect(out.tags).toEqual(['CrashLoopBackOff'])
+  })
+
+  it('uses sharedBy for the metadata.author when set, else userId', () => {
+    const shared = resolutionToKBFormat(
+      makeResolution({ sharedBy: 'alice', userId: 'bob' }), 'fixer', '') as Record<string, unknown>
+    expect((shared.metadata as Record<string, unknown>).author).toBe('alice')
+    const priv = resolutionToKBFormat(
+      makeResolution({ sharedBy: undefined, userId: 'bob' }), 'fixer', '') as Record<string, unknown>
+    expect((priv.metadata as Record<string, unknown>).author).toBe('bob')
+  })
+
+  it('metadata carries createdAt/updatedAt and marks source as kubestellar-console', () => {
+    const out = resolutionToKBFormat(makeResolution(), 'fixer', '') as Record<string, unknown>
+    const md = out.metadata as Record<string, unknown>
+    expect(md.source).toBe('kubestellar-console')
+    expect(md.createdAt).toBe('2026-01-01T00:00:00Z')
+    expect(md.updatedAt).toBe('2026-01-02T00:00:00Z')
+  })
+
+  it('falls back to title when resolution.summary is empty', () => {
+    const r = makeResolution({ title: 'Fallback title', resolution: { summary: '', steps: ['a'] } })
+    const out = resolutionToKBFormat(r, 'fixer', '') as Record<string, unknown>
+    expect(out.description).toBe('Fallback title')
+  })
+})
+
+// ─── generateFilename ───────────────────────────────────────────────────────
+
+describe('generateFilename', () => {
+  it('emits install-<slug>.json for missionClass=install', () => {
+    expect(generateFilename('Install Karmada CRDs', 'install')).toBe('install-install-karmada-crds.json')
+  })
+
+  it('emits fixer-<slug>.json for missionClass=fixer', () => {
+    expect(generateFilename('Fix CrashLoopBackOff', 'fixer')).toBe('fixer-fix-crashloopbackoff.json')
+  })
+
+  it('collapses runs of non-alphanumeric characters into single hyphens', () => {
+    expect(generateFilename('Foo & Bar!! (v2)', 'fixer')).toBe('fixer-foo-bar-v2.json')
+  })
+
+  it('lower-cases uppercase input', () => {
+    expect(generateFilename('KUBERNETES SUPPORT', 'fixer')).toBe('fixer-kubernetes-support.json')
+  })
+
+  it('strips leading and trailing hyphens from the slug', () => {
+    expect(generateFilename('---edge case---', 'fixer')).toBe('fixer-edge-case.json')
+  })
+
+  it('caps the slug at 60 characters', () => {
+    const title = 'a'.repeat(200)
+    const out = generateFilename(title, 'fixer')
+    // "fixer-" prefix + 60 slug chars + ".json"
+    expect(out).toBe(`fixer-${'a'.repeat(60)}.json`)
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds Vitest coverage for five pure-logic modules extracted by scanner PR #21857 (mission components split), all previously untested and tracked by #21762:

| Module | Tests | Coverage highlights |
|---|---|---|
| `MissionDetailView.helpers.ts` | 9 | `extractCodeBlocks`: single fence, language tags, multiple blocks (per-block `before`; only last block gets `after`), whitespace trimming, empty input, empty body |
| `StandaloneOrbitDialog.helpers.ts` | 11 | `CADENCE_OPTIONS` order; `buildScopeString`: cluster-scoped vs namespaced, single/multi namespaces, missing namespaces field, `;`-joined multi-filter, multi-cluster line-per-cluster, empty-cluster skipping |
| `SubmitToKBDialog.helpers.ts` | 29 | KB repo constants, `CNCF_PROJECT_KEYWORDS`; `detectCNCFProject` operator/title/namespace/summary/steps precedence and case-insensitivity; `resolutionToKBFormat` install-vs-fixer type/category, troubleshooting entry rules, tags composition, optional `cncfProject`/`yaml`, mission.resolution omission when empty, `sharedBy`/`userId` author precedence, empty-summary title fallback; `generateFilename` slug rules incl. 60-char cap |
| `MissionLandingPage.constants.ts` | 11 | `FETCH_TIMEOUT_MS`, `MAX_PREVIEW_STEPS`, `TYPE_COLORS` coverage for all six types, `DEFAULT_TYPE_COLOR` alignment with `custom`, `TABS` order + per-tab `getSteps` rules with empty-mission fallback |
| `MissionLandingPage.api.ts` | 5 | `getPreferredPaths` routing: `install-*` → cncf-install + platform-install; `platform-*` → platform-install; other slugs → `cncf-generated/<project-hint>/` + security/troubleshoot/llm-d/multi-cluster fallbacks; whole-slug hint when no hyphen |

**Total: 65 new tests**, all passing locally (`npx vitest run <files>`).

All modules are pure functions — no fetch, no React DOM harness. The `fetchMissionBySlug` API function itself is not covered here (mocked-fetch tests can come later); `getPreferredPaths` covers its routing logic which is where the recent perf-critical rewrite lives.

Refs #21762

---
*Filed by quality agent (ACMM L4/L6 — full mode)*