### PR TITLE
[scanner] fix: restore main build by typing settings section keys

### DIFF
--- a/web/src/components/settings/Settings.parts.tsx
+++ b/web/src/components/settings/Settings.parts.tsx
@@ -216,7 +216,7 @@ export function MobileHeader({ syncStatus }: MobileHeaderProps) {
 }
 
 interface SectionGroupHeaderProps {
-  labelKey: string
+  labelKey: (typeof SETTINGS_NAV)[number]['groupKey']
 }
 
 export function SectionGroupHeader({ labelKey }: SectionGroupHeaderProps) {

--- a/web/src/components/settings/Settings.parts.tsx
+++ b/web/src/components/settings/Settings.parts.tsx
@@ -36,6 +36,8 @@ export type SettingsNavGroup = {
   items: SettingsNavItem[]
 }
 
+export type SettingsGroupKey = (typeof SETTINGS_NAV)[number]['groupKey']
+
 // Labels use i18n keys resolved at render time. `as const` on each key keeps the
 // literal string type so it satisfies the typed i18next `t()` signature.
 export const SETTINGS_NAV = [
@@ -216,7 +218,7 @@ export function MobileHeader({ syncStatus }: MobileHeaderProps) {
 }
 
 interface SectionGroupHeaderProps {
-  labelKey: (typeof SETTINGS_NAV)[number]['groupKey']
+  labelKey: SettingsGroupKey
 }
 
 export function SectionGroupHeader({ labelKey }: SectionGroupHeaderProps) {


### PR DESCRIPTION
Fixes #21926
Fixes #21927
Fixes #21928
Fixes #21929

## Summary
- narrow `SectionGroupHeader` `labelKey` from `string` to the `SETTINGS_NAV` group-key union
- resolve i18next typed key mismatch (`TS2345`) in `Settings.parts.tsx` that broke main `Build and Deploy KC`