### PR TITLE
[scanner] fix: split remediation and drilldown modal components

### DIFF
--- a/web/src/components/drilldown/DrillDownModal.parts.tsx
+++ b/web/src/components/drilldown/DrillDownModal.parts.tsx
@@ -1,0 +1,219 @@
+import { Component, type ReactNode, type ErrorInfo, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign, AlertTriangle, RefreshCw, HardDrive } from 'lucide-react'
+import { Button } from '../ui/Button'
+import { moveFocusByKey } from '../../lib/a11y/rovingFocus'
+import type { DrillDownView } from '../../hooks/useDrillDown.types'
+
+// Loading fallback for lazy-loaded drilldown views
+export function DrillDownLoading() {
+  return (
+    <div className="flex items-center justify-center h-64">
+      <div className="animate-spin rounded-full h-8 w-8 border-2 border-transparent border-t-primary" />
+    </div>
+  )
+}
+
+/**
+ * Error boundary for drilldown view content. Catches render errors within
+ * individual drilldown views and displays a recovery UI inside the modal
+ * instead of crashing the entire application with a blank screen.
+ */
+export class DrillDownErrorBoundary extends Component<
+  { children: ReactNode; onClose: () => void },
+  { hasError: boolean; error: Error | null }
+> {
+  constructor(props: { children: ReactNode; onClose: () => void }) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error) {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('[DrillDownErrorBoundary] Render error in drilldown view:', error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center h-64 text-center p-6">
+          <AlertTriangle className="w-10 h-10 text-yellow-400 mb-3" />
+          <h3 className="text-base font-semibold text-foreground mb-1">
+            Failed to load view
+          </h3>
+          <div className="text-sm text-muted-foreground mb-4 max-w-md">
+            An error occurred while rendering this drilldown view.
+          </div>
+          {this.state.error && (
+            <div className="text-xs text-muted-foreground/70 font-mono mb-4 break-all max-w-md">
+              {this.state.error.message}
+            </div>
+          )}
+          <div className="flex items-center gap-3">
+            <Button
+              onClick={() => this.setState({ hasError: false, error: null })}
+              variant="secondary"
+              size="sm"
+              icon={<RefreshCw className="w-3.5 h-3.5" />}
+            >
+              Retry
+            </Button>
+            <Button
+              onClick={this.props.onClose}
+              variant="secondary"
+              size="sm"
+            >
+              Close
+            </Button>
+          </div>
+        </div>
+      )
+    }
+    return this.props.children
+  }
+}
+
+// Helper to get status badge color for pods
+export const getPodStatusColor = (status: string) => {
+  const lower = status?.toLowerCase() || ''
+  if (lower === 'running') return 'bg-green-500/20 text-green-400'
+  if (lower === 'succeeded' || lower === 'completed') return 'bg-blue-500/20 text-blue-400'
+  if (lower === 'pending') return 'bg-yellow-500/20 text-yellow-400'
+  if (lower === 'failed' || lower === 'error' || lower === 'crashloopbackoff' || lower === 'evicted') return 'bg-red-500/20 text-red-400'
+  return 'bg-orange-500/20 text-orange-400'
+}
+
+// Helper to get icon for view type
+export const getViewIcon = (type: string) => {
+  switch (type) {
+    case 'pod': return <Box className="w-4 h-4 text-cyan-400" />
+    case 'cluster': return <Server className="w-4 h-4 text-blue-400" />
+    case 'namespace': return <Layers className="w-4 h-4 text-purple-400" />
+    case 'deployment': return <Rocket className="w-4 h-4 text-green-400" />
+    case 'replicaset': return <Layers className="w-4 h-4 text-blue-400" />
+    case 'configmap': return <FileText className="w-4 h-4 text-yellow-400" />
+    case 'secret': return <Lock className="w-4 h-4 text-red-400" />
+    case 'serviceaccount': return <User className="w-4 h-4 text-purple-400" />
+    case 'service': return <Layers className="w-4 h-4 text-cyan-400" />
+    case 'pvc': return <HardDrive className="w-4 h-4 text-green-400" />
+    case 'node': return <Cpu className="w-4 h-4 text-orange-400" />
+    case 'gpu-node': return <Cpu className="w-4 h-4 text-purple-400" />
+    case 'gpu-namespace': return <Box className="w-4 h-4 text-purple-400" />
+    case 'logs': return <FileText className="w-4 h-4 text-yellow-400" />
+    case 'events': return <Zap className="w-4 h-4 text-yellow-400" />
+    // Phase 2 view types
+    case 'alert': return <Bell className="w-4 h-4 text-red-400" />
+    case 'helm': return <Ship className="w-4 h-4 text-blue-400" />
+    case 'argoapp': return <GitBranch className="w-4 h-4 text-orange-400" />
+    case 'operator': return <Settings className="w-4 h-4 text-purple-400" />
+    case 'policy': return <Shield className="w-4 h-4 text-blue-400" />
+    case 'compliance': return <Shield className="w-4 h-4 text-teal-400" />
+    case 'kustomization': return <Layers className="w-4 h-4 text-blue-400" />
+    case 'buildpack': return <Package className="w-4 h-4 text-blue-400" />
+    case 'crd': return <Package className="w-4 h-4 text-purple-400" />
+    case 'drift': return <GitBranch className="w-4 h-4 text-orange-400" />
+    case 'cost': return <DollarSign className="w-4 h-4 text-green-400" />
+    // Multi-cluster summary views
+    case 'all-clusters': return <Server className="w-4 h-4 text-blue-400" />
+    case 'all-namespaces': return <Layers className="w-4 h-4 text-purple-400" />
+    case 'all-deployments': return <Rocket className="w-4 h-4 text-green-400" />
+    case 'all-pods': return <Box className="w-4 h-4 text-cyan-400" />
+    case 'all-services': return <Layers className="w-4 h-4 text-blue-400" />
+    case 'all-nodes': return <Server className="w-4 h-4 text-orange-400" />
+    case 'all-events': return <Zap className="w-4 h-4 text-yellow-400" />
+    case 'all-alerts': return <Bell className="w-4 h-4 text-red-400" />
+    case 'all-helm': return <Ship className="w-4 h-4 text-blue-400" />
+    case 'all-operators': return <Settings className="w-4 h-4 text-purple-400" />
+    case 'all-security': return <Shield className="w-4 h-4 text-red-400" />
+    case 'all-gpu': return <Cpu className="w-4 h-4 text-purple-400" />
+    case 'all-storage': return <Package className="w-4 h-4 text-green-400" />
+    case 'all-jobs': return <Rocket className="w-4 h-4 text-yellow-400" />
+    case 'quantum-credentials': return <Lock className="w-4 h-4 text-blue-400" />
+    default: return null
+  }
+}
+
+interface DrillDownBreadcrumbsProps {
+  stack: DrillDownView[]
+  goTo: (index: number) => void
+  navigationHistoryLabel: string
+  navigateToLabel: (title: string) => string
+}
+
+/** Renders the breadcrumb trail (with roving tab-list keyboard nav) in the modal header. */
+export function DrillDownBreadcrumbs({ stack, goTo, navigationHistoryLabel, navigateToLabel }: DrillDownBreadcrumbsProps) {
+  const handleBreadcrumbKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
+    const nextTab = moveFocusByKey(event, { selector: '[role="tab"]', orientation: 'horizontal' })
+    const nextIndex = Number(nextTab?.dataset.index)
+    if (!Number.isNaN(nextIndex)) {
+      goTo(nextIndex)
+    }
+  }
+
+  return (
+    <nav data-testid="drilldown-tabs" className="flex items-center gap-1 min-w-0 overflow-x-auto" role="tablist" aria-label={navigationHistoryLabel} onKeyDown={handleBreadcrumbKeyDown}>
+      {stack.map((view, index) => {
+        const isLast = index === stack.length - 1
+        const isPod = view.type === 'pod'
+        const podStatus = isPod && view.data?.status ? String(view.data.status) : null
+
+        return (
+          <div key={index} className="flex items-center gap-1 shrink-0">
+            {index > 0 && (
+              <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => goTo(index)}
+              id={`drilldown-tab-${index}`}
+              data-index={index}
+              role="tab"
+              tabIndex={isLast ? 0 : -1}
+              aria-selected={isLast}
+              aria-controls={`drilldown-panel-${index}`}
+              aria-label={navigateToLabel(view.title)}
+              className={isLast ? 'font-medium text-foreground' : 'text-muted-foreground hover:text-foreground'}
+            >
+              {getViewIcon(view.type)}
+              {view.title}
+            </Button>
+            {/* Pod status badge - small, inline */}
+            {isLast && podStatus && (
+              <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${getPodStatusColor(podStatus)}`}>
+                {podStatus}
+              </span>
+            )}
+          </div>
+        )
+      })}
+    </nav>
+  )
+}
+
+interface DrillDownFooterHintsProps {
+  showBackHint: boolean
+}
+
+/** Keyboard-shortcut hints shown at the bottom of the modal on non-mobile viewports. */
+export function DrillDownFooterHints({ showBackHint }: DrillDownFooterHintsProps) {
+  return (
+    <div className="px-4 py-2 border-t border-border flex items-center justify-end text-xs text-muted-foreground">
+      <div className="flex items-center gap-2">
+        <kbd className="px-2 py-0.5 rounded bg-card border border-border">Esc</kbd>
+        <span>close</span>
+        {showBackHint && (
+          <>
+            <span className="mx-1">•</span>
+            <kbd className="px-2 py-0.5 rounded bg-card border border-border">Space</kbd>
+            <span>back</span>
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/DrillDownModal.tsx
+++ b/web/src/components/drilldown/DrillDownModal.tsx
@@ -1,178 +1,12 @@
-import { Component, useEffect, Suspense, type ReactNode, type ErrorInfo, type KeyboardEvent as ReactKeyboardEvent } from 'react'
+import { useEffect, Suspense } from 'react'
 import { createPortal } from 'react-dom'
-import { safeLazy } from '../../lib/safeLazy'
 import { useTranslation } from 'react-i18next'
-import { Box, Server, Layers, Rocket, FileText, Zap, Cpu, Lock, User, Bell, Ship, GitBranch, Settings, Shield, Package, DollarSign, AlertTriangle, RefreshCw, HardDrive } from 'lucide-react'
 import { useDrillDown } from '../../hooks/useDrillDown'
 import { useMobile } from '../../hooks/useMobile'
 import { Button } from '../ui/Button'
 import { useEscapeLayer } from '../../lib/modals'
-import { moveFocusByKey } from '../../lib/a11y/rovingFocus'
-// Lazy load large components (>300 lines) for better performance
-const ClusterDrillDown = safeLazy(() => import('./views/ClusterDrillDown'), 'ClusterDrillDown')
-const OperatorDrillDown = safeLazy(() => import('./views/OperatorDrillDown'), 'OperatorDrillDown')
-const PolicyDrillDown = safeLazy(() => import('./views/PolicyDrillDown'), 'PolicyDrillDown')
-const PodDrillDown = safeLazy(() => import('./views/PodDrillDown'), 'PodDrillDown')
-const DeploymentDrillDown = safeLazy(() => import('./views/DeploymentDrillDown'), 'DeploymentDrillDown')
-const MultiClusterSummaryDrillDown = safeLazy(() => import('./views/MultiClusterSummaryDrillDown'), 'MultiClusterSummaryDrillDown')
-const ReplicaSetDrillDown = safeLazy(() => import('./views/ReplicaSetDrillDown'), 'ReplicaSetDrillDown')
-const SecretDrillDown = safeLazy(() => import('./views/SecretDrillDown'), 'SecretDrillDown')
-const KustomizationDrillDown = safeLazy(() => import('./views/KustomizationDrillDown'), 'KustomizationDrillDown')
-const AlertDrillDown = safeLazy(() => import('./views/AlertDrillDown'), 'AlertDrillDown')
-const DriftDrillDown = safeLazy(() => import('./views/DriftDrillDown'), 'DriftDrillDown')
-const CRDDrillDown = safeLazy(() => import('./views/CRDDrillDown'), 'CRDDrillDown')
-const ResourcesDrillDown = safeLazy(() => import('./views/ResourcesDrillDown'), 'ResourcesDrillDown')
-const ServiceAccountDrillDown = safeLazy(() => import('./views/ServiceAccountDrillDown'), 'ServiceAccountDrillDown')
-const ArgoAppDrillDown = safeLazy(() => import('./views/ArgoAppDrillDown'), 'ArgoAppDrillDown')
-const HelmReleaseDrillDown = safeLazy(() => import('./views/HelmReleaseDrillDown'), 'HelmReleaseDrillDown')
-const ConfigMapDrillDown = safeLazy(() => import('./views/ConfigMapDrillDown'), 'ConfigMapDrillDown')
-const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 'BuildpackDrillDown')
-const ServiceDrillDown = safeLazy(() => import('./views/ServiceDrillDown'), 'default')
-const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
-const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
-const ComplianceDrillDown = safeLazy(() => import('./views/ComplianceDrillDown'), 'ComplianceDrillDown')
-const PVCDrillDown = safeLazy(() => import('./views/PVCDrillDown'), 'PVCDrillDown')
-const QuantumCredentialsDrillDown = safeLazy(() => import('./views/quantum/QuantumCredentialsDrillDown'), 'QuantumCredentialsDrillDown')
-
-const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'EventsDrillDown')
-
-const NamespaceDrillDown = safeLazy(() => import('./views/NamespaceDrillDown'), 'NamespaceDrillDown')
-const NodeDrillDown = safeLazy(() => import('./views/NodeDrillDown'), 'NodeDrillDown')
-const GPUNamespaceDrillDown = safeLazy(() => import('./views/GPUNamespaceDrillDown'), 'GPUNamespaceDrillDown')
-const LogsDrillDown = safeLazy(() => import('./views/LogsDrillDown'), 'LogsDrillDown')
-const GPUNodeDrillDown = safeLazy(() => import('./views/GPUNodeDrillDown'), 'GPUNodeDrillDown')
-const YAMLDrillDown = safeLazy(() => import('./views/YAMLDrillDown'), 'YAMLDrillDown')
-
-// Loading fallback for lazy-loaded drilldown views
-function DrillDownLoading() {
-  return (
-    <div className="flex items-center justify-center h-64">
-      <div className="animate-spin rounded-full h-8 w-8 border-2 border-transparent border-t-primary" />
-    </div>
-  )
-}
-
-/**
- * Error boundary for drilldown view content. Catches render errors within
- * individual drilldown views and displays a recovery UI inside the modal
- * instead of crashing the entire application with a blank screen.
- */
-class DrillDownErrorBoundary extends Component<
-  { children: ReactNode; onClose: () => void },
-  { hasError: boolean; error: Error | null }
-> {
-  constructor(props: { children: ReactNode; onClose: () => void }) {
-    super(props)
-    this.state = { hasError: false, error: null }
-  }
-
-  static getDerivedStateFromError(error: Error) {
-    return { hasError: true, error }
-  }
-
-  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
-    console.error('[DrillDownErrorBoundary] Render error in drilldown view:', error, errorInfo)
-  }
-
-  render() {
-    if (this.state.hasError) {
-      return (
-        <div className="flex flex-col items-center justify-center h-64 text-center p-6">
-          <AlertTriangle className="w-10 h-10 text-yellow-400 mb-3" />
-          <h3 className="text-base font-semibold text-foreground mb-1">
-            Failed to load view
-          </h3>
-          <div className="text-sm text-muted-foreground mb-4 max-w-md">
-            An error occurred while rendering this drilldown view.
-          </div>
-          {this.state.error && (
-            <div className="text-xs text-muted-foreground/70 font-mono mb-4 break-all max-w-md">
-              {this.state.error.message}
-            </div>
-          )}
-          <div className="flex items-center gap-3">
-            <Button
-              onClick={() => this.setState({ hasError: false, error: null })}
-              variant="secondary"
-              size="sm"
-              icon={<RefreshCw className="w-3.5 h-3.5" />}
-            >
-              Retry
-            </Button>
-            <Button
-              onClick={this.props.onClose}
-              variant="secondary"
-              size="sm"
-            >
-              Close
-            </Button>
-          </div>
-        </div>
-      )
-    }
-    return this.props.children
-  }
-}
-
-// Helper to get status badge color for pods
-const getPodStatusColor = (status: string) => {
-  const lower = status?.toLowerCase() || ''
-  if (lower === 'running') return 'bg-green-500/20 text-green-400'
-  if (lower === 'succeeded' || lower === 'completed') return 'bg-blue-500/20 text-blue-400'
-  if (lower === 'pending') return 'bg-yellow-500/20 text-yellow-400'
-  if (lower === 'failed' || lower === 'error' || lower === 'crashloopbackoff' || lower === 'evicted') return 'bg-red-500/20 text-red-400'
-  return 'bg-orange-500/20 text-orange-400'
-}
-
-// Helper to get icon for view type
-const getViewIcon = (type: string) => {
-  switch (type) {
-    case 'pod': return <Box className="w-4 h-4 text-cyan-400" />
-    case 'cluster': return <Server className="w-4 h-4 text-blue-400" />
-    case 'namespace': return <Layers className="w-4 h-4 text-purple-400" />
-    case 'deployment': return <Rocket className="w-4 h-4 text-green-400" />
-    case 'replicaset': return <Layers className="w-4 h-4 text-blue-400" />
-    case 'configmap': return <FileText className="w-4 h-4 text-yellow-400" />
-    case 'secret': return <Lock className="w-4 h-4 text-red-400" />
-    case 'serviceaccount': return <User className="w-4 h-4 text-purple-400" />
-    case 'service': return <Layers className="w-4 h-4 text-cyan-400" />
-    case 'pvc': return <HardDrive className="w-4 h-4 text-green-400" />
-    case 'node': return <Cpu className="w-4 h-4 text-orange-400" />
-    case 'gpu-node': return <Cpu className="w-4 h-4 text-purple-400" />
-    case 'gpu-namespace': return <Box className="w-4 h-4 text-purple-400" />
-    case 'logs': return <FileText className="w-4 h-4 text-yellow-400" />
-    case 'events': return <Zap className="w-4 h-4 text-yellow-400" />
-    // Phase 2 view types
-    case 'alert': return <Bell className="w-4 h-4 text-red-400" />
-    case 'helm': return <Ship className="w-4 h-4 text-blue-400" />
-    case 'argoapp': return <GitBranch className="w-4 h-4 text-orange-400" />
-    case 'operator': return <Settings className="w-4 h-4 text-purple-400" />
-    case 'policy': return <Shield className="w-4 h-4 text-blue-400" />
-    case 'compliance': return <Shield className="w-4 h-4 text-teal-400" />
-    case 'kustomization': return <Layers className="w-4 h-4 text-blue-400" />
-    case 'buildpack': return <Package className="w-4 h-4 text-blue-400" />
-    case 'crd': return <Package className="w-4 h-4 text-purple-400" />
-    case 'drift': return <GitBranch className="w-4 h-4 text-orange-400" />
-    case 'cost': return <DollarSign className="w-4 h-4 text-green-400" />
-    // Multi-cluster summary views
-    case 'all-clusters': return <Server className="w-4 h-4 text-blue-400" />
-    case 'all-namespaces': return <Layers className="w-4 h-4 text-purple-400" />
-    case 'all-deployments': return <Rocket className="w-4 h-4 text-green-400" />
-    case 'all-pods': return <Box className="w-4 h-4 text-cyan-400" />
-    case 'all-services': return <Layers className="w-4 h-4 text-blue-400" />
-    case 'all-nodes': return <Server className="w-4 h-4 text-orange-400" />
-    case 'all-events': return <Zap className="w-4 h-4 text-yellow-400" />
-    case 'all-alerts': return <Bell className="w-4 h-4 text-red-400" />
-    case 'all-helm': return <Ship className="w-4 h-4 text-blue-400" />
-    case 'all-operators': return <Settings className="w-4 h-4 text-purple-400" />
-    case 'all-security': return <Shield className="w-4 h-4 text-red-400" />
-    case 'all-gpu': return <Cpu className="w-4 h-4 text-purple-400" />
-    case 'all-storage': return <Package className="w-4 h-4 text-green-400" />
-    case 'all-jobs': return <Rocket className="w-4 h-4 text-yellow-400" />
-    case 'quantum-credentials': return <Lock className="w-4 h-4 text-blue-400" />
-    default: return null
-  }
-}
+import { renderDrillDownView } from './DrillDownModal.views'
+import { DrillDownLoading, DrillDownErrorBoundary, DrillDownBreadcrumbs, DrillDownFooterHints } from './DrillDownModal.parts'
 
 export function DrillDownModal() {
   const { t } = useTranslation()
@@ -231,102 +65,6 @@ export function DrillDownModal() {
 
   // Get current view - we've already checked it's not null above
   const currentView = state.currentView
-  const { type, data } = currentView
-
-  const renderView = () => {
-    switch (type) {
-      case 'cluster':
-        return <ClusterDrillDown data={data} />
-      case 'namespace':
-        return <NamespaceDrillDown data={data} />
-      case 'deployment':
-        return <DeploymentDrillDown data={data} />
-      case 'replicaset':
-        return <ReplicaSetDrillDown data={data} />
-      case 'pod':
-        return <PodDrillDown data={data} />
-      case 'logs':
-        return <LogsDrillDown data={data} />
-      case 'events':
-        return <EventsDrillDown data={data} />
-      case 'node':
-        return <NodeDrillDown data={data} />
-      case 'gpu-node':
-        return <GPUNodeDrillDown data={data} />
-      case 'gpu-namespace':
-        return <GPUNamespaceDrillDown data={data} />
-      case 'yaml':
-        return <YAMLDrillDown data={data} />
-      case 'resources':
-        return <ResourcesDrillDown data={data} />
-      case 'configmap':
-        return <ConfigMapDrillDown data={data} />
-      case 'secret':
-        return <SecretDrillDown data={data} />
-      case 'serviceaccount':
-        return <ServiceAccountDrillDown data={data} />
-      case 'pvc':
-        return <PVCDrillDown data={data} />
-      case 'service':
-        return <ServiceDrillDown data={data} />
-      // Phase 2 views
-      case 'alert':
-        return <AlertDrillDown data={data} />
-      case 'helm':
-        return <HelmReleaseDrillDown data={data} />
-      case 'argoapp':
-        return <ArgoAppDrillDown data={data} />
-      case 'operator':
-        return <OperatorDrillDown data={data} />
-      case 'policy':
-        return <PolicyDrillDown data={data} />
-      case 'compliance':
-        return <ComplianceDrillDown data={data} />
-      case 'kustomization':
-        return <KustomizationDrillDown data={data} />
-      case 'buildpack':
-        return <BuildpackDrillDown data={data} />
-
-      case 'crd':
-        return <CRDDrillDown data={data} />
-      case 'drift':
-        return <DriftDrillDown data={data} />
-      case 'rbac':
-        return <RBACDrillDown data={data} />
-      case 'cost':
-        return <CostDrillDown data={data} />
-      // Multi-cluster summary views
-      case 'all-clusters':
-      case 'all-namespaces':
-      case 'all-deployments':
-      case 'all-pods':
-      case 'all-services':
-      case 'all-nodes':
-      case 'all-events':
-      case 'all-alerts':
-      case 'all-helm':
-      case 'all-operators':
-      case 'all-security':
-      case 'all-gpu':
-      case 'all-storage':
-      case 'all-jobs':
-        return <MultiClusterSummaryDrillDown data={data} viewType={type} />
-      case 'custom':
-        return state.currentView?.customComponent || <div>{t('drilldown.customView')}</div>
-      case 'quantum-credentials':
-        return <QuantumCredentialsDrillDown data={data} />
-      default:
-        return <div>{t('drilldown.unknownViewType')}</div>
-    }
-  }
-
-  const handleBreadcrumbKeyDown = (event: ReactKeyboardEvent<HTMLElement>) => {
-    const nextTab = moveFocusByKey(event, { selector: '[role="tab"]', orientation: 'horizontal' })
-    const nextIndex = Number(nextTab?.dataset.index)
-    if (!Number.isNaN(nextIndex)) {
-      goTo(nextIndex)
-    }
-  }
 
   // Render the modal at document.body so it sits after the Layout sidebar
   // in DOM order. Both the sidebar and drill-down use z-modal; with equal
@@ -375,45 +113,12 @@ export function DrillDownModal() {
             </Button>
 
             {/* Breadcrumbs */}
-            <nav data-testid="drilldown-tabs" className="flex items-center gap-1 min-w-0 overflow-x-auto" role="tablist" aria-label={t('drilldown.navigationHistory', 'Navigation history')} onKeyDown={handleBreadcrumbKeyDown}>
-              {state.stack.map((view, index) => {
-                const isLast = index === state.stack.length - 1
-                const isPod = view.type === 'pod'
-                const podStatus = isPod && view.data?.status ? String(view.data.status) : null
-
-                return (
-                  <div key={index} className="flex items-center gap-1 shrink-0">
-                    {index > 0 && (
-                      <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                      </svg>
-                    )}
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => goTo(index)}
-                      id={`drilldown-tab-${index}`}
-                      data-index={index}
-                      role="tab"
-                      tabIndex={isLast ? 0 : -1}
-                      aria-selected={isLast}
-                      aria-controls={`drilldown-panel-${index}`}
-                      aria-label={t('drilldown.navigateTo', 'Navigate to {{title}}', { title: view.title })}
-                      className={isLast ? 'font-medium text-foreground' : 'text-muted-foreground hover:text-foreground'}
-                    >
-                      {getViewIcon(view.type)}
-                      {view.title}
-                    </Button>
-                    {/* Pod status badge - small, inline */}
-                    {isLast && podStatus && (
-                      <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${getPodStatusColor(podStatus)}`}>
-                        {podStatus}
-                      </span>
-                    )}
-                  </div>
-                )
-              })}
-            </nav>
+            <DrillDownBreadcrumbs
+              stack={state.stack}
+              goTo={goTo}
+              navigationHistoryLabel={t('drilldown.navigationHistory', 'Navigation history')}
+              navigateToLabel={(title) => t('drilldown.navigateTo', 'Navigate to {{title}}', { title })}
+            />
           </div>
 
           {/* Close button */}
@@ -435,27 +140,13 @@ export function DrillDownModal() {
         <div id={`drilldown-panel-${state.stack.length - 1}`} role="tabpanel" tabIndex={0} aria-labelledby={`drilldown-tab-${state.stack.length - 1}`} className="flex-1 overflow-y-auto p-4 md:p-6">
           <DrillDownErrorBoundary onClose={close}>
             <Suspense fallback={<DrillDownLoading />}>
-              {renderView()}
+              {renderDrillDownView(currentView, t('drilldown.unknownViewType'), t('drilldown.customView'))}
             </Suspense>
           </DrillDownErrorBoundary>
         </div>
 
         {/* Footer with keyboard hints - hidden on mobile */}
-        {!isMobile && (
-          <div className="px-4 py-2 border-t border-border flex items-center justify-end text-xs text-muted-foreground">
-            <div className="flex items-center gap-2">
-              <kbd className="px-2 py-0.5 rounded bg-card border border-border">Esc</kbd>
-              <span>close</span>
-              {state.stack.length > 1 && (
-                <>
-                  <span className="mx-1">•</span>
-                  <kbd className="px-2 py-0.5 rounded bg-card border border-border">Space</kbd>
-                  <span>back</span>
-                </>
-              )}
-            </div>
-          </div>
-        )}
+        {!isMobile && <DrillDownFooterHints showBackHint={state.stack.length > 1} />}
       </div>
     </div>,
     document.body

--- a/web/src/components/drilldown/DrillDownModal.views.tsx
+++ b/web/src/components/drilldown/DrillDownModal.views.tsx
@@ -1,0 +1,133 @@
+import { safeLazy } from '../../lib/safeLazy'
+import type { ReactNode } from 'react'
+import type { DrillDownView } from '../../hooks/useDrillDown.types'
+
+// Lazy load large components (>300 lines) for better performance
+const ClusterDrillDown = safeLazy(() => import('./views/ClusterDrillDown'), 'ClusterDrillDown')
+const OperatorDrillDown = safeLazy(() => import('./views/OperatorDrillDown'), 'OperatorDrillDown')
+const PolicyDrillDown = safeLazy(() => import('./views/PolicyDrillDown'), 'PolicyDrillDown')
+const PodDrillDown = safeLazy(() => import('./views/PodDrillDown'), 'PodDrillDown')
+const DeploymentDrillDown = safeLazy(() => import('./views/DeploymentDrillDown'), 'DeploymentDrillDown')
+const MultiClusterSummaryDrillDown = safeLazy(() => import('./views/MultiClusterSummaryDrillDown'), 'MultiClusterSummaryDrillDown')
+const ReplicaSetDrillDown = safeLazy(() => import('./views/ReplicaSetDrillDown'), 'ReplicaSetDrillDown')
+const SecretDrillDown = safeLazy(() => import('./views/SecretDrillDown'), 'SecretDrillDown')
+const KustomizationDrillDown = safeLazy(() => import('./views/KustomizationDrillDown'), 'KustomizationDrillDown')
+const AlertDrillDown = safeLazy(() => import('./views/AlertDrillDown'), 'AlertDrillDown')
+const DriftDrillDown = safeLazy(() => import('./views/DriftDrillDown'), 'DriftDrillDown')
+const CRDDrillDown = safeLazy(() => import('./views/CRDDrillDown'), 'CRDDrillDown')
+const ResourcesDrillDown = safeLazy(() => import('./views/ResourcesDrillDown'), 'ResourcesDrillDown')
+const ServiceAccountDrillDown = safeLazy(() => import('./views/ServiceAccountDrillDown'), 'ServiceAccountDrillDown')
+const ArgoAppDrillDown = safeLazy(() => import('./views/ArgoAppDrillDown'), 'ArgoAppDrillDown')
+const HelmReleaseDrillDown = safeLazy(() => import('./views/HelmReleaseDrillDown'), 'HelmReleaseDrillDown')
+const ConfigMapDrillDown = safeLazy(() => import('./views/ConfigMapDrillDown'), 'ConfigMapDrillDown')
+const BuildpackDrillDown = safeLazy(() => import('./views/BuildpackDrillDown'), 'BuildpackDrillDown')
+const ServiceDrillDown = safeLazy(() => import('./views/ServiceDrillDown'), 'default')
+const RBACDrillDown = safeLazy(() => import('./views/RBACDrillDown'), 'RBACDrillDown')
+const CostDrillDown = safeLazy(() => import('./views/CostDrillDown'), 'CostDrillDown')
+const ComplianceDrillDown = safeLazy(() => import('./views/ComplianceDrillDown'), 'ComplianceDrillDown')
+const PVCDrillDown = safeLazy(() => import('./views/PVCDrillDown'), 'PVCDrillDown')
+const QuantumCredentialsDrillDown = safeLazy(() => import('./views/quantum/QuantumCredentialsDrillDown'), 'QuantumCredentialsDrillDown')
+
+const EventsDrillDown = safeLazy(() => import('./views/EventsDrillDown'), 'EventsDrillDown')
+
+const NamespaceDrillDown = safeLazy(() => import('./views/NamespaceDrillDown'), 'NamespaceDrillDown')
+const NodeDrillDown = safeLazy(() => import('./views/NodeDrillDown'), 'NodeDrillDown')
+const GPUNamespaceDrillDown = safeLazy(() => import('./views/GPUNamespaceDrillDown'), 'GPUNamespaceDrillDown')
+const LogsDrillDown = safeLazy(() => import('./views/LogsDrillDown'), 'LogsDrillDown')
+const GPUNodeDrillDown = safeLazy(() => import('./views/GPUNodeDrillDown'), 'GPUNodeDrillDown')
+const YAMLDrillDown = safeLazy(() => import('./views/YAMLDrillDown'), 'YAMLDrillDown')
+
+type DrillDownViewLike = DrillDownView
+
+/**
+ * Maps a drill-down view type to its rendered component. Extracted from
+ * DrillDownModal so the lazy-import registry and routing switch can evolve
+ * independently of the modal chrome (header/breadcrumbs/footer).
+ */
+export function renderDrillDownView(currentView: DrillDownViewLike, unknownViewLabel: string, customViewLabel: string): ReactNode {
+  const { type, data } = currentView
+  switch (type) {
+    case 'cluster':
+      return <ClusterDrillDown data={data} />
+    case 'namespace':
+      return <NamespaceDrillDown data={data} />
+    case 'deployment':
+      return <DeploymentDrillDown data={data} />
+    case 'replicaset':
+      return <ReplicaSetDrillDown data={data} />
+    case 'pod':
+      return <PodDrillDown data={data} />
+    case 'logs':
+      return <LogsDrillDown data={data} />
+    case 'events':
+      return <EventsDrillDown data={data} />
+    case 'node':
+      return <NodeDrillDown data={data} />
+    case 'gpu-node':
+      return <GPUNodeDrillDown data={data} />
+    case 'gpu-namespace':
+      return <GPUNamespaceDrillDown data={data} />
+    case 'yaml':
+      return <YAMLDrillDown data={data} />
+    case 'resources':
+      return <ResourcesDrillDown data={data} />
+    case 'configmap':
+      return <ConfigMapDrillDown data={data} />
+    case 'secret':
+      return <SecretDrillDown data={data} />
+    case 'serviceaccount':
+      return <ServiceAccountDrillDown data={data} />
+    case 'pvc':
+      return <PVCDrillDown data={data} />
+    case 'service':
+      return <ServiceDrillDown data={data} />
+    // Phase 2 views
+    case 'alert':
+      return <AlertDrillDown data={data} />
+    case 'helm':
+      return <HelmReleaseDrillDown data={data} />
+    case 'argoapp':
+      return <ArgoAppDrillDown data={data} />
+    case 'operator':
+      return <OperatorDrillDown data={data} />
+    case 'policy':
+      return <PolicyDrillDown data={data} />
+    case 'compliance':
+      return <ComplianceDrillDown data={data} />
+    case 'kustomization':
+      return <KustomizationDrillDown data={data} />
+    case 'buildpack':
+      return <BuildpackDrillDown data={data} />
+
+    case 'crd':
+      return <CRDDrillDown data={data} />
+    case 'drift':
+      return <DriftDrillDown data={data} />
+    case 'rbac':
+      return <RBACDrillDown data={data} />
+    case 'cost':
+      return <CostDrillDown data={data} />
+    // Multi-cluster summary views
+    case 'all-clusters':
+    case 'all-namespaces':
+    case 'all-deployments':
+    case 'all-pods':
+    case 'all-services':
+    case 'all-nodes':
+    case 'all-events':
+    case 'all-alerts':
+    case 'all-helm':
+    case 'all-operators':
+    case 'all-security':
+    case 'all-gpu':
+    case 'all-storage':
+    case 'all-jobs':
+      return <MultiClusterSummaryDrillDown data={data} viewType={type} />
+    case 'custom':
+      return currentView.customComponent || <div>{customViewLabel}</div>
+    case 'quantum-credentials':
+      return <QuantumCredentialsDrillDown data={data} />
+    default:
+      return <div>{unknownViewLabel}</div>
+  }
+}

--- a/web/src/components/drilldown/RemediationConsole.parts.tsx
+++ b/web/src/components/drilldown/RemediationConsole.parts.tsx
@@ -1,4 +1,5 @@
 import { KeyboardEvent, RefObject } from 'react'
+import type { TFunction } from 'i18next'
 import { Sparkles, X, Play, Pause, CheckCircle, Loader2, Copy, Download, Terminal, Send, AlertTriangle, RefreshCw } from 'lucide-react'
 import { cn } from '../../lib/cn'
 import { Button } from '../ui/Button'
@@ -28,7 +29,7 @@ interface RemediationHeaderProps {
   resourceName: string
   onClose: () => void
   titleId: string
-  t: (key: string, opts?: Record<string, unknown>) => string
+  t: TFunction
 }
 
 export function RemediationHeader({ activeTab, resourceType, resourceName, onClose, titleId, t }: RemediationHeaderProps) {
@@ -70,9 +71,9 @@ interface RemediationTabsProps {
   tabListProps: TabKeyboardNav['tabListProps']
   getTabProps: TabKeyboardNav['getTabProps']
   setActiveTab: (tab: 'ai' | 'shell') => void
-  shellInputRef: RefObject<HTMLInputElement>
+  shellInputRef: RefObject<HTMLInputElement | null>
   focusDelayMs: number
-  t: (key: string) => string
+  t: TFunction
 }
 
 export function RemediationTabs({ activeTab, tabListProps, getTabProps, setActiveTab, shellInputRef, focusDelayMs, t }: RemediationTabsProps) {
@@ -116,8 +117,8 @@ interface RemediationAiOutputProps {
   logs: LogEntry[]
   isLoadingInitialData: boolean
   isRunning: boolean
-  logsEndRef: RefObject<HTMLDivElement>
-  t: (key: string) => string
+  logsEndRef: RefObject<HTMLDivElement | null>
+  t: TFunction
 }
 
 export function RemediationAiOutput({ logs, isLoadingInitialData, isRunning, logsEndRef, t }: RemediationAiOutputProps) {
@@ -200,8 +201,8 @@ interface RemediationShellOutputProps {
   quickCommands: Array<{ label: string; cmd: string }>
   executeCommand: (cmd: string) => void
   isExecuting: boolean
-  logsEndRef: RefObject<HTMLDivElement>
-  t: (key: string) => string
+  logsEndRef: RefObject<HTMLDivElement | null>
+  t: TFunction
 }
 
 export function RemediationShellOutput({ logs, cluster, namespace, quickCommands, executeCommand, isExecuting, logsEndRef, t }: RemediationShellOutputProps) {
@@ -262,11 +263,11 @@ interface RemediationShellInputProps {
   lastFailedCommand: string
   executeCommand: (cmd: string) => void
   isExecuting: boolean
-  shellInputRef: RefObject<HTMLInputElement>
+  shellInputRef: RefObject<HTMLInputElement | null>
   shellCommand: string
   updateShell: (patch: { command: string }) => void
   handleShellKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void
-  t: (key: string) => string
+  t: TFunction
 }
 
 export function RemediationShellInput({
@@ -351,7 +352,7 @@ interface RemediationFooterProps {
   logs: LogEntry[]
   copyLogs: () => void
   downloadLogs: () => void
-  t: (key: string) => string
+  t: TFunction
 }
 
 export function RemediationFooter({

--- a/web/src/components/drilldown/RemediationConsole.parts.tsx
+++ b/web/src/components/drilldown/RemediationConsole.parts.tsx
@@ -1,0 +1,460 @@
+import { KeyboardEvent, RefObject } from 'react'
+import { Sparkles, X, Play, Pause, CheckCircle, Loader2, Copy, Download, Terminal, Send, AlertTriangle, RefreshCw } from 'lucide-react'
+import { cn } from '../../lib/cn'
+import { Button } from '../ui/Button'
+import type { useTabKeyboardNav } from '../../hooks/useKeyboardNav'
+import type { LogEntry } from './RemediationConsole.types'
+
+type TabKeyboardNav = ReturnType<typeof useTabKeyboardNav<'ai' | 'shell'>>
+
+/** Handles Enter/Space activation for div-based "button" elements used throughout this console. */
+export function handleButtonLikeKeyDown(
+  event: KeyboardEvent<HTMLElement>,
+  action: () => void,
+  disabled = false,
+) {
+  if (disabled) {
+    return
+  }
+  if (event.key === 'Enter' || event.key === ' ') {
+    event.preventDefault()
+    action()
+  }
+}
+
+interface RemediationHeaderProps {
+  activeTab: 'ai' | 'shell'
+  resourceType: string
+  resourceName: string
+  onClose: () => void
+  titleId: string
+  t: (key: string, opts?: Record<string, unknown>) => string
+}
+
+export function RemediationHeader({ activeTab, resourceType, resourceName, onClose, titleId, t }: RemediationHeaderProps) {
+  return (
+    <div className="flex items-center justify-between p-4 border-b border-border">
+      <div className="flex items-center gap-3">
+        <div className="p-2 rounded-lg bg-purple-500/20">
+          {activeTab === 'ai' ? (
+            <Sparkles className="w-5 h-5 text-purple-400" />
+          ) : (
+            <Terminal className="w-5 h-5 text-green-400" />
+          )}
+        </div>
+        <div>
+          <h2 id={titleId} className="font-semibold text-foreground">
+            {activeTab === 'ai' ? t('remediation.title') : t('remediation.shellTitle')}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t('remediation.resourceType', { type: resourceType, name: resourceName })}
+          </p>
+        </div>
+      </div>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={onClose}
+        onKeyDown={(event) => handleButtonLikeKeyDown(event, onClose)}
+        aria-label="Close"
+        className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground cursor-pointer"
+      >
+        <X className="w-5 h-5" />
+      </div>
+    </div>
+  )
+}
+
+interface RemediationTabsProps {
+  activeTab: 'ai' | 'shell'
+  tabListProps: TabKeyboardNav['tabListProps']
+  getTabProps: TabKeyboardNav['getTabProps']
+  setActiveTab: (tab: 'ai' | 'shell') => void
+  shellInputRef: RefObject<HTMLInputElement>
+  focusDelayMs: number
+  t: (key: string) => string
+}
+
+export function RemediationTabs({ activeTab, tabListProps, getTabProps, setActiveTab, shellInputRef, focusDelayMs, t }: RemediationTabsProps) {
+  return (
+    <div {...tabListProps} className="flex border-b border-border">
+      <button
+        {...getTabProps('ai')}
+        aria-label={t('remediation.aiAnalysis')}
+        className={cn(
+          'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors cursor-pointer',
+          activeTab === 'ai'
+            ? 'text-purple-400 border-b-2 border-purple-500'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+      >
+        <Sparkles className="w-4 h-4" />
+        {t('remediation.aiAnalysis')}
+      </button>
+      <button
+        {...getTabProps('shell')}
+        onClick={() => {
+          setActiveTab('shell')
+          setTimeout(() => shellInputRef.current?.focus(), focusDelayMs)
+        }}
+        aria-label={t('remediation.shell')}
+        className={cn(
+          'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors cursor-pointer',
+          activeTab === 'shell'
+            ? 'text-green-400 border-b-2 border-green-500'
+            : 'text-muted-foreground hover:text-foreground'
+        )}
+      >
+        <Terminal className="w-4 h-4" />
+        {t('remediation.shell')}
+      </button>
+    </div>
+  )
+}
+
+interface RemediationAiOutputProps {
+  logs: LogEntry[]
+  isLoadingInitialData: boolean
+  isRunning: boolean
+  logsEndRef: RefObject<HTMLDivElement>
+  t: (key: string) => string
+}
+
+export function RemediationAiOutput({ logs, isLoadingInitialData, isRunning, logsEndRef, t }: RemediationAiOutputProps) {
+  if (logs.length === 0) {
+    return (
+      <div className="text-center py-12 text-muted-foreground">
+        {isLoadingInitialData ? (
+          <>
+            <Loader2 className="w-12 h-12 mx-auto mb-4 animate-spin opacity-50" />
+            <p>{t('remediation.gatheringData')}</p>
+          </>
+        ) : (
+          <>
+            <Sparkles className="w-12 h-12 mx-auto mb-4 opacity-50" />
+            <p>{t('remediation.clickStart')}</p>
+            <p className="text-xs mt-2">{t('remediation.claudeWillAnalyze')}</p>
+          </>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {logs.filter(l => l.type !== 'command' && l.type !== 'output').map(log => (
+        <div key={log.id} className="flex gap-3">
+          <span className="text-muted-foreground text-xs whitespace-nowrap">
+            {log.timestamp.toLocaleTimeString()}
+          </span>
+          <div className="flex-1">
+            <div className="flex items-start gap-2">
+              {log.type === 'thinking' && (
+                <span className="text-purple-400">🤔</span>
+              )}
+              {log.type === 'action' && (
+                <span className="text-blue-400">⚡</span>
+              )}
+              {log.type === 'result' && (
+                <span className="text-green-400">✅</span>
+              )}
+              {log.type === 'error' && (
+                <span className="text-red-400">❌</span>
+              )}
+              {log.type === 'info' && (
+                <span className="text-muted-foreground">ℹ️</span>
+              )}
+              <span className={cn(
+                log.type === 'thinking' && 'text-purple-300',
+                log.type === 'action' && 'text-blue-300',
+                log.type === 'result' && 'text-green-300',
+                log.type === 'error' && 'text-red-300',
+                log.type === 'info' && 'text-muted-foreground',
+              )}>
+                {log.message}
+              </span>
+            </div>
+            {log.details && (
+              <pre className="mt-1 ml-6 p-2 rounded bg-black/50 text-xs text-yellow-300 overflow-x-auto">
+                {log.details}
+              </pre>
+            )}
+          </div>
+        </div>
+      ))}
+      {isRunning && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span>{t('common.processing')}</span>
+        </div>
+      )}
+      <div ref={logsEndRef} />
+    </div>
+  )
+}
+
+interface RemediationShellOutputProps {
+  logs: LogEntry[]
+  cluster: string
+  namespace: string
+  quickCommands: Array<{ label: string; cmd: string }>
+  executeCommand: (cmd: string) => void
+  isExecuting: boolean
+  logsEndRef: RefObject<HTMLDivElement>
+  t: (key: string) => string
+}
+
+export function RemediationShellOutput({ logs, cluster, namespace, quickCommands, executeCommand, isExecuting, logsEndRef, t }: RemediationShellOutputProps) {
+  const shellLogs = logs.filter(l => l.type === 'command' || l.type === 'output' || l.type === 'error')
+
+  return (
+    <div className="space-y-2">
+      {/* Quick commands */}
+      <div className="flex flex-wrap gap-2 mb-4 pb-4 border-b border-border/30">
+        {quickCommands.map((qc, i) => (
+          <Button
+            key={i}
+            variant="ghost"
+            size="sm"
+            onClick={() => executeCommand(qc.cmd)}
+            disabled={isExecuting}
+            className="bg-card/50 border border-border hover:border-green-500/50"
+          >
+            {qc.label}
+          </Button>
+        ))}
+      </div>
+
+      {/* Shell output */}
+      {shellLogs.length === 0 ? (
+        <div className="text-muted-foreground">
+          <p className="mb-2">{t('remediation.welcomeShell')}</p>
+          <p className="text-xs">{t('remediation.clusterContext')} <span className="text-green-400">{cluster}</span></p>
+          <p className="text-xs">{t('remediation.namespaceContext')} <span className="text-green-400">{namespace}</span></p>
+          <p className="text-xs mt-4">{t('remediation.typeKubectl')}</p>
+        </div>
+      ) : (
+        shellLogs.map(log => (
+          <div key={log.id}>
+            {log.type === 'command' ? (
+              <div className="text-green-400">{log.message}</div>
+            ) : log.type === 'error' ? (
+              <pre className="text-red-400 whitespace-pre-wrap">{log.message}</pre>
+            ) : (
+              <pre className="text-muted-foreground whitespace-pre-wrap">{log.message}</pre>
+            )}
+          </div>
+        ))
+      )}
+      {isExecuting && (
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span>{t('common.executing')}</span>
+        </div>
+      )}
+      <div ref={logsEndRef} />
+    </div>
+  )
+}
+
+interface RemediationShellInputProps {
+  shellError: string | null
+  lastFailedCommand: string
+  executeCommand: (cmd: string) => void
+  isExecuting: boolean
+  shellInputRef: RefObject<HTMLInputElement>
+  shellCommand: string
+  updateShell: (patch: { command: string }) => void
+  handleShellKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void
+  t: (key: string) => string
+}
+
+export function RemediationShellInput({
+  shellError,
+  lastFailedCommand,
+  executeCommand,
+  isExecuting,
+  shellInputRef,
+  shellCommand,
+  updateShell,
+  handleShellKeyDown,
+  t,
+}: RemediationShellInputProps) {
+  return (
+    <div className="p-3 border-t border-border bg-terminal">
+      {shellError && (
+        <div className="mb-2 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 text-xs">
+          <div className="flex items-center gap-2 mb-2">
+            <AlertTriangle className="w-3 h-3 shrink-0" />
+            <span>{shellError}</span>
+          </div>
+          {lastFailedCommand && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                executeCommand(lastFailedCommand)
+              }}
+              disabled={isExecuting}
+              className="bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 hover:text-yellow-300"
+            >
+              <RefreshCw className={`w-3 h-3 ${isExecuting ? 'animate-spin' : ''}`} />
+              <span>{t('remediation.retryCommand')}</span>
+            </Button>
+          )}
+        </div>
+      )}
+      <div className="flex items-center gap-2">
+        <span className="text-green-400">$</span>
+        <input
+          ref={shellInputRef}
+          type="text"
+          value={shellCommand}
+          onChange={(e) => updateShell({ command: e.target.value })}
+          onKeyDown={handleShellKeyDown}
+          placeholder={t('remediation.enterCommand')}
+          disabled={isExecuting}
+          className="flex-1 bg-transparent border-none outline-hidden text-foreground placeholder:text-muted-foreground"
+          autoFocus
+        />
+        <div
+          role="button"
+          tabIndex={isExecuting || !shellCommand.trim() ? -1 : 0}
+          aria-disabled={isExecuting || !shellCommand.trim()}
+          aria-label={t('remediation.sendCommand')}
+          onClick={() => {
+            if (!isExecuting && shellCommand.trim()) {
+              executeCommand(shellCommand)
+            }
+          }}
+          onKeyDown={(event) => handleButtonLikeKeyDown(event, () => executeCommand(shellCommand), isExecuting || !shellCommand.trim())}
+          className={cn(
+            'p-2 rounded hover:bg-card/50 text-muted-foreground hover:text-green-400',
+            isExecuting || !shellCommand.trim() ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+          )}
+        >
+          <Send className="w-4 h-4" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface RemediationFooterProps {
+  activeTab: 'ai' | 'shell'
+  isRunning: boolean
+  isComplete: boolean
+  isPaused: boolean
+  setIsPaused: (paused: boolean) => void
+  startRemediation: () => void
+  stopRemediation: () => void
+  logs: LogEntry[]
+  copyLogs: () => void
+  downloadLogs: () => void
+  t: (key: string) => string
+}
+
+export function RemediationFooter({
+  activeTab,
+  isRunning,
+  isComplete,
+  isPaused,
+  setIsPaused,
+  startRemediation,
+  stopRemediation,
+  logs,
+  copyLogs,
+  downloadLogs,
+  t,
+}: RemediationFooterProps) {
+  return (
+    <div className="flex items-center justify-between p-4 border-t border-border">
+      <div className="flex items-center gap-2">
+        {activeTab === 'ai' && (
+          <>
+            {!isRunning && !isComplete && (
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label={t('remediation.startRemediation')}
+                onClick={startRemediation}
+                onKeyDown={(event) => handleButtonLikeKeyDown(event, startRemediation)}
+                className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-foreground transition-colors cursor-pointer"
+              >
+                <Play className="w-4 h-4" />
+                {t('remediation.startRemediation')}
+              </div>
+            )}
+            {isRunning && (
+              <>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  aria-label={isPaused ? t('remediation.resume') : t('remediation.pause')}
+                  onClick={() => setIsPaused(!isPaused)}
+                  onKeyDown={(event) => handleButtonLikeKeyDown(event, () => setIsPaused(!isPaused))}
+                  className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-500 hover:bg-yellow-600 text-foreground transition-colors cursor-pointer"
+                >
+                  {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
+                  {isPaused ? t('remediation.resume') : t('remediation.pause')}
+                </div>
+                <Button
+                  variant="danger"
+                  size="lg"
+                  onClick={stopRemediation}
+                  className="px-4"
+                >
+                  <X className="w-4 h-4" />
+                  {t('remediation.stop')}
+                </Button>
+              </>
+            )}
+            {isComplete && (
+              <div className="flex items-center gap-2 text-green-400">
+                <CheckCircle className="w-5 h-5" />
+                <span>{t('remediation.analysisComplete')}</span>
+              </div>
+            )}
+          </>
+        )}
+        {activeTab === 'shell' && (
+          <div className="text-xs text-muted-foreground">
+            {t('remediation.commandHistory')}
+          </div>
+        )}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <div
+          role="button"
+          tabIndex={logs.length === 0 ? -1 : 0}
+          aria-disabled={logs.length === 0}
+          aria-label={t('remediation.copyLogs')}
+          onClick={() => {
+            if (logs.length > 0) {
+              copyLogs()
+            }
+          }}
+          onKeyDown={(event) => handleButtonLikeKeyDown(event, copyLogs, logs.length === 0)}
+          className={cn(
+            'p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground',
+            logs.length === 0 ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
+          )}
+          title={t('remediation.copyLogs')}
+        >
+          <Copy className="w-4 h-4" />
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={downloadLogs}
+          disabled={logs.length === 0}
+          className="p-2 hover:bg-secondary"
+          title={t('remediation.downloadLogs')}
+        >
+          <Download className="w-4 h-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/RemediationConsole.tsx
+++ b/web/src/components/drilldown/RemediationConsole.tsx
@@ -1,95 +1,21 @@
-import { useState, useEffect, useRef, useCallback, KeyboardEvent } from 'react'
-import { Sparkles, X, Play, Pause, CheckCircle, Loader2, Copy, Download, Terminal, Send, AlertTriangle, RefreshCw } from 'lucide-react'
-import { cn } from '../../lib/cn'
-import { useTokenUsage } from '../../hooks/useTokenUsage'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
-import { AI_THINKING_DELAY_MS, FOCUS_DELAY_MS } from '../../lib/constants/network'
-import { authFetch } from '../../lib/api'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../lib/clipboard'
-import { downloadText } from '../../lib/download'
+import { FOCUS_DELAY_MS } from '../../lib/constants/network'
 import { PageErrorBoundary } from '../PageErrorBoundary'
-import { Button } from '../ui/Button'
 import { useTabKeyboardNav } from '../../hooks/useKeyboardNav'
+import { useRemediationRun } from './useRemediationRun'
+import {
+  RemediationHeader,
+  RemediationTabs,
+  RemediationAiOutput,
+  RemediationShellOutput,
+  RemediationShellInput,
+  RemediationFooter,
+} from './RemediationConsole.parts'
+import type { RemediationConsoleProps } from './RemediationConsole.types'
 
-interface LogEntry {
-  id: string
-  timestamp: Date
-  type: 'thinking' | 'action' | 'result' | 'error' | 'info' | 'command' | 'output'
-  message: string
-  details?: string
-}
-
-interface RemediationConsoleProps {
-  isOpen: boolean
-  onClose: () => void
-  resourceType: 'pod' | 'deployment' | 'node'
-  resourceName: string
-  namespace: string
-  cluster: string
-  issues: string[]
-}
-
-// Animation delay constants for simulated remediation steps
-const THINKING_DELAY_MS = 800
-const ACTION_DELAY_MS = 1000
-const ACTION_LONG_DELAY_MS = 1200
-const ANALYSIS_DELAY_MS = 1500
-const INFO_DELAY_MS = 600
-const RESULT_DELAY_MS = 500
-
-// Token usage estimation constants
-const BASE_TOKEN_ESTIMATE = 1000
-const TOKENS_PER_STEP_ESTIMATE = 100
-
-// Simulated remediation steps based on issue type
-const REMEDIATION_FLOWS: Record<string, Array<{ type: LogEntry['type']; message: string; details?: string; delay: number }>> = {
-  CrashLoopBackOff: [
-    { type: 'thinking', message: 'Analyzing CrashLoopBackOff issue...', delay: THINKING_DELAY_MS },
-    { type: 'action', message: 'Fetching pod logs to identify root cause', delay: ACTION_LONG_DELAY_MS },
-    { type: 'info', message: 'Found error in container logs: "Error: Cannot find module \'express\'"', delay: ANALYSIS_DELAY_MS },
-    { type: 'thinking', message: 'This appears to be a missing dependency issue. Checking if this is a code or image problem...', delay: ACTION_DELAY_MS },
-    { type: 'action', message: 'Checking deployment image and pull policy', delay: THINKING_DELAY_MS },
-    { type: 'info', message: 'Image: myapp:latest, PullPolicy: Always', delay: INFO_DELAY_MS },
-    { type: 'thinking', message: 'The issue is likely in the container image. Recommending image rebuild or rollback.', delay: ACTION_DELAY_MS },
-    { type: 'result', message: 'Recommendation: Rollback to previous working image version or fix the Docker build', details: 'kubectl rollout undo deployment/myapp -n default', delay: RESULT_DELAY_MS },
-  ],
-  ImagePullBackOff: [
-    { type: 'thinking', message: 'Analyzing ImagePullBackOff issue...', delay: THINKING_DELAY_MS },
-    { type: 'action', message: 'Checking image reference and pull secrets', delay: ACTION_DELAY_MS },
-    { type: 'info', message: 'Image: registry.example.com/app:v2.0', delay: INFO_DELAY_MS },
-    { type: 'action', message: 'Verifying image pull secrets in namespace', delay: ACTION_LONG_DELAY_MS },
-    { type: 'error', message: 'No valid pull secret found for registry.example.com', delay: THINKING_DELAY_MS },
-    { type: 'thinking', message: 'The pod needs a pull secret to access the private registry.', delay: ACTION_DELAY_MS },
-    { type: 'result', message: 'Fix: Create or update image pull secret for the registry', details: 'kubectl create secret docker-registry regcred --docker-server=registry.example.com --docker-username=<user> --docker-password=<pass> -n default', delay: RESULT_DELAY_MS },
-  ],
-  OOMKilled: [
-    { type: 'thinking', message: 'Analyzing OOMKilled issue...', delay: THINKING_DELAY_MS },
-    { type: 'action', message: 'Checking container resource limits', delay: ACTION_DELAY_MS },
-    { type: 'info', message: 'Current memory limit: 256Mi, Request: 128Mi', delay: INFO_DELAY_MS },
-    { type: 'action', message: 'Analyzing memory usage patterns from metrics', delay: ANALYSIS_DELAY_MS },
-    { type: 'info', message: 'Peak memory usage before OOM: 254Mi (99% of limit)', delay: THINKING_DELAY_MS },
-    { type: 'thinking', message: 'The container is running out of memory. Need to increase limits or optimize the application.', delay: ACTION_DELAY_MS },
-    { type: 'result', message: 'Recommendation: Increase memory limit to 512Mi', details: 'kubectl patch deployment myapp -p \'{"spec":{"template":{"spec":{"containers":[{"name":"app","resources":{"limits":{"memory":"512Mi"}}}]}}}}\'', delay: RESULT_DELAY_MS },
-  ],
-  Pending: [
-    { type: 'thinking', message: 'Analyzing why pod is stuck in Pending state...', delay: THINKING_DELAY_MS },
-    { type: 'action', message: 'Checking node resources and scheduling constraints', delay: ACTION_LONG_DELAY_MS },
-    { type: 'info', message: 'Pod requests: CPU 2, Memory 4Gi', delay: INFO_DELAY_MS },
-    { type: 'action', message: 'Checking available cluster capacity', delay: ACTION_DELAY_MS },
-    { type: 'info', message: 'Available: CPU 0.5, Memory 1Gi across all nodes', delay: THINKING_DELAY_MS },
-    { type: 'thinking', message: 'Insufficient cluster resources to schedule the pod.', delay: ACTION_DELAY_MS },
-    { type: 'result', message: 'Options: Scale up cluster, reduce pod resource requests, or remove other workloads', details: 'Consider: kubectl scale deployment less-critical-app --replicas=0', delay: RESULT_DELAY_MS },
-  ],
-  default: [
-    { type: 'thinking', message: 'Analyzing the issue...', delay: THINKING_DELAY_MS },
-    { type: 'action', message: 'Gathering diagnostic information', delay: ACTION_LONG_DELAY_MS },
-    { type: 'action', message: 'Checking pod events and logs', delay: ACTION_DELAY_MS },
-    { type: 'action', message: 'Analyzing resource configuration', delay: ACTION_DELAY_MS },
-    { type: 'thinking', message: 'Determining best remediation approach...', delay: ACTION_LONG_DELAY_MS },
-    { type: 'result', message: 'Analysis complete. Review the gathered information above for next steps.', delay: RESULT_DELAY_MS },
-  ],
-}
+const REMEDIATION_TABS = ['ai', 'shell'] as const
+const REMEDIATION_MODAL_TITLE_ID = 'remediation-console-title'
 
 function RemediationConsoleContent({
   isOpen,
@@ -101,339 +27,37 @@ function RemediationConsoleContent({
   issues,
 }: RemediationConsoleProps) {
   const { t } = useTranslation()
-  const [logs, setLogs] = useState<LogEntry[]>([])
-  const [isRunning, setIsRunning] = useState(false)
-  const [isComplete, setIsComplete] = useState(false)
-  const [isPaused, setIsPaused] = useState(false)
   const [activeTab, setActiveTab] = useState<'ai' | 'shell'>('ai')
-  const REMEDIATION_TABS = ['ai', 'shell'] as const
   const { tabListProps, getTabProps } = useTabKeyboardNav<'ai' | 'shell'>({
     tabs: REMEDIATION_TABS,
     activeTab,
     onChange: setActiveTab,
   })
-  // Shell state consolidated into a single object to prevent re-render flicker
-  // when multiple fields change together (e.g. after command execution completes).
-  const [shell, setShell] = useState({
-    command: '',
-    history: [] as string[],
-    historyIndex: -1,
-    isExecuting: false,
-    error: null as string | null,
-    lastFailedCommand: '',
-  })
-  // Convenience destructure for reads
-  const { command: shellCommand, history: commandHistory, historyIndex,
-    isExecuting, error: shellError, lastFailedCommand } = shell
-  const updateShell = useCallback(
-    (patch: Partial<typeof shell>) => setShell(prev => ({ ...prev, ...patch })),
-    [],
-  )
-  const [isLoadingInitialData, setIsLoadingInitialData] = useState(false)
-  const logsEndRef = useRef<HTMLDivElement>(null)
-  const shellInputRef = useRef<HTMLInputElement>(null)
-  const abortRef = useRef(false)
-  const { addTokens } = useTokenUsage()
 
-  // Auto-scroll to bottom when new logs appear
-  useEffect(() => {
-    logsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [logs])
-
-  // Abort any running remediation on unmount
-  useEffect(() => {
-    return () => { abortRef.current = true }
-  }, [])
-
-  const addLog = (entry: Omit<LogEntry, 'id' | 'timestamp'>) => {
-    setLogs(prev => [...prev, {
-      ...entry,
-      id: `log-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
-      timestamp: new Date(),
-    }])
-  }
-
-  const startRemediation = async () => {
-    abortRef.current = false
-    
-    // Batch state updates together to prevent render flicker
-    setLogs([])
-    setIsRunning(true)
-    setIsComplete(false)
-    setIsLoadingInitialData(true)
-
-    // Initial log
-    addLog({
-      type: 'info',
-      message: `Starting AI remediation for ${resourceType} "${resourceName}"`,
-      details: `Cluster: ${cluster}, Namespace: ${namespace}`,
-    })
-    
-    // Simulate brief loading for gathering initial data
-    await new Promise(resolve => setTimeout(resolve, AI_THINKING_DELAY_MS))
-    setIsLoadingInitialData(false)
-
-    // Get the remediation flow based on issues
-    const primaryIssue = issues[0] || 'default'
-    const flow = REMEDIATION_FLOWS[primaryIssue] || REMEDIATION_FLOWS.default
-
-    // Add issue context
-    addLog({
-      type: 'info',
-      message: `Detected issues: ${issues.join(', ') || 'Unknown'}`,
-    })
-
-    // Run through the flow
-    for (const step of flow) {
-      if (abortRef.current) break
-
-      // Wait while paused
-      while (isPaused && !abortRef.current) {
-        await new Promise(resolve => setTimeout(resolve, FOCUS_DELAY_MS))
-      }
-
-      await new Promise(resolve => setTimeout(resolve, step.delay))
-      if (abortRef.current) break
-
-      addLog({
-        type: step.type,
-        message: step.message,
-        details: step.details,
-      })
-    }
-
-    if (!abortRef.current) {
-      addLog({
-        type: 'info',
-        message: 'Remediation analysis complete',
-      })
-      addTokens(BASE_TOKEN_ESTIMATE + flow.length * TOKENS_PER_STEP_ESTIMATE)
-      // Batch state updates together
-      setIsRunning(false)
-      setIsComplete(true)
-    } else {
-      setIsRunning(false)
-    }
-  }
-
-  const stopRemediation = () => {
-    abortRef.current = true
-    setIsRunning(false)
-    addLog({
-      type: 'info',
-      message: 'Remediation stopped by user',
-    })
-  }
-
-  /**
-   * Map a kubectl command to an MCP ops tool call.
-   * Returns { name, arguments } if mapped, or null if the command is not supported.
-   */
-  const mapCommandToMcpTool = (cmd: string): { name: string; arguments: Record<string, string> } | null => {
-    const trimmed = cmd.trim()
-
-    // kubectl get pods
-    if (/^kubectl\s+get\s+pods?\b/.test(trimmed)) {
-      return { name: 'get_pods', arguments: { cluster, namespace } }
-    }
-    // kubectl describe pod <name>
-    const describeMatch = trimmed.match(/^kubectl\s+describe\s+pod\s+(\S+)/)
-    if (describeMatch) {
-      return { name: 'describe_pod', arguments: { cluster, namespace, pod: describeMatch[1] } }
-    }
-    // kubectl describe deployment <name>
-    if (/^kubectl\s+describe\s+(deployment|deploy)\b/.test(trimmed)) {
-      return { name: 'find_deployment_issues', arguments: { cluster, namespace } }
-    }
-    // kubectl logs <pod>
-    const logsMatch = trimmed.match(/^kubectl\s+logs?\s+(\S+)/)
-    if (logsMatch) {
-      return { name: 'get_pod_logs', arguments: { cluster, namespace, pod: logsMatch[1] } }
-    }
-    // kubectl get events
-    if (/^kubectl\s+get\s+events?\b/.test(trimmed)) {
-      return { name: 'get_events', arguments: { cluster, namespace } }
-    }
-    // kubectl get deployments
-    if (/^kubectl\s+get\s+(deployments?|deploy)\b/.test(trimmed)) {
-      return { name: 'get_deployments', arguments: { cluster, namespace } }
-    }
-    // kubectl get services
-    if (/^kubectl\s+get\s+(services?|svc)\b/.test(trimmed)) {
-      return { name: 'get_services', arguments: { cluster, namespace } }
-    }
-    // kubectl get nodes
-    if (/^kubectl\s+get\s+nodes?\b/.test(trimmed)) {
-      return { name: 'get_nodes', arguments: { cluster } }
-    }
-
-    return null
-  }
-
-  // Shell command execution via MCP ops tools
-  const executeCommand = async (cmd: string) => {
-    if (!cmd.trim()) return
-
-    // Add to history
-    updateShell({ history: [...commandHistory, cmd], historyIndex: -1 })
-
-    // Log the command
-    addLog({
-      type: 'command',
-      message: `$ ${cmd}`,
-    })
-
-    updateShell({ isExecuting: true, error: null })
-
-    const toolCall = mapCommandToMcpTool(cmd)
-
-    if (!toolCall) {
-      // Command is not a supported kubectl operation
-      addLog({
-        type: 'output',
-        message: simulateCommandOutput(cmd),
-      })
-      updateShell({ error: 'This command is not supported via the MCP bridge. Use the quick commands above for supported operations.', lastFailedCommand: cmd, isExecuting: false, command: '' })
-      return
-    }
-
-    try {
-      const response = await authFetch('/api/mcp/tools/ops/call', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          name: toolCall.name,
-          arguments: toolCall.arguments,
-        }),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-      })
-
-      if (!response.ok) {
-        throw new Error(`MCP tool call failed: ${response.status}`)
-      }
-
-      const result = await response.json()
-
-      // MCP tools return content as an array of { type, text } or as a direct object
-      const output = Array.isArray(result?.content)
-        ? (result.content as Array<{ text?: string }>).map((c: { text?: string }) => c.text || '').join('\n')
-        : typeof result === 'string'
-          ? result
-          : JSON.stringify(result, null, 2)
-
-      addLog({
-        type: 'output',
-        message: output,
-      })
-    } catch (error: unknown) {
-      // Fall back to simulated output when backend is unavailable
-      const message = error instanceof Error ? error.message : 'Connection failed'
-      updateShell({ error: `MCP bridge unavailable: ${message}`, lastFailedCommand: cmd })
-      addLog({
-        type: 'output',
-        message: simulateCommandOutput(cmd),
-      })
-    }
-
-    updateShell({ isExecuting: false, command: '' })
-  }
-
-  // Simulate command output for demo
-  const simulateCommandOutput = (cmd: string): string => {
-    if (cmd.includes('kubectl get pods')) {
-      return `NAME                      READY   STATUS    RESTARTS   AGE
-${resourceName}   1/1     Running   0          5m
-app-backend-xyz           1/1     Running   2          1h
-redis-master-abc          1/1     Running   0          2h`
-    }
-    if (cmd.includes('kubectl describe')) {
-      return `Name:         ${resourceName}
-Namespace:    ${namespace}
-Status:       Running
-IP:           10.42.0.15
-Node:         worker-1/192.168.1.10
-Start Time:   ${new Date().toISOString()}
-Labels:       app=${resourceName.split('-')[0]}
-...`
-    }
-    if (cmd.includes('kubectl logs')) {
-      return `[${new Date().toISOString()}] Server starting on port 3000
-[${new Date().toISOString()}] Connected to database
-[${new Date().toISOString()}] Ready to accept connections`
-    }
-    return `Command executed: ${cmd}\n(Demo mode - connect backend for real output)`
-  }
-
-  const handleShellKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter' && !isExecuting) {
-      executeCommand(shellCommand)
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      if (commandHistory.length > 0) {
-        const newIndex = historyIndex < commandHistory.length - 1 ? historyIndex + 1 : historyIndex
-        updateShell({ historyIndex: newIndex, command: commandHistory[commandHistory.length - 1 - newIndex] || '' })
-      }
-    } else if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      if (historyIndex > 0) {
-        const newIndex = historyIndex - 1
-        updateShell({ historyIndex: newIndex, command: commandHistory[commandHistory.length - 1 - newIndex] || '' })
-      } else {
-        updateShell({ historyIndex: -1, command: '' })
-      }
-    }
-  }
-
-  const handleButtonLikeKeyDown = (
-    event: KeyboardEvent<HTMLElement>,
-    action: () => void,
-    disabled = false,
-  ) => {
-    if (disabled) {
-      return
-    }
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault()
-      action()
-    }
-  }
-
-  // Quick commands for the shell
-  const quickCommands = [
-    { label: 'Get Pods', cmd: `kubectl get pods -n ${namespace}` },
-    { label: 'Describe', cmd: `kubectl describe ${resourceType} ${resourceName} -n ${namespace}` },
-    { label: 'Logs', cmd: `kubectl logs ${resourceName} -n ${namespace} --tail=50` },
-    { label: 'Events', cmd: `kubectl get events -n ${namespace} --sort-by='.lastTimestamp'` },
-  ]
-
-  const copyLogs = () => {
-    const text = logs.map(log =>
-      `[${log.timestamp.toISOString()}] [${log.type.toUpperCase()}] ${log.message}${log.details ? `\n  ${log.details}` : ''}`
-    ).join('\n')
-    copyToClipboard(text)
-  }
-
-  const downloadLogs = () => {
-    const text = logs.map(log =>
-      `[${log.timestamp.toISOString()}] [${log.type.toUpperCase()}] ${log.message}${log.details ? `\n  ${log.details}` : ''}`
-    ).join('\n')
-    // #6226: route through downloadText so a failure (storage quota,
-    // browser blocker, etc.) is captured and surfaced in the remediation
-    // log itself rather than crashing the dialog. This dialog has no
-    // useToast, so an inline addLog entry is the most natural feedback.
-    const result = downloadText(`remediation-${resourceName}-${Date.now()}.log`, text)
-    if (!result.ok) {
-      addLog({
-        type: 'error',
-        message: 'Failed to download remediation log',
-        details: result.error?.message || 'unknown browser error',
-      })
-    }
-  }
+  const {
+    logs,
+    isRunning,
+    isComplete,
+    isPaused,
+    setIsPaused,
+    isLoadingInitialData,
+    shellCommand,
+    isExecuting,
+    shellError,
+    lastFailedCommand,
+    updateShell,
+    logsEndRef,
+    shellInputRef,
+    startRemediation,
+    stopRemediation,
+    executeCommand,
+    handleShellKeyDown,
+    quickCommands,
+    copyLogs,
+    downloadLogs,
+  } = useRemediationRun({ resourceType, resourceName, namespace, cluster, issues })
 
   if (!isOpen) return null
-
-  const REMEDIATION_MODAL_TITLE_ID = 'remediation-console-title'
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-xs flex items-center justify-center z-modal">
@@ -443,341 +67,77 @@ Labels:       app=${resourceName.split('-')[0]}
         aria-labelledby={REMEDIATION_MODAL_TITLE_ID}
         className="w-[800px] max-h-[80vh] glass rounded-xl flex flex-col overflow-hidden animate-fade-in-up"
       >
-        {/* Header */}
-        <div className="flex items-center justify-between p-4 border-b border-border">
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-lg bg-purple-500/20">
-              {activeTab === 'ai' ? (
-                <Sparkles className="w-5 h-5 text-purple-400" />
-              ) : (
-                <Terminal className="w-5 h-5 text-green-400" />
-              )}
-            </div>
-            <div>
-              <h2 id={REMEDIATION_MODAL_TITLE_ID} className="font-semibold text-foreground">
-                {activeTab === 'ai' ? t('remediation.title') : t('remediation.shellTitle')}
-              </h2>
-              <p className="text-sm text-muted-foreground">
-                {t('remediation.resourceType', { type: resourceType, name: resourceName })}
-              </p>
-            </div>
-          </div>
-          <div
-            role="button"
-            tabIndex={0}
-            onClick={onClose}
-            onKeyDown={(event) => handleButtonLikeKeyDown(event, onClose)}
-            aria-label="Close"
-            className="p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground cursor-pointer"
-          >
-            <X className="w-5 h-5" />
-          </div>
-        </div>
+        <RemediationHeader
+          activeTab={activeTab}
+          resourceType={resourceType}
+          resourceName={resourceName}
+          onClose={onClose}
+          titleId={REMEDIATION_MODAL_TITLE_ID}
+          t={t}
+        />
 
-        {/* Tabs */}
-        <div {...tabListProps} className="flex border-b border-border">
-          <button
-            {...getTabProps('ai')}
-            aria-label={t('remediation.aiAnalysis')}
-            className={cn(
-              'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors cursor-pointer',
-              activeTab === 'ai'
-                ? 'text-purple-400 border-b-2 border-purple-500'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Sparkles className="w-4 h-4" />
-            {t('remediation.aiAnalysis')}
-          </button>
-          <button
-            {...getTabProps('shell')}
-            onClick={() => {
-              setActiveTab('shell')
-              setTimeout(() => shellInputRef.current?.focus(), FOCUS_DELAY_MS)
-            }}
-            aria-label={t('remediation.shell')}
-            className={cn(
-              'flex items-center gap-2 px-4 py-2 text-sm font-medium transition-colors cursor-pointer',
-              activeTab === 'shell'
-                ? 'text-green-400 border-b-2 border-green-500'
-                : 'text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Terminal className="w-4 h-4" />
-            {t('remediation.shell')}
-          </button>
-        </div>
+        <RemediationTabs
+          activeTab={activeTab}
+          tabListProps={tabListProps}
+          getTabProps={getTabProps}
+          setActiveTab={setActiveTab}
+          shellInputRef={shellInputRef}
+          focusDelayMs={FOCUS_DELAY_MS}
+          t={t}
+        />
 
         {/* Console Output */}
         <div className="flex-1 overflow-y-auto p-4 bg-terminal font-mono text-sm">
           {activeTab === 'ai' ? (
-            // AI Tab Content
-            logs.length === 0 ? (
-              <div className="text-center py-12 text-muted-foreground">
-                {isLoadingInitialData ? (
-                  <>
-                    <Loader2 className="w-12 h-12 mx-auto mb-4 animate-spin opacity-50" />
-                    <p>{t('remediation.gatheringData')}</p>
-                  </>
-                ) : (
-                  <>
-                    <Sparkles className="w-12 h-12 mx-auto mb-4 opacity-50" />
-                    <p>{t('remediation.clickStart')}</p>
-                    <p className="text-xs mt-2">{t('remediation.claudeWillAnalyze')}</p>
-                  </>
-                )}
-              </div>
-            ) : (
-              <div className="space-y-2">
-                {logs.filter(l => l.type !== 'command' && l.type !== 'output').map(log => (
-                  <div key={log.id} className="flex gap-3">
-                    <span className="text-muted-foreground text-xs whitespace-nowrap">
-                      {log.timestamp.toLocaleTimeString()}
-                    </span>
-                    <div className="flex-1">
-                      <div className="flex items-start gap-2">
-                        {log.type === 'thinking' && (
-                          <span className="text-purple-400">🤔</span>
-                        )}
-                        {log.type === 'action' && (
-                          <span className="text-blue-400">⚡</span>
-                        )}
-                        {log.type === 'result' && (
-                          <span className="text-green-400">✅</span>
-                        )}
-                        {log.type === 'error' && (
-                          <span className="text-red-400">❌</span>
-                        )}
-                        {log.type === 'info' && (
-                          <span className="text-muted-foreground">ℹ️</span>
-                        )}
-                        <span className={cn(
-                          log.type === 'thinking' && 'text-purple-300',
-                          log.type === 'action' && 'text-blue-300',
-                          log.type === 'result' && 'text-green-300',
-                          log.type === 'error' && 'text-red-300',
-                          log.type === 'info' && 'text-muted-foreground',
-                        )}>
-                          {log.message}
-                        </span>
-                      </div>
-                      {log.details && (
-                        <pre className="mt-1 ml-6 p-2 rounded bg-black/50 text-xs text-yellow-300 overflow-x-auto">
-                          {log.details}
-                        </pre>
-                      )}
-                    </div>
-                  </div>
-                ))}
-                {isRunning && (
-                  <div className="flex items-center gap-2 text-muted-foreground">
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    <span>{t('common.processing')}</span>
-                  </div>
-                )}
-                <div ref={logsEndRef} />
-              </div>
-            )
+            <RemediationAiOutput
+              logs={logs}
+              isLoadingInitialData={isLoadingInitialData}
+              isRunning={isRunning}
+              logsEndRef={logsEndRef}
+              t={t}
+            />
           ) : (
-            // Shell Tab Content
-            <div className="space-y-2">
-              {/* Quick commands */}
-              <div className="flex flex-wrap gap-2 mb-4 pb-4 border-b border-border/30">
-                {quickCommands.map((qc, i) => (
-                  <Button
-                    key={i}
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => executeCommand(qc.cmd)}
-                    disabled={isExecuting}
-                    className="bg-card/50 border border-border hover:border-green-500/50"
-                  >
-                    {qc.label}
-                  </Button>
-                ))}
-              </div>
-
-              {/* Shell output */}
-              {logs.filter(l => l.type === 'command' || l.type === 'output' || l.type === 'error').length === 0 ? (
-                <div className="text-muted-foreground">
-                  <p className="mb-2">{t('remediation.welcomeShell')}</p>
-                  <p className="text-xs">{t('remediation.clusterContext')} <span className="text-green-400">{cluster}</span></p>
-                  <p className="text-xs">{t('remediation.namespaceContext')} <span className="text-green-400">{namespace}</span></p>
-                  <p className="text-xs mt-4">{t('remediation.typeKubectl')}</p>
-                </div>
-              ) : (
-                logs.filter(l => l.type === 'command' || l.type === 'output' || l.type === 'error').map(log => (
-                  <div key={log.id}>
-                    {log.type === 'command' ? (
-                      <div className="text-green-400">{log.message}</div>
-                    ) : log.type === 'error' ? (
-                      <pre className="text-red-400 whitespace-pre-wrap">{log.message}</pre>
-                    ) : (
-                      <pre className="text-muted-foreground whitespace-pre-wrap">{log.message}</pre>
-                    )}
-                  </div>
-                ))
-              )}
-              {isExecuting && (
-                <div className="flex items-center gap-2 text-muted-foreground">
-                  <Loader2 className="w-4 h-4 animate-spin" />
-                  <span>{t('common.executing')}</span>
-                </div>
-              )}
-              <div ref={logsEndRef} />
-            </div>
+            <RemediationShellOutput
+              logs={logs}
+              cluster={cluster}
+              namespace={namespace}
+              quickCommands={quickCommands}
+              executeCommand={executeCommand}
+              isExecuting={isExecuting}
+              logsEndRef={logsEndRef}
+              t={t}
+            />
           )}
         </div>
 
         {/* Shell Input (only shown in shell tab) */}
         {activeTab === 'shell' && (
-          <div className="p-3 border-t border-border bg-terminal">
-            {shellError && (
-              <div className="mb-2 px-3 py-2 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-yellow-400 text-xs">
-                <div className="flex items-center gap-2 mb-2">
-                  <AlertTriangle className="w-3 h-3 shrink-0" />
-                  <span>{shellError}</span>
-                </div>
-                {lastFailedCommand && (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => {
-                      executeCommand(lastFailedCommand)
-                    }}
-                    disabled={isExecuting}
-                    className="bg-yellow-500/20 text-yellow-400 hover:bg-yellow-500/30 hover:text-yellow-300"
-                  >
-                    <RefreshCw className={`w-3 h-3 ${isExecuting ? 'animate-spin' : ''}`} />
-                    <span>{t('remediation.retryCommand')}</span>
-                  </Button>
-                )}
-              </div>
-            )}
-            <div className="flex items-center gap-2">
-              <span className="text-green-400">$</span>
-              <input
-                ref={shellInputRef}
-                type="text"
-                value={shellCommand}
-                onChange={(e) => updateShell({ command: e.target.value })}
-                onKeyDown={handleShellKeyDown}
-                placeholder={t('remediation.enterCommand')}
-                disabled={isExecuting}
-                className="flex-1 bg-transparent border-none outline-hidden text-foreground placeholder:text-muted-foreground"
-                autoFocus
-              />
-              <div
-                role="button"
-                tabIndex={isExecuting || !shellCommand.trim() ? -1 : 0}
-                aria-disabled={isExecuting || !shellCommand.trim()}
-                aria-label={t('remediation.sendCommand')}
-                onClick={() => {
-                  if (!isExecuting && shellCommand.trim()) {
-                    executeCommand(shellCommand)
-                  }
-                }}
-                onKeyDown={(event) => handleButtonLikeKeyDown(event, () => executeCommand(shellCommand), isExecuting || !shellCommand.trim())}
-                className={cn(
-                  'p-2 rounded hover:bg-card/50 text-muted-foreground hover:text-green-400',
-                  isExecuting || !shellCommand.trim() ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
-                )}
-              >
-                <Send className="w-4 h-4" />
-              </div>
-            </div>
-          </div>
+          <RemediationShellInput
+            shellError={shellError}
+            lastFailedCommand={lastFailedCommand}
+            executeCommand={executeCommand}
+            isExecuting={isExecuting}
+            shellInputRef={shellInputRef}
+            shellCommand={shellCommand}
+            updateShell={updateShell}
+            handleShellKeyDown={handleShellKeyDown}
+            t={t}
+          />
         )}
 
-        {/* Footer Controls */}
-        <div className="flex items-center justify-between p-4 border-t border-border">
-          <div className="flex items-center gap-2">
-            {activeTab === 'ai' && (
-              <>
-                {!isRunning && !isComplete && (
-                  <div
-                    role="button"
-                    tabIndex={0}
-                    aria-label={t('remediation.startRemediation')}
-                    onClick={startRemediation}
-                    onKeyDown={(event) => handleButtonLikeKeyDown(event, startRemediation)}
-                    className="flex items-center gap-2 px-4 py-2 rounded-lg bg-purple-500 hover:bg-purple-600 text-foreground transition-colors cursor-pointer"
-                  >
-                    <Play className="w-4 h-4" />
-                    {t('remediation.startRemediation')}
-                  </div>
-                )}
-                {isRunning && (
-                  <>
-                    <div
-                      role="button"
-                      tabIndex={0}
-                      aria-label={isPaused ? t('remediation.resume') : t('remediation.pause')}
-                      onClick={() => setIsPaused(!isPaused)}
-                      onKeyDown={(event) => handleButtonLikeKeyDown(event, () => setIsPaused(!isPaused))}
-                      className="flex items-center gap-2 px-4 py-2 rounded-lg bg-yellow-500 hover:bg-yellow-600 text-foreground transition-colors cursor-pointer"
-                    >
-                      {isPaused ? <Play className="w-4 h-4" /> : <Pause className="w-4 h-4" />}
-                      {isPaused ? t('remediation.resume') : t('remediation.pause')}
-                    </div>
-                    <Button
-                      variant="danger"
-                      size="lg"
-                      onClick={stopRemediation}
-                      className="px-4"
-                    >
-                      <X className="w-4 h-4" />
-                      {t('remediation.stop')}
-                    </Button>
-                  </>
-                )}
-                {isComplete && (
-                  <div className="flex items-center gap-2 text-green-400">
-                    <CheckCircle className="w-5 h-5" />
-                    <span>{t('remediation.analysisComplete')}</span>
-                  </div>
-                )}
-              </>
-            )}
-            {activeTab === 'shell' && (
-              <div className="text-xs text-muted-foreground">
-                {t('remediation.commandHistory')}
-              </div>
-            )}
-          </div>
-
-          <div className="flex items-center gap-2">
-            <div
-              role="button"
-              tabIndex={logs.length === 0 ? -1 : 0}
-              aria-disabled={logs.length === 0}
-              aria-label={t('remediation.copyLogs')}
-              onClick={() => {
-                if (logs.length > 0) {
-                  copyLogs()
-                }
-              }}
-              onKeyDown={(event) => handleButtonLikeKeyDown(event, copyLogs, logs.length === 0)}
-              className={cn(
-                'p-2 rounded-lg hover:bg-secondary text-muted-foreground hover:text-foreground',
-                logs.length === 0 ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer',
-              )}
-              title={t('remediation.copyLogs')}
-            >
-              <Copy className="w-4 h-4" />
-            </div>
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={downloadLogs}
-              disabled={logs.length === 0}
-              className="p-2 hover:bg-secondary"
-              title={t('remediation.downloadLogs')}
-            >
-              <Download className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
+        <RemediationFooter
+          activeTab={activeTab}
+          isRunning={isRunning}
+          isComplete={isComplete}
+          isPaused={isPaused}
+          setIsPaused={setIsPaused}
+          startRemediation={startRemediation}
+          stopRemediation={stopRemediation}
+          logs={logs}
+          copyLogs={copyLogs}
+          downloadLogs={downloadLogs}
+          t={t}
+        />
       </div>
     </div>
   )

--- a/web/src/components/drilldown/RemediationConsole.types.ts
+++ b/web/src/components/drilldown/RemediationConsole.types.ts
@@ -1,0 +1,85 @@
+export interface LogEntry {
+  id: string
+  timestamp: Date
+  type: 'thinking' | 'action' | 'result' | 'error' | 'info' | 'command' | 'output'
+  message: string
+  details?: string
+}
+
+export interface RemediationConsoleProps {
+  isOpen: boolean
+  onClose: () => void
+  resourceType: 'pod' | 'deployment' | 'node'
+  resourceName: string
+  namespace: string
+  cluster: string
+  issues: string[]
+}
+
+export interface RemediationFlowStep {
+  type: LogEntry['type']
+  message: string
+  details?: string
+  delay: number
+}
+
+// Animation delay constants for simulated remediation steps
+export const THINKING_DELAY_MS = 800
+export const ACTION_DELAY_MS = 1000
+export const ACTION_LONG_DELAY_MS = 1200
+export const ANALYSIS_DELAY_MS = 1500
+export const INFO_DELAY_MS = 600
+export const RESULT_DELAY_MS = 500
+
+// Token usage estimation constants
+export const BASE_TOKEN_ESTIMATE = 1000
+export const TOKENS_PER_STEP_ESTIMATE = 100
+
+// Simulated remediation steps based on issue type
+export const REMEDIATION_FLOWS: Record<string, RemediationFlowStep[]> = {
+  CrashLoopBackOff: [
+    { type: 'thinking', message: 'Analyzing CrashLoopBackOff issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Fetching pod logs to identify root cause', delay: ACTION_LONG_DELAY_MS },
+    { type: 'info', message: 'Found error in container logs: "Error: Cannot find module \'express\'"', delay: ANALYSIS_DELAY_MS },
+    { type: 'thinking', message: 'This appears to be a missing dependency issue. Checking if this is a code or image problem...', delay: ACTION_DELAY_MS },
+    { type: 'action', message: 'Checking deployment image and pull policy', delay: THINKING_DELAY_MS },
+    { type: 'info', message: 'Image: myapp:latest, PullPolicy: Always', delay: INFO_DELAY_MS },
+    { type: 'thinking', message: 'The issue is likely in the container image. Recommending image rebuild or rollback.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Recommendation: Rollback to previous working image version or fix the Docker build', details: 'kubectl rollout undo deployment/myapp -n default', delay: RESULT_DELAY_MS },
+  ],
+  ImagePullBackOff: [
+    { type: 'thinking', message: 'Analyzing ImagePullBackOff issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking image reference and pull secrets', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Image: registry.example.com/app:v2.0', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Verifying image pull secrets in namespace', delay: ACTION_LONG_DELAY_MS },
+    { type: 'error', message: 'No valid pull secret found for registry.example.com', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'The pod needs a pull secret to access the private registry.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Fix: Create or update image pull secret for the registry', details: 'kubectl create secret docker-registry regcred --docker-server=registry.example.com --docker-username=<user> --docker-password=<pass> -n default', delay: RESULT_DELAY_MS },
+  ],
+  OOMKilled: [
+    { type: 'thinking', message: 'Analyzing OOMKilled issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking container resource limits', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Current memory limit: 256Mi, Request: 128Mi', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Analyzing memory usage patterns from metrics', delay: ANALYSIS_DELAY_MS },
+    { type: 'info', message: 'Peak memory usage before OOM: 254Mi (99% of limit)', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'The container is running out of memory. Need to increase limits or optimize the application.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Recommendation: Increase memory limit to 512Mi', details: 'kubectl patch deployment myapp -p \'{"spec":{"template":{"spec":{"containers":[{"name":"app","resources":{"limits":{"memory":"512Mi"}}}]}}}}\'', delay: RESULT_DELAY_MS },
+  ],
+  Pending: [
+    { type: 'thinking', message: 'Analyzing why pod is stuck in Pending state...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Checking node resources and scheduling constraints', delay: ACTION_LONG_DELAY_MS },
+    { type: 'info', message: 'Pod requests: CPU 2, Memory 4Gi', delay: INFO_DELAY_MS },
+    { type: 'action', message: 'Checking available cluster capacity', delay: ACTION_DELAY_MS },
+    { type: 'info', message: 'Available: CPU 0.5, Memory 1Gi across all nodes', delay: THINKING_DELAY_MS },
+    { type: 'thinking', message: 'Insufficient cluster resources to schedule the pod.', delay: ACTION_DELAY_MS },
+    { type: 'result', message: 'Options: Scale up cluster, reduce pod resource requests, or remove other workloads', details: 'Consider: kubectl scale deployment less-critical-app --replicas=0', delay: RESULT_DELAY_MS },
+  ],
+  default: [
+    { type: 'thinking', message: 'Analyzing the issue...', delay: THINKING_DELAY_MS },
+    { type: 'action', message: 'Gathering diagnostic information', delay: ACTION_LONG_DELAY_MS },
+    { type: 'action', message: 'Checking pod events and logs', delay: ACTION_DELAY_MS },
+    { type: 'action', message: 'Analyzing resource configuration', delay: ACTION_DELAY_MS },
+    { type: 'thinking', message: 'Determining best remediation approach...', delay: ACTION_LONG_DELAY_MS },
+    { type: 'result', message: 'Analysis complete. Review the gathered information above for next steps.', delay: RESULT_DELAY_MS },
+  ],
+}

--- a/web/src/components/drilldown/useRemediationRun.ts
+++ b/web/src/components/drilldown/useRemediationRun.ts
@@ -1,0 +1,359 @@
+import { useState, useEffect, useRef, useCallback, KeyboardEvent } from 'react'
+import { useTokenUsage } from '../../hooks/useTokenUsage'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants'
+import { AI_THINKING_DELAY_MS, FOCUS_DELAY_MS } from '../../lib/constants/network'
+import { authFetch } from '../../lib/api'
+import { copyToClipboard } from '../../lib/clipboard'
+import { downloadText } from '../../lib/download'
+import {
+  LogEntry,
+  RemediationConsoleProps,
+  REMEDIATION_FLOWS,
+  BASE_TOKEN_ESTIMATE,
+  TOKENS_PER_STEP_ESTIMATE,
+} from './RemediationConsole.types'
+
+type RemediationRunProps = Pick<RemediationConsoleProps, 'resourceType' | 'resourceName' | 'namespace' | 'cluster' | 'issues'>
+
+/**
+ * Encapsulates the AI remediation run lifecycle (start/pause/stop) and the
+ * interactive shell state (command history, execution, MCP tool mapping) for
+ * RemediationConsole. Split out of the component to keep the UI file focused
+ * on rendering.
+ */
+export function useRemediationRun({ resourceType, resourceName, namespace, cluster, issues }: RemediationRunProps) {
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [isRunning, setIsRunning] = useState(false)
+  const [isComplete, setIsComplete] = useState(false)
+  const [isPaused, setIsPaused] = useState(false)
+  const [isLoadingInitialData, setIsLoadingInitialData] = useState(false)
+
+  // Shell state consolidated into a single object to prevent re-render flicker
+  // when multiple fields change together (e.g. after command execution completes).
+  const [shell, setShell] = useState({
+    command: '',
+    history: [] as string[],
+    historyIndex: -1,
+    isExecuting: false,
+    error: null as string | null,
+    lastFailedCommand: '',
+  })
+  // Convenience destructure for reads
+  const { command: shellCommand, history: commandHistory, historyIndex,
+    isExecuting, error: shellError, lastFailedCommand } = shell
+  const updateShell = useCallback(
+    (patch: Partial<typeof shell>) => setShell(prev => ({ ...prev, ...patch })),
+    [],
+  )
+
+  const logsEndRef = useRef<HTMLDivElement>(null)
+  const shellInputRef = useRef<HTMLInputElement>(null)
+  const abortRef = useRef(false)
+  const { addTokens } = useTokenUsage()
+
+  // Auto-scroll to bottom when new logs appear
+  useEffect(() => {
+    logsEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [logs])
+
+  // Abort any running remediation on unmount
+  useEffect(() => {
+    return () => { abortRef.current = true }
+  }, [])
+
+  const addLog = (entry: Omit<LogEntry, 'id' | 'timestamp'>) => {
+    setLogs(prev => [...prev, {
+      ...entry,
+      id: `log-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+      timestamp: new Date(),
+    }])
+  }
+
+  const startRemediation = async () => {
+    abortRef.current = false
+
+    // Batch state updates together to prevent render flicker
+    setLogs([])
+    setIsRunning(true)
+    setIsComplete(false)
+    setIsLoadingInitialData(true)
+
+    // Initial log
+    addLog({
+      type: 'info',
+      message: `Starting AI remediation for ${resourceType} "${resourceName}"`,
+      details: `Cluster: ${cluster}, Namespace: ${namespace}`,
+    })
+
+    // Simulate brief loading for gathering initial data
+    await new Promise(resolve => setTimeout(resolve, AI_THINKING_DELAY_MS))
+    setIsLoadingInitialData(false)
+
+    // Get the remediation flow based on issues
+    const primaryIssue = issues[0] || 'default'
+    const flow = REMEDIATION_FLOWS[primaryIssue] || REMEDIATION_FLOWS.default
+
+    // Add issue context
+    addLog({
+      type: 'info',
+      message: `Detected issues: ${issues.join(', ') || 'Unknown'}`,
+    })
+
+    // Run through the flow
+    for (const step of flow) {
+      if (abortRef.current) break
+
+      // Wait while paused
+      while (isPaused && !abortRef.current) {
+        await new Promise(resolve => setTimeout(resolve, FOCUS_DELAY_MS))
+      }
+
+      await new Promise(resolve => setTimeout(resolve, step.delay))
+      if (abortRef.current) break
+
+      addLog({
+        type: step.type,
+        message: step.message,
+        details: step.details,
+      })
+    }
+
+    if (!abortRef.current) {
+      addLog({
+        type: 'info',
+        message: 'Remediation analysis complete',
+      })
+      addTokens(BASE_TOKEN_ESTIMATE + flow.length * TOKENS_PER_STEP_ESTIMATE)
+      // Batch state updates together
+      setIsRunning(false)
+      setIsComplete(true)
+    } else {
+      setIsRunning(false)
+    }
+  }
+
+  const stopRemediation = () => {
+    abortRef.current = true
+    setIsRunning(false)
+    addLog({
+      type: 'info',
+      message: 'Remediation stopped by user',
+    })
+  }
+
+  /**
+   * Map a kubectl command to an MCP ops tool call.
+   * Returns { name, arguments } if mapped, or null if the command is not supported.
+   */
+  const mapCommandToMcpTool = (cmd: string): { name: string; arguments: Record<string, string> } | null => {
+    const trimmed = cmd.trim()
+
+    // kubectl get pods
+    if (/^kubectl\s+get\s+pods?\b/.test(trimmed)) {
+      return { name: 'get_pods', arguments: { cluster, namespace } }
+    }
+    // kubectl describe pod <name>
+    const describeMatch = trimmed.match(/^kubectl\s+describe\s+pod\s+(\S+)/)
+    if (describeMatch) {
+      return { name: 'describe_pod', arguments: { cluster, namespace, pod: describeMatch[1] } }
+    }
+    // kubectl describe deployment <name>
+    if (/^kubectl\s+describe\s+(deployment|deploy)\b/.test(trimmed)) {
+      return { name: 'find_deployment_issues', arguments: { cluster, namespace } }
+    }
+    // kubectl logs <pod>
+    const logsMatch = trimmed.match(/^kubectl\s+logs?\s+(\S+)/)
+    if (logsMatch) {
+      return { name: 'get_pod_logs', arguments: { cluster, namespace, pod: logsMatch[1] } }
+    }
+    // kubectl get events
+    if (/^kubectl\s+get\s+events?\b/.test(trimmed)) {
+      return { name: 'get_events', arguments: { cluster, namespace } }
+    }
+    // kubectl get deployments
+    if (/^kubectl\s+get\s+(deployments?|deploy)\b/.test(trimmed)) {
+      return { name: 'get_deployments', arguments: { cluster, namespace } }
+    }
+    // kubectl get services
+    if (/^kubectl\s+get\s+(services?|svc)\b/.test(trimmed)) {
+      return { name: 'get_services', arguments: { cluster, namespace } }
+    }
+    // kubectl get nodes
+    if (/^kubectl\s+get\s+nodes?\b/.test(trimmed)) {
+      return { name: 'get_nodes', arguments: { cluster } }
+    }
+
+    return null
+  }
+
+  // Simulate command output for demo
+  const simulateCommandOutput = (cmd: string): string => {
+    if (cmd.includes('kubectl get pods')) {
+      return `NAME                      READY   STATUS    RESTARTS   AGE
+${resourceName}   1/1     Running   0          5m
+app-backend-xyz           1/1     Running   2          1h
+redis-master-abc          1/1     Running   0          2h`
+    }
+    if (cmd.includes('kubectl describe')) {
+      return `Name:         ${resourceName}
+Namespace:    ${namespace}
+Status:       Running
+IP:           10.42.0.15
+Node:         worker-1/192.168.1.10
+Start Time:   ${new Date().toISOString()}
+Labels:       app=${resourceName.split('-')[0]}
+...`
+    }
+    if (cmd.includes('kubectl logs')) {
+      return `[${new Date().toISOString()}] Server starting on port 3000
+[${new Date().toISOString()}] Connected to database
+[${new Date().toISOString()}] Ready to accept connections`
+    }
+    return `Command executed: ${cmd}\n(Demo mode - connect backend for real output)`
+  }
+
+  // Shell command execution via MCP ops tools
+  const executeCommand = async (cmd: string) => {
+    if (!cmd.trim()) return
+
+    // Add to history
+    updateShell({ history: [...commandHistory, cmd], historyIndex: -1 })
+
+    // Log the command
+    addLog({
+      type: 'command',
+      message: `$ ${cmd}`,
+    })
+
+    updateShell({ isExecuting: true, error: null })
+
+    const toolCall = mapCommandToMcpTool(cmd)
+
+    if (!toolCall) {
+      // Command is not a supported kubectl operation
+      addLog({
+        type: 'output',
+        message: simulateCommandOutput(cmd),
+      })
+      updateShell({ error: 'This command is not supported via the MCP bridge. Use the quick commands above for supported operations.', lastFailedCommand: cmd, isExecuting: false, command: '' })
+      return
+    }
+
+    try {
+      const response = await authFetch('/api/mcp/tools/ops/call', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: toolCall.name,
+          arguments: toolCall.arguments,
+        }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+
+      if (!response.ok) {
+        throw new Error(`MCP tool call failed: ${response.status}`)
+      }
+
+      const result = await response.json()
+
+      // MCP tools return content as an array of { type, text } or as a direct object
+      const output = Array.isArray(result?.content)
+        ? (result.content as Array<{ text?: string }>).map((c: { text?: string }) => c.text || '').join('\n')
+        : typeof result === 'string'
+          ? result
+          : JSON.stringify(result, null, 2)
+
+      addLog({
+        type: 'output',
+        message: output,
+      })
+    } catch (error: unknown) {
+      // Fall back to simulated output when backend is unavailable
+      const message = error instanceof Error ? error.message : 'Connection failed'
+      updateShell({ error: `MCP bridge unavailable: ${message}`, lastFailedCommand: cmd })
+      addLog({
+        type: 'output',
+        message: simulateCommandOutput(cmd),
+      })
+    }
+
+    updateShell({ isExecuting: false, command: '' })
+  }
+
+  const handleShellKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter' && !isExecuting) {
+      executeCommand(shellCommand)
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      if (commandHistory.length > 0) {
+        const newIndex = historyIndex < commandHistory.length - 1 ? historyIndex + 1 : historyIndex
+        updateShell({ historyIndex: newIndex, command: commandHistory[commandHistory.length - 1 - newIndex] || '' })
+      }
+    } else if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      if (historyIndex > 0) {
+        const newIndex = historyIndex - 1
+        updateShell({ historyIndex: newIndex, command: commandHistory[commandHistory.length - 1 - newIndex] || '' })
+      } else {
+        updateShell({ historyIndex: -1, command: '' })
+      }
+    }
+  }
+
+  // Quick commands for the shell
+  const quickCommands = [
+    { label: 'Get Pods', cmd: `kubectl get pods -n ${namespace}` },
+    { label: 'Describe', cmd: `kubectl describe ${resourceType} ${resourceName} -n ${namespace}` },
+    { label: 'Logs', cmd: `kubectl logs ${resourceName} -n ${namespace} --tail=50` },
+    { label: 'Events', cmd: `kubectl get events -n ${namespace} --sort-by='.lastTimestamp'` },
+  ]
+
+  const copyLogs = () => {
+    const text = logs.map(log =>
+      `[${log.timestamp.toISOString()}] [${log.type.toUpperCase()}] ${log.message}${log.details ? `\n  ${log.details}` : ''}`
+    ).join('\n')
+    copyToClipboard(text)
+  }
+
+  const downloadLogs = () => {
+    const text = logs.map(log =>
+      `[${log.timestamp.toISOString()}] [${log.type.toUpperCase()}] ${log.message}${log.details ? `\n  ${log.details}` : ''}`
+    ).join('\n')
+    // #6226: route through downloadText so a failure (storage quota,
+    // browser blocker, etc.) is captured and surfaced in the remediation
+    // log itself rather than crashing the dialog. This dialog has no
+    // useToast, so an inline addLog entry is the most natural feedback.
+    const result = downloadText(`remediation-${resourceName}-${Date.now()}.log`, text)
+    if (!result.ok) {
+      addLog({
+        type: 'error',
+        message: 'Failed to download remediation log',
+        details: result.error?.message || 'unknown browser error',
+      })
+    }
+  }
+
+  return {
+    logs,
+    isRunning,
+    isComplete,
+    isPaused,
+    setIsPaused,
+    isLoadingInitialData,
+    shellCommand,
+    commandHistory,
+    isExecuting,
+    shellError,
+    lastFailedCommand,
+    updateShell,
+    logsEndRef,
+    shellInputRef,
+    startRemediation,
+    stopRemediation,
+    executeCommand,
+    handleShellKeyDown,
+    quickCommands,
+    copyLogs,
+    downloadLogs,
+  }
+}


### PR DESCRIPTION
Fixes #21788

Part of #21791 — this PR splits `DrillDownModal.tsx` only. The other two files in scope for #21791 (`SecretDrillDown.tsx`, `ComplianceDrillDown.tsx`) are tracked as separate follow-up child issues (#21912, #21911) per that issue's own guidance to split into multiple PRs if needed, keeping this PR reviewable and low-risk.

## Changes

### `RemediationConsole.tsx` (792 → 152 lines)
- `RemediationConsole.types.ts` — `LogEntry`, `RemediationConsoleProps`, remediation flow data/constants
- `useRemediationRun.ts` — run lifecycle (start/pause/stop) + shell command state/execution, extracted as a hook
- `RemediationConsole.parts.tsx` — presentational sections: header, tabs, AI/shell output, shell input, footer controls

### `DrillDownModal.tsx` (463 → 154 lines)
- `DrillDownModal.views.tsx` — lazy-loaded view registry and the view-type → component routing switch
- `DrillDownModal.parts.tsx` — modal chrome: error boundary, loading fallback, icon/status-color helpers, breadcrumb trail, footer keyboard hints

## Notes
- No behavior changes; this is a pure extraction following the existing `*.parts.tsx` split convention used elsewhere in the codebase (e.g. `GPUDetailModal.parts.tsx`, `Clusters.parts.tsx`).
- The drill-down stack navigation contract via `useDrillDown()` and the `DrillDownProvider` registration are unchanged.
- No magic numbers introduced; existing named constants were preserved verbatim.
- Build + lint are validated by CI on this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
