### PR TITLE
[scanner] fix: restore main build after #21904

### DIFF
--- a/web/src/components/clusters/Clusters.parts.tsx
+++ b/web/src/components/clusters/Clusters.parts.tsx
@@ -41,7 +41,7 @@ export interface ClustersBeforeCardsProps {
   isDegraded: boolean
   isLoading: boolean
   permissionsLoading: boolean
-  isClusterAdmin: boolean
+  isClusterAdmin: (clusterName: string) => boolean
   clusterGroups: ClusterGroup[]
   addClusterGroup: (group: Omit<ClusterGroup, 'id'>) => void
   deleteClusterGroup: (id: string) => void

--- a/web/src/components/clusters/useClustersView.ts
+++ b/web/src/components/clusters/useClustersView.ts
@@ -46,7 +46,7 @@ export interface ClustersViewState {
   showSkeletonContent: boolean
   // Permissions
   permissionsLoading: boolean
-  isClusterAdmin: boolean
+  isClusterAdmin: (clusterName: string) => boolean
   // View state
   filter: ClusterHealthFilter
   setFilter: (f: ClusterHealthFilter) => void
@@ -213,6 +213,7 @@ export function useClustersView(): ClustersViewState {
     gpuNodes: gpuNodes || [],
     gpuLoading,
     gpuError,
+    gpuRefetch,
     nvidiaOperators,
     isConnected,
     isDegraded,

--- a/web/src/components/layout/ProfileCard.parts.tsx
+++ b/web/src/components/layout/ProfileCard.parts.tsx
@@ -9,6 +9,7 @@ import { Linkedin } from '@/lib/icons'
 import { Tooltip } from '../ui/Tooltip'
 import { useVersionCheck } from '../../hooks/useVersionCheck'
 import { REWARD_ACTIONS } from '../../hooks/useRewards'
+import type { RewardActionType } from '../../types/rewards'
 import { checkOAuthConfigured } from '../../lib/api'
 import { isDemoModeForced } from '../../lib/demoMode'
 import { LANGUAGE_STORAGE_KEY, languages } from '../../lib/i18n'
@@ -332,7 +333,7 @@ export function ProfileDevPanel({
 interface ProfileActionMenuProps {
   closeDropdown: () => void
   openFeedbackModal: () => void
-  awardCoins: (action: string) => void
+  awardCoins: (action: RewardActionType, metadata?: Record<string, unknown>) => boolean
   onShowSetupDialog: () => void
   onPreferences?: () => void
   onShowLogoutConfirm: () => void


### PR DESCRIPTION
Fixes #21907

## Root cause
PR #21904 split `Clusters.tsx` and `ProfileCard.tsx` into hook + presentational-component pairs. During that extraction, the new files added explicit TypeScript type annotations that didn't match the actual runtime values, and dropped one field from a hook's return object:

- `useClustersView.ts` / `Clusters.parts.tsx`: `isClusterAdmin` was typed as `boolean`, but `usePermissions()` actually returns `isClusterAdmin: (clusterName: string) => boolean`, and `ClusterGrid` calls it as a per-cluster function (`isClusterAdmin(cluster.name)`).
- `useClustersView.ts`: `gpuRefetch` was destructured from `useGPUNodes()` but never included in the hook's returned object, even though `ClustersViewState` declares it and `Clusters.tsx` consumes it via `view.gpuRefetch`.
- `ProfileCard.parts.tsx`: `ProfileActionMenuProps.awardCoins` was typed as `(action: string) => void`, but `useRewards().awardCoins` is actually `(action: RewardActionType, metadata?: Record<string, unknown>) => boolean`.

## Fix
- Corrected `isClusterAdmin` type to `(clusterName: string) => boolean` in both `useClustersView.ts` and `Clusters.parts.tsx`.
- Added the missing `gpuRefetch` field to the object returned by `useClustersView()`.
- Corrected `awardCoins` prop type in `ProfileCard.parts.tsx` to match `useRewards().awardCoins`, importing `RewardActionType` from `../../types/rewards`.

No behavior change — purely restoring type correctness to match existing runtime behavior.

## Files changed
- `web/src/components/clusters/Clusters.parts.tsx`
- `web/src/components/clusters/useClustersView.ts`
- `web/src/components/layout/ProfileCard.parts.tsx`