### PR TITLE
[quality] test: unit tests for drift/operator drilldown helper functions

### DIFF
--- a/web/src/components/drilldown/views/drift-drilldown/helpers.test.ts
+++ b/web/src/components/drilldown/views/drift-drilldown/helpers.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest'
+import { CheckCircle, XCircle, AlertTriangle } from 'lucide-react'
+import { getDriftSeverityStyle, getChangeTypeStyle } from './helpers'
+
+describe('getDriftSeverityStyle', () => {
+  it.each([
+    ['none', CheckCircle, 'text-green-400'],
+    ['synced', CheckCircle, 'text-green-400'],
+    ['SYNCED', CheckCircle, 'text-green-400'],
+    ['low', AlertTriangle, 'text-yellow-400'],
+    ['minor', AlertTriangle, 'text-yellow-400'],
+    ['medium', AlertTriangle, 'text-orange-400'],
+    ['moderate', AlertTriangle, 'text-orange-400'],
+    ['high', XCircle, 'text-red-400'],
+    ['critical', XCircle, 'text-red-400'],
+    ['drifted', XCircle, 'text-red-400'],
+  ])('maps severity %s to expected style', (severity, icon, text) => {
+    const style = getDriftSeverityStyle(severity)
+    expect(style.icon).toBe(icon)
+    expect(style.text).toBe(text)
+    expect(style.bg).toBeDefined()
+    expect(style.border).toBeDefined()
+  })
+
+  it('returns fallback style for unknown severity', () => {
+    const style = getDriftSeverityStyle('unknown-value')
+    expect(style.icon).toBe(AlertTriangle)
+    expect(style.text).toBe('text-muted-foreground')
+    expect(style.bg).toBe('bg-secondary')
+    expect(style.border).toBe('border-border')
+  })
+
+  it('handles empty string as fallback', () => {
+    const style = getDriftSeverityStyle('')
+    expect(style.icon).toBe(AlertTriangle)
+    expect(style.text).toBe('text-muted-foreground')
+  })
+
+  it('handles null/undefined severity safely', () => {
+    // @ts-expect-error verify runtime safety of undefined input
+    const styleU = getDriftSeverityStyle(undefined)
+    // @ts-expect-error verify runtime safety of null input
+    const styleN = getDriftSeverityStyle(null)
+    expect(styleU.text).toBe('text-muted-foreground')
+    expect(styleN.text).toBe('text-muted-foreground')
+  })
+})
+
+describe('getChangeTypeStyle', () => {
+  it.each([
+    ['added', 'text-green-400', 'Added'],
+    ['create', 'text-green-400', 'Added'],
+    ['modified', 'text-yellow-400', 'Modified'],
+    ['update', 'text-yellow-400', 'Modified'],
+    ['changed', 'text-yellow-400', 'Modified'],
+    ['deleted', 'text-red-400', 'Deleted'],
+    ['remove', 'text-red-400', 'Deleted'],
+    ['DELETED', 'text-red-400', 'Deleted'],
+  ])('maps change type %s to expected style', (changeType, text, label) => {
+    const style = getChangeTypeStyle(changeType)
+    expect(style.text).toBe(text)
+    expect(style.label).toBe(label)
+    expect(style.bg).toBeDefined()
+  })
+
+  it('falls back and preserves original label for unknown change type', () => {
+    const style = getChangeTypeStyle('mystery')
+    expect(style.text).toBe('text-muted-foreground')
+    expect(style.bg).toBe('bg-secondary')
+    expect(style.label).toBe('mystery')
+  })
+
+  it('handles empty string as fallback with empty label', () => {
+    const style = getChangeTypeStyle('')
+    expect(style.text).toBe('text-muted-foreground')
+    expect(style.label).toBe('')
+  })
+})

--- a/web/src/components/drilldown/views/operator-drilldown/helpers.test.ts
+++ b/web/src/components/drilldown/views/operator-drilldown/helpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest'
+import { CheckCircle, XCircle, AlertTriangle, RefreshCw } from 'lucide-react'
+import { getPhaseStyle } from './helpers'
+
+describe('getPhaseStyle', () => {
+  it.each([
+    ['succeeded', CheckCircle, 'text-green-400'],
+    ['installed', CheckCircle, 'text-green-400'],
+    ['SUCCEEDED', CheckCircle, 'text-green-400'],
+    ['installing', RefreshCw, 'text-blue-400'],
+    ['pending', RefreshCw, 'text-blue-400'],
+    ['installready', RefreshCw, 'text-blue-400'],
+    ['failed', XCircle, 'text-red-400'],
+    ['unknown', XCircle, 'text-red-400'],
+    ['upgrading', RefreshCw, 'text-yellow-400'],
+    ['replacing', RefreshCw, 'text-yellow-400'],
+  ])('maps phase %s to expected style', (phase, icon, text) => {
+    const style = getPhaseStyle(phase)
+    expect(style.icon).toBe(icon)
+    expect(style.text).toBe(text)
+    expect(style.bg).toBeDefined()
+    expect(style.border).toBeDefined()
+  })
+
+  it('returns fallback style for unrecognized phase', () => {
+    const style = getPhaseStyle('quiescent')
+    expect(style.icon).toBe(AlertTriangle)
+    expect(style.text).toBe('text-muted-foreground')
+    expect(style.bg).toBe('bg-secondary')
+    expect(style.border).toBe('border-border')
+  })
+
+  it('handles empty string as fallback', () => {
+    const style = getPhaseStyle('')
+    expect(style.icon).toBe(AlertTriangle)
+    expect(style.text).toBe('text-muted-foreground')
+  })
+
+  it('handles null/undefined phase safely', () => {
+    // @ts-expect-error verify runtime safety of undefined input
+    const styleU = getPhaseStyle(undefined)
+    // @ts-expect-error verify runtime safety of null input
+    const styleN = getPhaseStyle(null)
+    expect(styleU.text).toBe('text-muted-foreground')
+    expect(styleN.text).toBe('text-muted-foreground')
+  })
+})


### PR DESCRIPTION
## Test Improvement

Adds 36 unit tests for the pure style helper functions extracted in #21950. This PR targets the `scanner/fix-21803` branch so tests land alongside the extraction, addressing the `needs-tests` label.

### Coverage

**`drift-drilldown/helpers.tsx`**
- `getDriftSeverityStyle` — all documented severity branches (none/synced, low/minor, medium/moderate, high/critical/drifted), case-insensitive matching, unknown-value fallback, empty string, null/undefined runtime safety
- `getChangeTypeStyle` — added/create, modified/update/changed, deleted/remove, unknown-value fallback (verifies fallback preserves original label), empty string

**`operator-drilldown/helpers.tsx`**
- `getPhaseStyle` — succeeded/installed, installing/pending/installready, failed/unknown, upgrading/replacing, case-insensitive matching, unknown-value fallback, empty string, null/undefined runtime safety

### Verification

```
$ npx vitest run src/components/drilldown/views/drift-drilldown/helpers.test.ts \
                src/components/drilldown/views/operator-drilldown/helpers.test.ts
Test Files  2 passed (2)
     Tests  36 passed (36)
```

Follows the existing `vitest` + `describe/it/expect` convention used elsewhere in `web/src/components/drilldown/views/`.

Related to #21950 (adds tests for its extracted helpers).

---
*Filed by quality agent (ACMM L4/L6 — full mode)*