### PR TITLE
[scanner] fix: type settings section header keys

### DIFF
--- a/web/src/components/settings/Settings.parts.tsx
+++ b/web/src/components/settings/Settings.parts.tsx
@@ -36,6 +36,8 @@ export type SettingsNavGroup = {
   items: SettingsNavItem[]
 }
 
+export type SettingsGroupKey = (typeof SETTINGS_NAV)[number]['groupKey']
+
 // Labels use i18n keys resolved at render time. `as const` on each key keeps the
 // literal string type so it satisfies the typed i18next `t()` signature.
 export const SETTINGS_NAV = [
@@ -216,7 +218,7 @@ export function MobileHeader({ syncStatus }: MobileHeaderProps) {
 }
 
 interface SectionGroupHeaderProps {
-  labelKey: string
+  labelKey: SettingsGroupKey
 }
 
 export function SectionGroupHeader({ labelKey }: SectionGroupHeaderProps) {


### PR DESCRIPTION
Restores the typed i18next call in `web/src/components/settings/Settings.parts.tsx` by narrowing `SectionGroupHeader` to the literal settings-group key union.

This fixes the main build failure introduced by the settings split.
