### PR TITLE
🌱 refactor: split oversized drilldown components

### DIFF
--- a/web/src/components/drilldown/views/EventsDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.parts.tsx
@@ -1,0 +1,245 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
+import { ClusterEvent } from './useEventsDrillDown'
+import { StatusIndicator } from '../../charts/StatusIndicator'
+import { Terminal, Copy, CheckCircle, RefreshCw, AlertCircle } from 'lucide-react'
+
+// Skeleton component for loading state
+export function EventsSkeleton() {
+  return (
+    <div className="space-y-4 animate-pulse">
+      <div className="grid grid-cols-3 gap-4">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="p-4 rounded-lg bg-card/50 border border-border">
+            <div className="h-8 w-16 bg-muted rounded mb-2" />
+            <div className="h-4 w-24 bg-muted rounded" />
+          </div>
+        ))}
+      </div>
+      <div className="space-y-2">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="p-4 rounded-lg bg-card/50 border-l-4 border-l-muted">
+            <div className="h-4 w-32 bg-muted rounded mb-2" />
+            <div className="h-3 w-48 bg-muted rounded mb-2" />
+            <div className="h-3 w-full bg-muted rounded" />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface StatsProps {
+  totalCount: number
+  warningCount: number
+  normalCount: number
+}
+
+export function EventsStats({ totalCount, warningCount, normalCount }: StatsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-2xl font-bold text-foreground">{totalCount}</div>
+        <div className="text-sm text-muted-foreground">{t('drilldown.events.totalEvents', 'Total Events')}</div>
+      </div>
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-2xl font-bold text-yellow-400">{warningCount}</div>
+        <div className="text-sm text-muted-foreground">{t('common.warnings', 'Warnings')}</div>
+      </div>
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-2xl font-bold text-green-400">{normalCount}</div>
+        <div className="text-sm text-muted-foreground">{t('common.normal')}</div>
+      </div>
+    </div>
+  )
+}
+
+interface EventRowProps {
+  event: ClusterEvent
+}
+
+export function EventRow({ event }: EventRowProps) {
+  return (
+    <div
+      className={`p-4 rounded-lg border-l-4 ${
+        event.type === 'Warning'
+          ? 'bg-yellow-500/10 border-l-yellow-500'
+          : 'bg-card/50 border-l-green-500'
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2">
+          <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
+          <span className="font-medium text-foreground">{event.reason}</span>
+        </div>
+        {event.count > 1 && (
+          <span className="text-xs px-2 py-1 rounded bg-card text-muted-foreground">
+            x{event.count}
+          </span>
+        )}
+      </div>
+      <div className="text-xs text-muted-foreground mt-1">
+        {event.namespace}/{event.object}
+      </div>
+      <p className="text-sm text-foreground mt-2">{event.message}</p>
+      {event.lastSeen && (
+        <div className="text-xs text-muted-foreground mt-2">
+          Last seen: {new Date(event.lastSeen).toLocaleString()}
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface KubectlFallbackProps {
+  clusterShort: string
+  namespace: string | undefined
+  objectName: string | undefined
+  copied: boolean
+  onCopyCommand: () => void
+}
+
+export function KubectlFallback({ clusterShort, namespace, objectName, copied, onCopyCommand }: KubectlFallbackProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="p-4 rounded-lg bg-card/50 border border-border">
+      <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+        <Terminal className="w-4 h-4" />
+        {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
+      </h4>
+      <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
+        <code className="text-muted-foreground truncate">
+          kubectl --context {clusterShort} get events{objectName ? ` --field-selector involvedObject.name=${objectName}` : ''}{namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp
+        </code>
+        <button
+          onClick={onCopyCommand}
+          className="ml-2 p-1 hover:bg-card rounded shrink-0"
+          title={t('drilldown.tooltips.copyCommand')}
+        >
+          {copied ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
+        </button>
+      </div>
+    </div>
+  )
+}
+
+interface ErrorStateProps {
+  error: string | null
+  clusterShort: string
+  namespace: string | undefined
+  objectName: string | undefined
+  isLoading: boolean
+  copied: boolean
+  onRefetch: () => void
+  onCopyCommand: () => void
+}
+
+export function ErrorState({ error, clusterShort, namespace, objectName, isLoading, copied, onRefetch, onCopyCommand }: ErrorStateProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-4">
+      <div className="p-6 rounded-lg bg-yellow-500/10 border border-yellow-500/30 text-center">
+        <AlertCircle className="w-8 h-8 text-yellow-400 mx-auto mb-3" />
+        <h4 className="font-medium text-yellow-400 mb-2">
+          {error ? t('drilldown.events.failedToLoad', 'Failed to load events') : t('drilldown.events.noEventsFound', 'No events found')}
+        </h4>
+        <p className="text-sm text-muted-foreground mb-4">
+          {error || `No events found for ${objectName || clusterShort}. Events may have expired or the cluster may be unreachable.`}
+        </p>
+        <div className="flex justify-center gap-2">
+          <button
+            onClick={onRefetch}
+            className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card border border-border text-sm hover:bg-card/80 transition-colors"
+          >
+            <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
+            {t('common.retry', 'Retry')}
+          </button>
+        </div>
+      </div>
+      <KubectlFallback
+        clusterShort={clusterShort}
+        namespace={namespace}
+        objectName={objectName}
+        copied={copied}
+        onCopyCommand={onCopyCommand}
+      />
+    </div>
+  )
+}
+
+interface PaginationProps {
+  currentPage: number
+  totalPages: number
+  totalCount: number
+  onPageChange: (page: number) => void
+}
+
+/** Events displayed per page. */
+export const PAGE_SIZE = 20
+
+export function Pagination({ currentPage, totalPages, totalCount, onPageChange }: PaginationProps) {
+  const { t } = useTranslation()
+  const ChevronLeft = () => (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+    </svg>
+  )
+  const ChevronRight = () => (
+    <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  )
+
+  return (
+    <div className="flex items-center justify-between pt-2 text-sm text-muted-foreground border-t border-border">
+      <span>
+        {t('drilldown.events.showingRange', {
+          from: (currentPage - 1) * PAGE_SIZE + 1,
+          to: Math.min(currentPage * PAGE_SIZE, totalCount),
+          total: totalCount,
+          defaultValue: `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, totalCount)} of ${totalCount}`,
+        })}
+      </span>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={() => onPageChange(currentPage - 1)}
+          disabled={currentPage === 1}
+          aria-label={t('common.previousPage', 'Previous page')}
+          className={cn(
+            'p-1.5 rounded-lg transition-colors',
+            currentPage === 1
+              ? 'text-muted-foreground/40 cursor-not-allowed'
+              : 'hover:bg-card text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <ChevronLeft />
+        </button>
+        <span className="px-2 tabular-nums">
+          {t('drilldown.events.pageOf', {
+            page: currentPage,
+            total: totalPages,
+            defaultValue: `Page ${currentPage} of ${totalPages}`,
+          })}
+        </span>
+        <button
+          onClick={() => onPageChange(currentPage + 1)}
+          disabled={currentPage === totalPages}
+          aria-label={t('common.nextPage', 'Next page')}
+          className={cn(
+            'p-1.5 rounded-lg transition-colors',
+            currentPage === totalPages
+              ? 'text-muted-foreground/40 cursor-not-allowed'
+              : 'hover:bg-card text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <ChevronRight />
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/EventsDrillDown.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.tsx
@@ -1,61 +1,22 @@
-import { useMemo, useState, useEffect, useCallback, useRef } from 'react'
-import { AlertCircle, RefreshCw, Terminal, Copy, CheckCircle, Server, Layers, ChevronLeft, ChevronRight, Search, Filter } from 'lucide-react'
-import { StatusIndicator } from '../../charts/StatusIndicator'
+import { useMemo, useState, useEffect } from 'react'
+import { ChevronLeft, ChevronRight, Server, Layers, Search, Filter } from 'lucide-react'
 import { ClusterBadge } from '../../ui/ClusterBadge'
-import { getDemoMode } from '../../../hooks/useDemoMode'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useTranslation } from 'react-i18next'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
-import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
-import { agentFetch } from '../../../hooks/mcp/shared'
-import { copyToClipboard } from '../../../lib/clipboard'
 import { cn } from '../../../lib/cn'
-
-interface ClusterEvent {
-  type: string
-  reason: string
-  message: string
-  object: string
-  namespace: string
-  cluster: string
-  count: number
-  age?: string
-  firstSeen?: string
-  lastSeen?: string
-}
+import { useEventsDrillDown, TypeFilter } from './useEventsDrillDown'
+import {
+  EventsSkeleton,
+  EventsStats,
+  EventRow,
+  KubectlFallback,
+  ErrorState,
+  Pagination,
+  PAGE_SIZE,
+} from './EventsDrillDown.parts'
 
 interface Props {
   data: Record<string, unknown>
-}
-
-/** Events displayed per page. */
-const PAGE_SIZE = 20
-
-type TypeFilter = 'all' | 'Warning' | 'Normal'
-
-// Skeleton component for loading state
-function EventsSkeleton() {
-  return (
-    <div className="space-y-4 animate-pulse">
-      <div className="grid grid-cols-3 gap-4">
-        {[1, 2, 3].map(i => (
-          <div key={i} className="p-4 rounded-lg bg-card/50 border border-border">
-            <div className="h-8 w-16 bg-muted rounded mb-2" />
-            <div className="h-4 w-24 bg-muted rounded" />
-          </div>
-        ))}
-      </div>
-      <div className="space-y-2">
-        {[1, 2, 3].map(i => (
-          <div key={i} className="p-4 rounded-lg bg-card/50 border-l-4 border-l-muted">
-            <div className="h-4 w-32 bg-muted rounded mb-2" />
-            <div className="h-3 w-48 bg-muted rounded mb-2" />
-            <div className="h-3 w-full bg-muted rounded" />
-          </div>
-        ))}
-      </div>
-    </div>
-  )
 }
 
 export function EventsDrillDown({ data }: Props) {
@@ -67,65 +28,16 @@ export function EventsDrillDown({ data }: Props) {
   const { state, pop, close } = useDrillDown()
   const { drillToCluster, drillToNamespace } = useDrillDownActions()
 
-  const [events, setEvents] = useState<ClusterEvent[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [copied, setCopied] = useState(false)
-  const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const { events, isLoading, error, copied, refetch, copyCommand } = useEventsDrillDown(
+    clusterShort,
+    namespace,
+    objectName
+  )
 
   // Interactive controls
   const [currentPage, setCurrentPage] = useState(1)
   const [typeFilter, setTypeFilter] = useState<TypeFilter>('all')
   const [searchQuery, setSearchQuery] = useState('')
-
-  // Fetch events from local agent (no auth required)
-  const refetch = useCallback(async (silent = false) => {
-    // Skip agent requests in demo mode (no local agent on Netlify)
-    if (getDemoMode()) {
-      setIsLoading(false)
-      return
-    }
-    if (!silent) setIsLoading(true)
-    setError(null)
-    try {
-      // Use local agent - for node events, check default namespace with higher limit
-      const params = new URLSearchParams()
-      params.append('cluster', clusterShort)
-      // For node events, use default namespace where node events are stored
-      if (objectName && !namespace) {
-        params.append('namespace', 'default')
-      } else if (namespace) {
-        params.append('namespace', namespace)
-      }
-      if (objectName) {
-        params.append('object', objectName)
-      }
-      params.append('limit', '100')
-
-      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-      })
-      if (response.ok) {
-        const data = await response.json()
-        setEvents(data.events || [])
-      } else {
-        setError('Failed to fetch events')
-      }
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch events')
-    } finally {
-      setIsLoading(false)
-    }
-  }, [clusterShort, namespace, objectName])
-
-  // Initial fetch and auto-refresh every 30 seconds
-  useEffect(() => {
-    refetch()
-    refreshIntervalRef.current = setInterval(() => refetch(true), POLL_INTERVAL_MS)
-    return () => {
-      if (refreshIntervalRef.current) clearInterval(refreshIntervalRef.current)
-    }
-  }, [refetch])
 
   // Reset to page 1 when the viewed resource changes so stale page numbers
   // don't persist across drilldown navigations to different resources.
@@ -139,8 +51,6 @@ export function EventsDrillDown({ data }: Props) {
   }, [typeFilter, searchQuery])
 
   // Full pre-paginated dataset: apply objectName, type, and search filters then sort.
-  // Stat tiles read from this so they always reflect the complete matching set,
-  // not just the items visible on the current page.
   const allFilteredSortedEvents = useMemo(() => {
     let result = events
 
@@ -182,15 +92,6 @@ export function EventsDrillDown({ data }: Props) {
     setSearchQuery('')
   }
 
-  const copyCommand = () => {
-    const cmd = objectName
-      ? `kubectl --context ${clusterShort} get events --field-selector involvedObject.name=${objectName}${namespace ? ` -n ${namespace}` : ''}`
-      : `kubectl --context ${clusterShort} get events${namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp`
-    copyToClipboard(cmd)
-    setCopied(true)
-    setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
-  }
-
   if (isLoading && events.length === 0 && !error) {
     return <EventsSkeleton />
   }
@@ -198,46 +99,16 @@ export function EventsDrillDown({ data }: Props) {
   // Show error state with retry and kubectl fallback
   if (error || (events.length === 0 && !isLoading)) {
     return (
-      <div className="space-y-4">
-        <div className="p-6 rounded-lg bg-yellow-500/10 border border-yellow-500/30 text-center">
-          <AlertCircle className="w-8 h-8 text-yellow-400 mx-auto mb-3" />
-          <h4 className="font-medium text-yellow-400 mb-2">
-            {error ? t('drilldown.events.failedToLoad', 'Failed to load events') : t('drilldown.events.noEventsFound', 'No events found')}
-          </h4>
-          <p className="text-sm text-muted-foreground mb-4">
-            {error || `No events found for ${objectName || clusterShort}. Events may have expired or the cluster may be unreachable.`}
-          </p>
-          <div className="flex justify-center gap-2">
-            <button
-              onClick={() => refetch?.()}
-              className="flex items-center gap-2 px-4 py-2 rounded-lg bg-card border border-border text-sm hover:bg-card/80 transition-colors"
-            >
-              <RefreshCw className={`w-4 h-4 ${isLoading ? 'animate-spin' : ''}`} />
-              {t('common.retry', 'Retry')}
-            </button>
-          </div>
-        </div>
-
-        {/* Kubectl fallback */}
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-            <Terminal className="w-4 h-4" />
-            {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
-          </h4>
-          <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
-            <code className="text-muted-foreground truncate">
-              kubectl --context {clusterShort} get events{objectName ? ` --field-selector involvedObject.name=${objectName}` : ''}{namespace ? ` -n ${namespace}` : ' -A'}
-            </code>
-            <button
-              onClick={copyCommand}
-              className="ml-2 p-1 hover:bg-card rounded shrink-0"
-              title={t('drilldown.tooltips.copyCommand')}
-            >
-              {copied ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
-            </button>
-          </div>
-        </div>
-      </div>
+      <ErrorState
+        error={error}
+        clusterShort={clusterShort}
+        namespace={namespace}
+        objectName={objectName}
+        isLoading={isLoading}
+        copied={copied}
+        onRefetch={() => refetch()}
+        onCopyCommand={copyCommand}
+      />
     )
   }
 
@@ -325,35 +196,7 @@ export function EventsDrillDown({ data }: Props) {
       {/* Events List */}
       <div className="space-y-2">
         {pagedEvents.map((event, i) => (
-          <div
-            key={i}
-            className={`p-4 rounded-lg border-l-4 ${
-              event.type === 'Warning'
-                ? 'bg-yellow-500/10 border-l-yellow-500'
-                : 'bg-card/50 border-l-green-500'
-            }`}
-          >
-            <div className="flex items-start justify-between">
-              <div className="flex items-center gap-2">
-                <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
-                <span className="font-medium text-foreground">{event.reason}</span>
-              </div>
-              {event.count > 1 && (
-                <span className="text-xs px-2 py-1 rounded bg-card text-muted-foreground">
-                  x{event.count}
-                </span>
-              )}
-            </div>
-            <div className="text-xs text-muted-foreground mt-1">
-              {event.namespace}/{event.object}
-            </div>
-            <p className="text-sm text-foreground mt-2">{event.message}</p>
-            {event.lastSeen && (
-              <div className="text-xs text-muted-foreground mt-2">
-                Last seen: {new Date(event.lastSeen).toLocaleString()}
-              </div>
-            )}
-          </div>
+          <EventRow key={i} event={event} />
         ))}
       </div>
 
@@ -383,75 +226,25 @@ export function EventsDrillDown({ data }: Props) {
 
           {/* Kubectl fallback — only shown when no active filters are hiding results */}
           {!hasActiveFilters && (
-            <div className="p-4 rounded-lg bg-card/50 border border-border">
-              <h4 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-                <Terminal className="w-4 h-4" />
-                {t('drilldown.actions.getEvents', 'Get Events via kubectl')}
-              </h4>
-              <div className="flex items-center justify-between p-2 rounded bg-background/50 font-mono text-xs">
-                <code className="text-muted-foreground truncate">
-                  kubectl --context {clusterShort} get events{objectName ? ` --field-selector involvedObject.name=${objectName}` : ''}{namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp
-                </code>
-                <button
-                  onClick={copyCommand}
-                  className="ml-2 p-1 hover:bg-card rounded shrink-0"
-                  title={t('drilldown.tooltips.copyCommand')}
-                >
-                  {copied ? <CheckCircle className="w-3 h-3 text-green-400" /> : <Copy className="w-3 h-3 text-muted-foreground" />}
-                </button>
-              </div>
-            </div>
+            <KubectlFallback
+              clusterShort={clusterShort}
+              namespace={namespace}
+              objectName={objectName}
+              copied={copied}
+              onCopyCommand={copyCommand}
+            />
           )}
         </div>
       )}
 
       {/* Pagination controls — shown only when there is more than one page */}
       {totalPages > 1 && (
-        <div className="flex items-center justify-between pt-2 text-sm text-muted-foreground border-t border-border">
-          <span>
-            {t('drilldown.events.showingRange', {
-              from: (currentPage - 1) * PAGE_SIZE + 1,
-              to: Math.min(currentPage * PAGE_SIZE, allFilteredSortedEvents.length),
-              total: allFilteredSortedEvents.length,
-              defaultValue: `Showing ${(currentPage - 1) * PAGE_SIZE + 1}–${Math.min(currentPage * PAGE_SIZE, allFilteredSortedEvents.length)} of ${allFilteredSortedEvents.length}`,
-            })}
-          </span>
-          <div className="flex items-center gap-1">
-            <button
-              onClick={() => setCurrentPage(p => p - 1)}
-              disabled={currentPage === 1}
-              aria-label={t('common.previousPage', 'Previous page')}
-              className={cn(
-                'p-1.5 rounded-lg transition-colors',
-                currentPage === 1
-                  ? 'text-muted-foreground/40 cursor-not-allowed'
-                  : 'hover:bg-card text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </button>
-            <span className="px-2 tabular-nums">
-              {t('drilldown.events.pageOf', {
-                page: currentPage,
-                total: totalPages,
-                defaultValue: `Page ${currentPage} of ${totalPages}`,
-              })}
-            </span>
-            <button
-              onClick={() => setCurrentPage(p => p + 1)}
-              disabled={currentPage === totalPages}
-              aria-label={t('common.nextPage', 'Next page')}
-              className={cn(
-                'p-1.5 rounded-lg transition-colors',
-                currentPage === totalPages
-                  ? 'text-muted-foreground/40 cursor-not-allowed'
-                  : 'hover:bg-card text-muted-foreground hover:text-foreground'
-              )}
-            >
-              <ChevronRight className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
+        <Pagination
+          currentPage={currentPage}
+          totalPages={totalPages}
+          totalCount={allFilteredSortedEvents.length}
+          onPageChange={setCurrentPage}
+        />
       )}
     </div>
   )

--- a/web/src/components/drilldown/views/NamespaceDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.parts.tsx
@@ -1,0 +1,210 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
+import { StatusIndicator } from '../../charts/StatusIndicator'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { ChevronRight, Box, Network, HardDrive } from 'lucide-react'
+import { DeploymentIssue, PodIssue, NamespaceEvent, Pod, Deployment, Service, PVC } from './useNamespaceDrillDown'
+
+interface DeploymentIssueRowProps {
+  issue: DeploymentIssue
+  onClick: () => void
+}
+
+export function DeploymentIssueRow({ issue, onClick }: DeploymentIssueRowProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="p-4 rounded-lg bg-orange-500/10 border border-orange-500/20 cursor-pointer hover:bg-orange-500/20 transition-colors"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="font-semibold text-foreground">{issue.name}</span>
+            <StatusBadge color="orange" size="xs">
+              {issue.readyReplicas}/{issue.replicas} ready
+            </StatusBadge>
+          </div>
+          {issue.reason && (
+            <div className="text-sm text-muted-foreground">Reason: {issue.reason}</div>
+          )}
+          {issue.message && (
+            <div className="text-xs text-orange-400 mt-1">{issue.message}</div>
+          )}
+        </div>
+        <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0 ml-4" />
+      </div>
+    </div>
+  )
+}
+
+interface PodIssueRowProps {
+  issue: PodIssue
+  onClick: () => void
+}
+
+export function PodIssueRow({ issue, onClick }: PodIssueRowProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-1">
+            <span className="font-semibold text-foreground">{issue.name}</span>
+            <StatusBadge color="red" size="xs">
+              {issue.status}
+            </StatusBadge>
+          </div>
+          <div className="flex items-center gap-4 text-sm text-muted-foreground">
+            <span>{issue.restarts} restarts</span>
+            {issue.reason && <span>• {issue.reason}</span>}
+          </div>
+          {(issue.issues?.length ?? 0) > 0 && (
+            <div className="flex flex-wrap gap-1 mt-2">
+              {issue.issues?.map((iss, j) => (
+                <StatusBadge key={j} color="red" size="xs">
+                  {iss}
+                </StatusBadge>
+              ))}
+            </div>
+          )}
+        </div>
+        <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0 ml-4" />
+      </div>
+    </div>
+  )
+}
+
+interface EventRowProps {
+  event: NamespaceEvent
+}
+
+export function EventRow({ event }: EventRowProps) {
+  return (
+    <div
+      className={`p-3 rounded-lg border-l-4 ${
+        event.type === 'Warning'
+          ? 'bg-yellow-500/10 border-l-yellow-500'
+          : 'bg-card/50 border-l-green-500'
+      }`}
+    >
+      <div className="flex items-center gap-2">
+        <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
+        <span className="font-medium text-foreground text-sm">{event.reason}</span>
+        <span className="text-xs text-muted-foreground">on {event.object}</span>
+      </div>
+      <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{event.message}</p>
+    </div>
+  )
+}
+
+interface PodRowProps {
+  pod: Pod
+  onClick: () => void
+}
+
+export function PodRow({ pod, onClick }: PodRowProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+    >
+      <div className={`w-2 h-2 rounded-full ${pod.status === 'Running' ? 'bg-green-400' : pod.status === 'Pending' ? 'bg-yellow-400' : 'bg-red-400'}`} />
+      <Box className="w-3 h-3 text-green-400" />
+      <span className="text-sm text-foreground">{pod.name}</span>
+      <StatusBadge
+        color={pod.status === 'Running' ? 'green' : pod.status === 'Pending' ? 'yellow' : 'red'}
+        size="xs"
+      >
+        {pod.status}
+      </StatusBadge>
+      <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+    </div>
+  )
+}
+
+interface DeploymentRowProps {
+  deployment: Deployment
+  onClick: () => void
+}
+
+export function DeploymentRow({ deployment, onClick }: DeploymentRowProps) {
+  return (
+    <div
+      onClick={onClick}
+      className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
+    >
+      <Box className="w-3 h-3 text-blue-400" />
+      <span className="text-sm text-foreground">{deployment.name}</span>
+      <span className={`text-xs ${deployment.readyReplicas === deployment.replicas ? 'text-green-400' : 'text-yellow-400'}`}>
+        {deployment.readyReplicas}/{deployment.replicas}
+      </span>
+      <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+    </div>
+  )
+}
+
+interface ServiceRowProps {
+  service: Service
+}
+
+export function ServiceRow({ service }: ServiceRowProps) {
+  return (
+    <div className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group">
+      <Network className="w-3 h-3 text-blue-400" />
+      <span className="text-sm text-foreground">{service.name}</span>
+      <StatusBadge color="blue" size="xs">{service.type}</StatusBadge>
+      <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+    </div>
+  )
+}
+
+interface PVCRowProps {
+  pvc: PVC
+}
+
+export function PVCRow({ pvc }: PVCRowProps) {
+  return (
+    <div className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group">
+      <HardDrive className="w-3 h-3 text-green-400" />
+      <span className="text-sm text-foreground">{pvc.name}</span>
+      <StatusBadge
+        color={pvc.status === 'Bound' ? 'green' : 'yellow'}
+        size="xs"
+      >
+        {pvc.status}
+      </StatusBadge>
+      {pvc.capacity && <span className="text-xs text-muted-foreground">{pvc.capacity}</span>}
+      <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
+    </div>
+  )
+}
+
+interface OverviewStatsProps {
+  deploymentIssuesCount: number
+  podIssuesCount: number
+  eventsCount: number
+}
+
+export function OverviewStats({ deploymentIssuesCount, podIssuesCount, eventsCount }: OverviewStatsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="grid grid-cols-3 gap-4">
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.deploymentsWithIssues', 'Deployments with Issues')}</div>
+        <div className="text-2xl font-bold text-foreground">{deploymentIssuesCount}</div>
+      </div>
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.podsWithIssues', 'Pods with Issues')}</div>
+        <div className="text-2xl font-bold text-foreground">{podIssuesCount}</div>
+      </div>
+      <div className="p-4 rounded-lg bg-card/50 border border-border">
+        <div className="text-sm text-muted-foreground mb-2">{t('drilldown.fields.recentEvents')}</div>
+        <div className="text-2xl font-bold text-foreground">{eventsCount}</div>
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -139,7 +139,6 @@ export function NamespaceDrillDown({ data }: Props) {
                 </span>
               )}
             </button>
-          ))}
         </div>
       </div>
 

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -139,6 +139,7 @@ export function NamespaceDrillDown({ data }: Props) {
                 </span>
               )}
             </button>
+          ))}
         </div>
       </div>
 
@@ -204,7 +205,6 @@ export function NamespaceDrillDown({ data }: Props) {
             <div className="space-y-2">
               {nsEvents.map((event, i) => (
                 <EventRow key={i} event={event} />
-              ))}
               ))}
             </div>
           ) : (

--- a/web/src/components/drilldown/views/NamespaceDrillDown.tsx
+++ b/web/src/components/drilldown/views/NamespaceDrillDown.tsx
@@ -1,14 +1,21 @@
 import { useState } from 'react'
-import { ChevronRight, Search, Box, Network, HardDrive, Layers, Server } from 'lucide-react'
-import { usePodIssues, useDeploymentIssues, useEvents, useDeployments, useServices, usePods } from '../../../hooks/useMCP'
-import { useCachedPVCs } from '../../../hooks/useCachedData'
+import { Search, Box, Network, HardDrive, Layers, Server } from 'lucide-react'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
-import { StatusIndicator } from '../../charts/StatusIndicator'
-import { StatusBadge } from '../../ui/StatusBadge'
 import { useTranslation } from 'react-i18next'
 import { useTabKeyboardNav } from '../../../hooks/useKeyboardNav'
 import { cn } from '../../../lib/cn'
+import { useNamespaceDrillDown } from './useNamespaceDrillDown'
+import {
+  DeploymentIssueRow,
+  PodIssueRow,
+  EventRow,
+  PodRow,
+  DeploymentRow,
+  ServiceRow,
+  PVCRow,
+  OverviewStats,
+} from './NamespaceDrillDown.parts'
 
 type TabType = 'issues' | 'events' | 'resources'
 type ResourceFilter = 'all' | 'pods' | 'deployments' | 'services' | 'pvcs'
@@ -21,6 +28,7 @@ export function NamespaceDrillDown({ data }: Props) {
   const { t } = useTranslation()
   const cluster = data.cluster as string
   const namespace = data.namespace as string
+  const clusterShort = cluster.split('/').pop() || cluster
   const { drillToDeployment, drillToPod, drillToEvents, drillToCluster } = useDrillDownActions()
 
   const [activeTab, setActiveTab] = useState<TabType>('issues')
@@ -28,23 +36,15 @@ export function NamespaceDrillDown({ data }: Props) {
   const [resourceSearch, setResourceSearch] = useState('')
   const { tabListProps, getTabProps, getTabPanelProps } = useTabKeyboardNav<TabType>({ tabs: ['issues', 'events', 'resources'], activeTab, onChange: setActiveTab })
 
-  const { issues: allPodIssues } = usePodIssues(cluster)
-  const { issues: allDeploymentIssues } = useDeploymentIssues()
-  const { events } = useEvents(cluster, namespace, 20)
-
-  // Resource hooks for the Resources tab
-  const clusterShort = cluster.split('/').pop() || cluster
-  const { deployments: allDeployments } = useDeployments(clusterShort, namespace)
-  const { services: allServices } = useServices(clusterShort, namespace)
-  const { pvcs: allPVCs } = useCachedPVCs(clusterShort, namespace)
-  const { pods: allPods } = usePods(clusterShort, namespace)
-
-  const podIssues = allPodIssues.filter(p => p.namespace === namespace)
-
-  const deploymentIssues = allDeploymentIssues.filter(d => d.namespace === namespace &&
-      (d.cluster === cluster || d.cluster?.includes(cluster.split('/')[0])))
-
-  const nsEvents = events.filter(e => e.namespace === namespace)
+  const {
+    podIssues,
+    deploymentIssues,
+    nsEvents,
+    allDeployments,
+    allServices,
+    allPVCs,
+    allPods,
+  } = useNamespaceDrillDown(cluster, namespace)
 
   // Filtered resources for the Resources tab
   const filteredDeployments = (() => {
@@ -107,20 +107,11 @@ export function NamespaceDrillDown({ data }: Props) {
       </div>
 
       {/* Overview Stats */}
-      <div className="grid grid-cols-3 gap-4">
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.deploymentsWithIssues', 'Deployments with Issues')}</div>
-          <div className="text-2xl font-bold text-foreground">{deploymentIssues.length}</div>
-        </div>
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-sm text-muted-foreground mb-2">{t('drilldown.namespace.podsWithIssues', 'Pods with Issues')}</div>
-          <div className="text-2xl font-bold text-foreground">{podIssues.length}</div>
-        </div>
-        <div className="p-4 rounded-lg bg-card/50 border border-border">
-          <div className="text-sm text-muted-foreground mb-2">{t('drilldown.fields.recentEvents')}</div>
-          <div className="text-2xl font-bold text-foreground">{nsEvents.length}</div>
-        </div>
-      </div>
+      <OverviewStats
+        deploymentIssuesCount={deploymentIssues.length}
+        podIssuesCount={podIssues.length}
+        eventsCount={nsEvents.length}
+      />
 
       {/* Tabs */}
       <div className="border-b border-border">
@@ -161,29 +152,11 @@ export function NamespaceDrillDown({ data }: Props) {
               <h3 className="text-lg font-semibold text-foreground mb-4">{t('drilldown.namespace.deploymentIssues', 'Deployment Issues')}</h3>
               <div className="space-y-2">
                 {deploymentIssues.map((issue, i) => (
-                  <div
+                  <DeploymentIssueRow
                     key={i}
+                    issue={issue}
                     onClick={() => drillToDeployment(cluster, namespace, issue.name, { ...issue })}
-                    className="p-4 rounded-lg bg-orange-500/10 border border-orange-500/20 cursor-pointer hover:bg-orange-500/20 transition-colors"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-semibold text-foreground">{issue.name}</span>
-                          <StatusBadge color="orange" size="xs">
-                            {issue.readyReplicas}/{issue.replicas} ready
-                          </StatusBadge>
-                        </div>
-                        {issue.reason && (
-                          <div className="text-sm text-muted-foreground">Reason: {issue.reason}</div>
-                        )}
-                        {issue.message && (
-                          <div className="text-xs text-orange-400 mt-1">{issue.message}</div>
-                        )}
-                      </div>
-                      <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0 ml-4" />
-                    </div>
-                  </div>
+                  />
                 ))}
               </div>
             </div>
@@ -195,36 +168,11 @@ export function NamespaceDrillDown({ data }: Props) {
               <h3 className="text-lg font-semibold text-foreground mb-4">{t('drilldown.namespace.podIssues', 'Pod Issues')}</h3>
               <div className="space-y-2">
                 {podIssues.map((issue, i) => (
-                  <div
+                  <PodIssueRow
                     key={i}
+                    issue={issue}
                     onClick={() => drillToPod(cluster, namespace, issue.name, { ...issue })}
-                    className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 cursor-pointer hover:bg-red-500/20 transition-colors"
-                  >
-                    <div className="flex items-center justify-between">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-2 mb-1">
-                          <span className="font-semibold text-foreground">{issue.name}</span>
-                          <StatusBadge color="red" size="xs">
-                            {issue.status}
-                          </StatusBadge>
-                        </div>
-                        <div className="flex items-center gap-4 text-sm text-muted-foreground">
-                          <span>{issue.restarts} restarts</span>
-                          {issue.reason && <span>• {issue.reason}</span>}
-                        </div>
-                        {(issue.issues?.length ?? 0) > 0 && (
-                          <div className="flex flex-wrap gap-1 mt-2">
-                            {issue.issues?.map((iss, j) => (
-                              <StatusBadge key={j} color="red" size="xs">
-                                {iss}
-                              </StatusBadge>
-                            ))}
-                          </div>
-                        )}
-                      </div>
-                      <ChevronRight className="w-5 h-5 text-muted-foreground shrink-0 ml-4" />
-                    </div>
-                  </div>
+                  />
                 ))}
               </div>
             </div>
@@ -256,21 +204,8 @@ export function NamespaceDrillDown({ data }: Props) {
           {nsEvents.length > 0 ? (
             <div className="space-y-2">
               {nsEvents.map((event, i) => (
-                <div
-                  key={i}
-                  className={`p-3 rounded-lg border-l-4 ${
-                    event.type === 'Warning'
-                      ? 'bg-yellow-500/10 border-l-yellow-500'
-                      : 'bg-card/50 border-l-green-500'
-                  }`}
-                >
-                  <div className="flex items-center gap-2">
-                    <StatusIndicator status={event.type === 'Warning' ? 'warning' : 'healthy'} size="sm" />
-                    <span className="font-medium text-foreground text-sm">{event.reason}</span>
-                    <span className="text-xs text-muted-foreground">on {event.object}</span>
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1 line-clamp-2">{event.message}</p>
-                </div>
+                <EventRow key={i} event={event} />
+              ))}
               ))}
             </div>
           ) : (
@@ -326,22 +261,7 @@ export function NamespaceDrillDown({ data }: Props) {
               <h4 className="text-sm font-medium text-muted-foreground mb-2">Pods ({filteredPods.length})</h4>
               <div className="space-y-1">
                 {filteredPods.slice(0, 20).map((pod, i) => (
-                  <div
-                    key={i}
-                    onClick={() => drillToPod(cluster, namespace, pod.name, { ...pod })}
-                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                  >
-                    <div className={`w-2 h-2 rounded-full ${pod.status === 'Running' ? 'bg-green-400' : pod.status === 'Pending' ? 'bg-yellow-400' : 'bg-red-400'}`} />
-                    <Box className="w-3 h-3 text-green-400" />
-                    <span className="text-sm text-foreground">{pod.name}</span>
-                    <StatusBadge
-                      color={pod.status === 'Running' ? 'green' : pod.status === 'Pending' ? 'yellow' : 'red'}
-                      size="xs"
-                    >
-                      {pod.status}
-                    </StatusBadge>
-                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                  </div>
+                  <PodRow key={i} pod={pod} onClick={() => drillToPod(cluster, namespace, pod.name, { ...pod })} />
                 ))}
                 {filteredPods.length > 20 && (
                   <div className="text-xs text-muted-foreground p-2">+{filteredPods.length - 20} more pods...</div>
@@ -356,18 +276,7 @@ export function NamespaceDrillDown({ data }: Props) {
               <h4 className="text-sm font-medium text-muted-foreground mb-2">Deployments ({filteredDeployments.length})</h4>
               <div className="space-y-1">
                 {filteredDeployments.slice(0, 20).map((dep, i) => (
-                  <div
-                    key={i}
-                    onClick={() => drillToDeployment(cluster, namespace, dep.name, { ...dep })}
-                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                  >
-                    <Box className="w-3 h-3 text-blue-400" />
-                    <span className="text-sm text-foreground">{dep.name}</span>
-                    <span className={`text-xs ${dep.readyReplicas === dep.replicas ? 'text-green-400' : 'text-yellow-400'}`}>
-                      {dep.readyReplicas}/{dep.replicas}
-                    </span>
-                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                  </div>
+                  <DeploymentRow key={i} deployment={dep} onClick={() => drillToDeployment(cluster, namespace, dep.name, { ...dep })} />
                 ))}
                 {filteredDeployments.length > 20 && (
                   <div className="text-xs text-muted-foreground p-2">+{filteredDeployments.length - 20} more deployments...</div>
@@ -382,15 +291,7 @@ export function NamespaceDrillDown({ data }: Props) {
               <h4 className="text-sm font-medium text-muted-foreground mb-2">Services ({filteredServices.length})</h4>
               <div className="space-y-1">
                 {filteredServices.slice(0, 20).map((svc, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                  >
-                    <Network className="w-3 h-3 text-blue-400" />
-                    <span className="text-sm text-foreground">{svc.name}</span>
-                    <StatusBadge color="blue" size="xs">{svc.type}</StatusBadge>
-                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                  </div>
+                  <ServiceRow key={i} service={svc} />
                 ))}
                 {filteredServices.length > 20 && (
                   <div className="text-xs text-muted-foreground p-2">+{filteredServices.length - 20} more services...</div>
@@ -405,21 +306,7 @@ export function NamespaceDrillDown({ data }: Props) {
               <h4 className="text-sm font-medium text-muted-foreground mb-2">PVCs ({filteredPVCs.length})</h4>
               <div className="space-y-1">
                 {filteredPVCs.slice(0, 20).map((pvc, i) => (
-                  <div
-                    key={i}
-                    className="flex items-center gap-2 p-2 rounded-lg hover:bg-secondary/50 cursor-pointer group"
-                  >
-                    <HardDrive className="w-3 h-3 text-green-400" />
-                    <span className="text-sm text-foreground">{pvc.name}</span>
-                    <StatusBadge
-                      color={pvc.status === 'Bound' ? 'green' : 'yellow'}
-                      size="xs"
-                    >
-                      {pvc.status}
-                    </StatusBadge>
-                    {pvc.capacity && <span className="text-xs text-muted-foreground">{pvc.capacity}</span>}
-                    <ChevronRight className="w-3 h-3 text-muted-foreground opacity-0 group-hover:opacity-100 ml-auto" />
-                  </div>
+                  <PVCRow key={i} pvc={pvc} />
                 ))}
                 {filteredPVCs.length > 20 && (
                   <div className="text-xs text-muted-foreground p-2">+{filteredPVCs.length - 20} more PVCs...</div>

--- a/web/src/components/drilldown/views/PVCDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/PVCDrillDown.parts.tsx
@@ -1,0 +1,209 @@
+/* eslint-disable react-refresh/only-export-components */
+import { HardDrive, Code, Info, Tag, Loader2, Copy, Check, ChevronLeft, Layers, Server, Database } from 'lucide-react'
+import { cn } from '../../../lib/cn'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { useTranslation } from 'react-i18next'
+
+export type TabType = 'overview' | 'describe' | 'yaml'
+
+export function getStatusColor(status: string): string {
+  const s = status?.toLowerCase() || ''
+  if (s === 'bound') return 'bg-green-500/20 text-green-400'
+  if (s === 'pending') return 'bg-yellow-500/20 text-yellow-400'
+  if (s === 'lost') return 'bg-red-500/20 text-red-400'
+  return 'bg-muted text-muted-foreground'
+}
+
+export function getTabs(t: (key: string, fallback?: string) => string): { id: TabType; label: string; icon: typeof Info }[] {
+  return [
+    { id: 'overview', label: t('drilldown.overview', 'Overview'), icon: Info },
+    { id: 'describe', label: t('drilldown.describe', 'Describe'), icon: Code },
+    { id: 'yaml', label: 'YAML', icon: Code },
+  ]
+}
+
+interface CopyButtonProps {
+  text: string
+  field: string
+  copiedField: string | null
+  onCopy: (text: string, field: string) => void
+}
+
+export function CopyButton({ text, field, copiedField, onCopy }: CopyButtonProps) {
+  return (
+    <button
+      onClick={() => onCopy(text, field)}
+      className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
+      title="Copy to clipboard"
+    >
+      {copiedField === field ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
+    </button>
+  )
+}
+
+interface HeaderProps {
+  pvcName: string
+  status: string
+  statusColor: string
+  isLoading: boolean
+  cluster: string
+  namespace: string
+  canGoBack: boolean
+  onBack?: () => void
+  onClusterClick: () => void
+  onNamespaceClick: () => void
+}
+
+export function PVCDrillDownHeader({
+  pvcName,
+  status,
+  statusColor,
+  isLoading,
+  cluster,
+  namespace,
+  canGoBack,
+  onBack,
+  onClusterClick,
+  onNamespaceClick,
+}: HeaderProps) {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      {/* Back navigation */}
+      {canGoBack && onBack && (
+        <button
+          type="button"
+          onClick={onBack}
+          className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+          aria-label={t('drilldown.goBack')}
+          title={t('drilldown.goBack')}
+        >
+          <ChevronLeft className="w-4 h-4" />
+          <span>{t('common.back')}</span>
+        </button>
+      )}
+
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-lg bg-green-500/20 flex items-center justify-center">
+            <HardDrive className="w-5 h-5 text-green-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-foreground">{pvcName}</h2>
+              {status && (
+                <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', statusColor)}>
+                  {status}
+                </span>
+              )}
+              {isLoading && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
+            </div>
+            <div className="flex items-center gap-2 mt-0.5">
+              <button
+                onClick={onClusterClick}
+                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              >
+                <ClusterBadge cluster={cluster} size="sm" />
+              </button>
+              <span className="text-muted-foreground">/</span>
+              <button
+                onClick={onNamespaceClick}
+                className="flex items-center gap-1 text-sm text-purple-400 hover:text-purple-300 transition-colors"
+              >
+                <Layers className="w-3.5 h-3.5" />
+                {namespace}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </>
+  )
+}
+
+interface TabBarProps {
+  activeTab: TabType
+  tabs: { id: TabType; label: string; icon: typeof Info }[]
+  onSelect: (tabId: TabType, fetchDescribe?: () => void, fetchYaml?: () => void) => void
+  describeOutput: string | null
+  yamlOutput: string | null
+  fetchDescribe: () => void
+  fetchYaml: () => void
+}
+
+export function PVCTabBar({ activeTab, tabs, onSelect, describeOutput, yamlOutput, fetchDescribe, fetchYaml }: TabBarProps) {
+  return (
+    <div className="flex gap-1 border-b border-border">
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          onClick={() => {
+            onSelect(tab.id)
+            if (tab.id === 'describe' && !describeOutput) void fetchDescribe()
+            if (tab.id === 'yaml' && !yamlOutput) void fetchYaml()
+          }}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
+            activeTab === tab.id
+              ? 'border-primary text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <tab.icon className="w-3.5 h-3.5" />
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+interface LabelsProps {
+  labels: Record<string, string>
+}
+
+export function LabelsSection({ labels }: LabelsProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+        <Tag className="w-4 h-4 text-yellow-400" />
+        {t('drilldown.labels', 'Labels')}
+      </h3>
+      <div className="flex flex-wrap gap-1.5">
+        {Object.entries(labels).map(([key, value]) => (
+          <span key={key} className="px-2 py-1 rounded bg-secondary/50 text-xs font-mono text-foreground">
+            {key}={value}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface AnnotationsProps {
+  annotations: Record<string, string>
+}
+
+export function AnnotationsSection({ annotations }: AnnotationsProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+        <Tag className="w-4 h-4 text-muted-foreground" />
+        {t('drilldown.annotations', 'Annotations')}
+      </h3>
+      <div className="space-y-1">
+        {Object.entries(annotations).map(([key, value]) => (
+          <div key={key} className="flex items-start gap-2 text-xs">
+            <span className="font-mono text-muted-foreground break-all">{key}</span>
+            <span className="text-foreground break-all">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+export { Info, Database, Server, Layers, Loader2, Copy, Check }

--- a/web/src/components/drilldown/views/PVCDrillDown.tsx
+++ b/web/src/components/drilldown/views/PVCDrillDown.tsx
@@ -1,224 +1,87 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useState } from 'react'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
-import { ClusterBadge } from '../../ui/ClusterBadge'
-import { HardDrive, Code, Info, Tag, Loader2, Copy, Check, ChevronLeft, Layers, Server, Database } from 'lucide-react'
+import { Loader2, Copy, Check } from 'lucide-react'
 import { cn } from '../../../lib/cn'
-import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../../lib/clipboard'
+import { usePVCDrillDown } from './usePVCDrillDown'
+import {
+  type TabType,
+  getStatusColor,
+  getTabs,
+  CopyButton,
+  PVCDrillDownHeader,
+  PVCTabBar,
+  LabelsSection,
+  AnnotationsSection,
+  Info,
+  Database,
+  Server,
+  Layers,
+} from './PVCDrillDown.parts'
 
 interface Props {
   data: Record<string, unknown>
 }
-
-type TabType = 'overview' | 'describe' | 'yaml'
 
 export function PVCDrillDown({ data }: Props) {
   const { t } = useTranslation()
   const cluster = data.cluster as string
   const namespace = data.namespace as string
   const pvcName = data.pvc as string
-  const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster } = useDrillDownActions()
   const { state, pop } = useDrillDown()
-  const { runKubectl } = useDrillDownWebSocket(cluster)
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [status, setStatus] = useState<string>(data.status as string || '')
-  const [capacity, setCapacity] = useState<string>(data.capacity as string || '')
-  const [accessModes, setAccessModes] = useState<string[]>((data.accessModes as string[]) || [])
-  const [storageClass, setStorageClass] = useState<string>(data.storageClass as string || '')
-  const [volumeName, setVolumeName] = useState<string>(data.volumeName as string || '')
-  const [volumeMode, setVolumeMode] = useState<string>('')
-  const [labels, setLabels] = useState<Record<string, string> | null>(null)
-  const [annotations, setAnnotations] = useState<Record<string, string> | null>(null)
-  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
-  const [describeLoading, setDescribeLoading] = useState(false)
-  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
-  const [yamlLoading, setYamlLoading] = useState(false)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
-  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [isLoading, setIsLoading] = useState(false)
 
+  const {
+    status,
+    capacity,
+    accessModes,
+    storageClass,
+    volumeName,
+    volumeMode,
+    labels,
+    annotations,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    isLoading,
+    handleCopy,
+    fetchDescribe,
+    fetchYaml,
+    agentConnected,
+  } = usePVCDrillDown(cluster, namespace, pvcName, data)
 
-  // Fetch PVC data from cluster
-  const fetchData = async () => {
-    if (!agentConnected) return
-
-    setIsLoading(true)
-    try {
-      const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'json'])
-      if (output) {
-        let pvc
-        try {
-          pvc = JSON.parse(output)
-        } catch {
-          setLabels(null)
-          setAnnotations(null)
-          return
-        }
-        setStatus(pvc.status?.phase || '')
-        setCapacity(pvc.status?.capacity?.storage || pvc.spec?.resources?.requests?.storage || '')
-        setAccessModes(pvc.spec?.accessModes || [])
-        setStorageClass(pvc.spec?.storageClassName || '')
-        setVolumeName(pvc.spec?.volumeName || '')
-        setVolumeMode(pvc.spec?.volumeMode || 'Filesystem')
-        setLabels(pvc.metadata?.labels || null)
-        setAnnotations(pvc.metadata?.annotations || null)
-      }
-    } catch {
-      // Parse error — keep data from props
-    } finally {
-      setIsLoading(false)
-    }
-  }
-
-  const fetchedRef = useRef(false)
-  useEffect(() => {
-    if (!fetchedRef.current) {
-      fetchedRef.current = true
-      void fetchData()
-    }
-  }, [agentConnected])
-
-  const fetchDescribe = async () => {
-    if (!agentConnected || describeLoading) return
-    setDescribeLoading(true)
-    const output = await runKubectl(['describe', 'pvc', pvcName, '-n', namespace])
-    setDescribeOutput(output || 'No output received')
-    setDescribeLoading(false)
-  }
-
-  const fetchYaml = async () => {
-    if (!agentConnected || yamlLoading) return
-    setYamlLoading(true)
-    const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'yaml'])
-    setYamlOutput(output || 'No output received')
-    setYamlLoading(false)
-  }
-
-  useEffect(() => {
-    return () => {
-      if (copiedFieldTimeoutRef.current) {
-        clearTimeout(copiedFieldTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = async (text: string, field: string) => {
-    const ok = await copyToClipboard(text)
-    if (ok) {
-      setCopiedField(field)
-      if (copiedFieldTimeoutRef.current) {
-        clearTimeout(copiedFieldTimeoutRef.current)
-      }
-      copiedFieldTimeoutRef.current = setTimeout(() => {
-        setCopiedField(null)
-        copiedFieldTimeoutRef.current = null
-      }, UI_FEEDBACK_TIMEOUT_MS)
-    }
-  }
-
-  const CopyButton = ({ text, field }: { text: string; field: string }) => (
-    <button
-      onClick={() => void handleCopy(text, field)}
-      className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground transition-colors"
-      title="Copy to clipboard"
-    >
-      {copiedField === field ? <Check className="w-3.5 h-3.5 text-green-400" /> : <Copy className="w-3.5 h-3.5" />}
-    </button>
-  )
-
-  const statusColor = (() => {
-    const s = status?.toLowerCase() || ''
-    if (s === 'bound') return 'bg-green-500/20 text-green-400'
-    if (s === 'pending') return 'bg-yellow-500/20 text-yellow-400'
-    if (s === 'lost') return 'bg-red-500/20 text-red-400'
-    return 'bg-muted text-muted-foreground'
-  })()
-
-  const tabs: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: t('drilldown.overview', 'Overview'), icon: Info },
-    { id: 'describe', label: t('drilldown.describe', 'Describe'), icon: Code },
-    { id: 'yaml', label: 'YAML', icon: Code },
-  ]
+  const statusColor = getStatusColor(status)
+  const tabs = getTabs(t)
 
   return (
     <div className="space-y-4">
-      {/* Back navigation */}
-      {state.stack.length > 1 && (
-        <button
-          type="button"
-          onClick={pop}
-          className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
-          aria-label={t('drilldown.goBack')}
-          title={t('drilldown.goBack')}
-        >
-          <ChevronLeft className="w-4 h-4" />
-          <span>{t('common.back')}</span>
-        </button>
-      )}
-      
-      {/* Header */}
-      <div className="flex items-start justify-between">
-        <div className="flex items-center gap-3">
-          <div className="w-10 h-10 rounded-lg bg-green-500/20 flex items-center justify-center">
-            <HardDrive className="w-5 h-5 text-green-400" />
-          </div>
-          <div>
-            <div className="flex items-center gap-2">
-              <h2 className="text-lg font-semibold text-foreground">{pvcName}</h2>
-              {status && (
-                <span className={cn('px-2 py-0.5 rounded-full text-xs font-medium', statusColor)}>
-                  {status}
-                </span>
-              )}
-              {isLoading && <Loader2 className="w-4 h-4 animate-spin text-muted-foreground" />}
-            </div>
-            <div className="flex items-center gap-2 mt-0.5">
-              <button
-                onClick={() => drillToCluster(cluster)}
-                className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              >
-                <ClusterBadge cluster={cluster} size="sm" />
-              </button>
-              <span className="text-muted-foreground">/</span>
-              <button
-                onClick={() => drillToNamespace(cluster, namespace)}
-                className="flex items-center gap-1 text-sm text-purple-400 hover:text-purple-300 transition-colors"
-              >
-                <Layers className="w-3.5 h-3.5" />
-                {namespace}
-              </button>
-            </div>
-          </div>
-        </div>
-      </div>
+      <PVCDrillDownHeader
+        pvcName={pvcName}
+        status={status}
+        statusColor={statusColor}
+        isLoading={isLoading}
+        cluster={cluster}
+        namespace={namespace}
+        canGoBack={state.stack.length > 1}
+        onBack={pop}
+        onClusterClick={() => drillToCluster(cluster)}
+        onNamespaceClick={() => drillToNamespace(cluster, namespace)}
+      />
 
       {/* Tabs */}
-      <div className="flex gap-1 border-b border-border">
-        {tabs.map(tab => (
-          <button
-            key={tab.id}
-            onClick={() => {
-              setActiveTab(tab.id)
-              if (tab.id === 'describe' && !describeOutput) void fetchDescribe()
-              if (tab.id === 'yaml' && !yamlOutput) void fetchYaml()
-            }}
-            className={cn(
-              'flex items-center gap-1.5 px-3 py-2 text-sm font-medium border-b-2 transition-colors',
-              activeTab === tab.id
-                ? 'border-primary text-foreground'
-                : 'border-transparent text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <tab.icon className="w-3.5 h-3.5" />
-            {tab.label}
-          </button>
-        ))}
-      </div>
+      <PVCTabBar
+        activeTab={activeTab}
+        tabs={tabs}
+        onSelect={setActiveTab}
+        describeOutput={describeOutput}
+        yamlOutput={yamlOutput}
+        fetchDescribe={fetchDescribe}
+        fetchYaml={fetchYaml}
+      />
 
       {/* Tab content */}
       {activeTab === 'overview' && (
@@ -313,37 +176,12 @@ export function PVCDrillDown({ data }: Props) {
 
           {/* Labels */}
           {labels && Object.keys(labels).length > 0 && (
-            <div className="space-y-2">
-              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                <Tag className="w-4 h-4 text-yellow-400" />
-                {t('drilldown.labels', 'Labels')}
-              </h3>
-              <div className="flex flex-wrap gap-1.5">
-                {Object.entries(labels).map(([key, value]) => (
-                  <span key={key} className="px-2 py-1 rounded bg-secondary/50 text-xs font-mono text-foreground">
-                    {key}={value}
-                  </span>
-                ))}
-              </div>
-            </div>
+            <LabelsSection labels={labels} />
           )}
 
           {/* Annotations */}
           {annotations && Object.keys(annotations).length > 0 && (
-            <div className="space-y-2">
-              <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
-                <Tag className="w-4 h-4 text-muted-foreground" />
-                {t('drilldown.annotations', 'Annotations')}
-              </h3>
-              <div className="space-y-1">
-                {Object.entries(annotations).map(([key, value]) => (
-                  <div key={key} className="flex items-start gap-2 text-xs">
-                    <span className="font-mono text-muted-foreground break-all">{key}</span>
-                    <span className="text-foreground break-all">{value}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
+            <AnnotationsSection annotations={annotations} />
           )}
         </div>
       )}

--- a/web/src/components/drilldown/views/PolicyDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.parts.tsx
@@ -1,0 +1,224 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { KeyboardEvent as ReactKeyboardEvent } from 'react'
+import {
+  Info, AlertCircle, FileText, Stethoscope,
+  CheckCircle, XCircle, ChevronLeft, Layers, Server,
+} from 'lucide-react'
+import { cn } from '../../../lib/cn'
+import { TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { useTranslation } from 'react-i18next'
+import type { Violation, PolicySpec } from './usePolicyDrillDown'
+
+export type TabType = 'overview' | 'violations' | 'spec' | 'ai'
+
+export const POLICY_TABS: { id: TabType; label: string; icon: typeof Info }[] = [
+  { id: 'overview', label: 'Overview', icon: Info },
+  { id: 'violations', label: 'Violations', icon: AlertCircle },
+  { id: 'spec', label: 'Policy Spec', icon: FileText },
+  { id: 'ai', label: 'AI Analysis', icon: Stethoscope },
+]
+
+// Policy status styles
+export interface StatusStyle {
+  bg: string
+  text: string
+  border: string
+  icon: typeof CheckCircle
+}
+
+export function getStatusStyle(status: string): StatusStyle {
+  const lower = status?.toLowerCase() || ''
+  if (lower === 'active' || lower === 'ready' || lower === 'enforced') {
+    return { bg: 'bg-green-500/20', text: 'text-green-400', border: 'border-green-500/30', icon: CheckCircle }
+  }
+  if (lower === 'audit' || lower === 'warn') {
+    return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', icon: XCircle }
+  }
+  if (lower === 'failed' || lower === 'error' || lower === 'inactive') {
+    return { bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/30', icon: XCircle }
+  }
+  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertCircle }
+}
+
+export function getTabsWithCount(violationCount: number): { id: TabType; label: string; icon: typeof Info }[] {
+  return [
+    { id: 'overview', label: 'Overview', icon: Info },
+    { id: 'violations', label: `Violations (${violationCount})`, icon: AlertCircle },
+    { id: 'spec', label: 'Policy Spec', icon: FileText },
+    { id: 'ai', label: 'AI Analysis', icon: Stethoscope },
+  ]
+}
+
+interface TabBarProps {
+  activeTab: TabType
+  tabs: { id: TabType; label: string; icon: typeof Info }[]
+  onSelect: (tabId: TabType) => void
+  onKeyDown?: (event: ReactKeyboardEvent<HTMLDivElement>) => void
+}
+
+export function PolicyTabBar({ activeTab, tabs, onSelect, onKeyDown }: TabBarProps) {
+  return (
+    <div className="border-b border-border px-6" onKeyDown={onKeyDown}>
+      <div className="flex gap-1">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onSelect(tab.id)}
+              className={cn(
+                cn('flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors', TOUCH_TARGET_SIZE_CLASS),
+                activeTab === tab.id
+                  ? 'text-primary border-primary'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+              )}
+            >
+              <Icon className="w-4 h-4" />
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface HeaderProps {
+  cluster: string
+  namespace?: string
+  policyType: string
+  policyStatus: string
+  statusStyle: StatusStyle
+  canGoBack: boolean
+  onBack: () => void
+  onNamespaceClick?: () => void
+  onClusterClick: () => void
+}
+
+export function PolicyDrillDownHeader({
+  cluster,
+  namespace,
+  policyType,
+  policyStatus,
+  statusStyle,
+  canGoBack,
+  onBack,
+  onNamespaceClick,
+  onClusterClick,
+}: HeaderProps) {
+  const { t } = useTranslation()
+  const StatusIcon = statusStyle.icon
+
+  return (
+    <div className="px-6 pt-6 pb-4">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-6 text-sm">
+          {canGoBack && (
+            <button onClick={onBack} className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors min-h-11 min-w-11 px-2 py-2">
+              <ChevronLeft className="w-4 h-4" />
+              {t('drilldown.goBack', 'Back')}
+            </button>
+          )}
+          {namespace && onNamespaceClick && (
+            <button
+              onClick={onNamespaceClick}
+              className={cn('group flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 transition-all hover:border-purple-500/30 hover:bg-purple-500/10', TOUCH_TARGET_SIZE_CLASS)}
+            >
+              <Layers className="w-4 h-4 text-purple-400" />
+              <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+              <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+              <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+              </svg>
+            </button>
+          )}
+          <button
+            onClick={onClusterClick}
+            className={cn('group flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 transition-all hover:border-blue-500/30 hover:bg-blue-500/10', TOUCH_TARGET_SIZE_CLASS)}
+          >
+            <Server className="w-4 h-4 text-blue-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+            <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
+            <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Status badge */}
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">{policyType === 'kyverno' ? 'Kyverno' : 'OPA'}</span>
+          <span className={cn('px-2.5 py-1 rounded-lg text-xs font-medium flex items-center gap-1', statusStyle.bg, statusStyle.text, 'border', statusStyle.border)}>
+            <StatusIcon className="w-3 h-3" />
+            {policyStatus}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ViolationRowProps {
+  violation: Violation
+  onClick?: () => void
+}
+
+export function ViolationRow({ violation, onClick }: ViolationRowProps) {
+  const isClickable = violation.kind === 'Pod' && violation.namespace
+  return (
+    <div
+      onClick={onClick}
+      className={cn(
+        'flex items-start gap-3 p-3 rounded-lg border border-red-500/30 bg-red-500/10',
+        isClickable && 'cursor-pointer hover:bg-red-500/20 transition-colors'
+      )}
+    >
+      <XCircle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-foreground">{violation.kind}/{violation.resource}</span>
+          {violation.namespace && (
+            <span className="text-xs text-muted-foreground">in {violation.namespace}</span>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground mt-1">{violation.message}</p>
+        {violation.timestamp && (
+          <span className="text-xs text-muted-foreground">{violation.timestamp}</span>
+        )}
+      </div>
+      {isClickable && (
+        <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+        </svg>
+      )}
+    </div>
+  )
+}
+
+interface PolicyRulesListProps {
+  rules: NonNullable<PolicySpec['rules']>
+}
+
+export function PolicyRulesList({ rules }: PolicyRulesListProps) {
+  return (
+    <div className="p-4 rounded-lg border border-border bg-card/50">
+      <h4 className="text-sm font-medium text-foreground mb-3">Rules ({rules.length})</h4>
+      <div className="space-y-2">
+        {rules.map((rule, i) => (
+          <div key={i} className="p-3 rounded-lg bg-secondary/50 flex items-center justify-between">
+            <span className="text-sm font-medium text-foreground">{rule.name}</span>
+            <div className="flex gap-2">
+              {rule.validate && (
+                <span className="px-2 py-0.5 rounded text-xs bg-blue-500/20 text-blue-400">Validate</span>
+              )}
+              {rule.mutate && (
+                <span className="px-2 py-0.5 rounded text-xs bg-purple-500/20 text-purple-400">Mutate</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/PolicyDrillDown.tsx
+++ b/web/src/components/drilldown/views/PolicyDrillDown.tsx
@@ -1,18 +1,14 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useState } from 'react'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { useMissions } from '../../../hooks/useMissions'
-import { ClusterBadge } from '../../ui/ClusterBadge'
 import {
-  Shield, Info, Loader2,
-  Layers, Server, RefreshCw, Stethoscope, ChevronLeft,
-  CheckCircle, XCircle, AlertTriangle,
-  FileText, AlertCircle
+  Shield, Loader2,
+  Layers, RefreshCw, Stethoscope,
+  CheckCircle,
+  FileText
 } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
-import { StatusBadge } from '../../ui/StatusBadge'
 import { ConsoleAIIcon } from '../../ui/ConsoleAIIcon'
 import {
   AIActionBar,
@@ -20,54 +16,19 @@ import {
   type ResourceContext,
 } from '../../modals'
 import { useTranslation } from 'react-i18next'
+import { usePolicyDrillDown } from './usePolicyDrillDown'
+import {
+  type TabType,
+  getStatusStyle,
+  getTabsWithCount,
+  PolicyTabBar,
+  PolicyDrillDownHeader,
+  ViolationRow,
+  PolicyRulesList,
+} from './PolicyDrillDown.parts'
 
 interface Props {
   data: Record<string, unknown>
-}
-
-type TabType = 'overview' | 'violations' | 'spec' | 'ai'
-
-// Policy status styles
-const getStatusStyle = (status: string) => {
-  const lower = status?.toLowerCase() || ''
-  if (lower === 'active' || lower === 'ready' || lower === 'enforced') {
-    return { bg: 'bg-green-500/20', text: 'text-green-400', border: 'border-green-500/30', icon: CheckCircle }
-  }
-  if (lower === 'audit' || lower === 'warn') {
-    return { bg: 'bg-yellow-500/20', text: 'text-yellow-400', border: 'border-yellow-500/30', icon: AlertTriangle }
-  }
-  if (lower === 'failed' || lower === 'error' || lower === 'inactive') {
-    return { bg: 'bg-red-500/20', text: 'text-red-400', border: 'border-red-500/30', icon: XCircle }
-  }
-  return { bg: 'bg-secondary', text: 'text-muted-foreground', border: 'border-border', icon: AlertCircle }
-}
-
-interface Violation {
-  resource: string
-  kind: string
-  namespace?: string
-  message: string
-  timestamp?: string
-}
-
-interface ViolationRaw {
-  name?: string
-  kind?: string
-  namespace?: string
-  message?: string
-}
-
-interface PolicySpec {
-  match?: Record<string, unknown>
-  parameters?: Record<string, unknown>
-  validationFailureAction?: string
-  background?: boolean
-  rules?: Array<{
-    name: string
-    match?: Record<string, unknown>
-    validate?: Record<string, unknown>
-    mutate?: Record<string, unknown>
-  }>
 }
 
 export function PolicyDrillDown({ data }: Props) {
@@ -83,18 +44,22 @@ export function PolicyDrillDown({ data }: Props) {
   const constraintTemplate = data.constraintTemplate as string | undefined
   const violationCount = (data.violationCount as number) || 0
 
-  const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod } = useDrillDownActions()
   const { state, pop, close: closeDrillDown } = useDrillDown()
   const { startMission } = useMissions()
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [violations, setViolations] = useState<Violation[] | null>(null)
-  const [violationsLoading, setViolationsLoading] = useState(false)
-  const [policySpec, setPolicySpec] = useState<PolicySpec | null>(null)
-  const [specLoading, setSpecLoading] = useState(false)
   const [aiAnalysis] = useState<string | null>(null)
   const [aiAnalysisLoading] = useState(false)
+
+  // Use extracted hook for data loading
+  const {
+    agentConnected,
+    violations,
+    violationsLoading,
+    policySpec,
+    specLoading,
+  } = usePolicyDrillDown(cluster, policyName, policyType, policyKind, namespace)
 
   // Resource context for AI actions
   const resourceContext: ResourceContext = {
@@ -123,105 +88,6 @@ export function PolicyDrillDown({ data }: Props) {
       violationCount,
     },
   })
-  const { runKubectl } = useDrillDownWebSocket(cluster)
-
-
-  // Fetch violations
-  const fetchViolations = async () => {
-    if (!agentConnected || violations) return
-    setViolationsLoading(true)
-    try {
-      let output: string
-      if (policyType === 'kyverno') {
-        // For Kyverno, fetch policy reports
-        output = await runKubectl([
-          'get', 'policyreport,clusterpolicyreport', '-A', '-o', 'json'
-        ])
-        if (output) {
-          const data = JSON.parse(output)
-          const items = data.items || []
-          const policyViolations: Violation[] = []
-
-          for (const report of items) {
-            const results = report.results || []
-            for (const result of results) {
-              if (result.policy === policyName && result.result === 'fail') {
-                policyViolations.push({
-                  resource: result.resources?.[0]?.name || 'Unknown',
-                  kind: result.resources?.[0]?.kind || 'Unknown',
-                  namespace: result.resources?.[0]?.namespace,
-                  message: result.message || 'Policy violation',
-                  timestamp: typeof result.timestamp === 'string'
-                    ? result.timestamp
-                    : result.timestamp && typeof result.timestamp === 'object' && 'seconds' in result.timestamp
-                      ? (() => { const d = new Date(Number(result.timestamp.seconds) * 1000); return isNaN(d.getTime()) ? undefined : d.toISOString() })()
-                      : undefined,
-                })
-              }
-            }
-          }
-          setViolations(policyViolations)
-        }
-      } else {
-        // For OPA Gatekeeper, fetch constraint status
-        output = await runKubectl([
-          'get', policyKind.toLowerCase(), policyName, '-o', 'json'
-        ])
-        if (output) {
-          const constraint = JSON.parse(output)
-          const statusViolations = constraint.status?.violations || []
-          setViolations(statusViolations.map((v: ViolationRaw) => ({
-            resource: v.name || 'Unknown',
-            kind: v.kind || 'Unknown',
-            namespace: v.namespace,
-            message: v.message || 'Policy violation',
-          })))
-        }
-      }
-    } catch {
-      setViolations([])
-    }
-    setViolationsLoading(false)
-  }
-
-  // Fetch policy spec
-  const fetchSpec = async () => {
-    if (!agentConnected || policySpec) return
-    setSpecLoading(true)
-    try {
-      let output: string
-      if (policyType === 'kyverno') {
-        const resource = namespace ? `policy/${policyName}` : `clusterpolicy/${policyName}`
-        const nsArgs = namespace ? ['-n', namespace] : []
-        output = await runKubectl(['get', resource, ...nsArgs, '-o', 'json'])
-      } else {
-        output = await runKubectl([
-          'get', policyKind.toLowerCase(), policyName, '-o', 'json'
-        ])
-      }
-
-      if (output) {
-        const policy = JSON.parse(output)
-        setPolicySpec(policy.spec || {})
-      }
-    } catch {
-      setPolicySpec({})
-    }
-    setSpecLoading(false)
-  }
-
-  // Track if we've already loaded data
-  const hasLoadedRef = useRef(false)
-
-  useEffect(() => {
-    if (!agentConnected || hasLoadedRef.current) return
-    hasLoadedRef.current = true
-
-    const loadData = async () => {
-      await Promise.all([fetchViolations(), fetchSpec()])
-    }
-    loadData()
-  }, [agentConnected, fetchViolations, fetchSpec])
 
   // Start AI diagnosis
   const handleDiagnose = () => {
@@ -269,61 +135,23 @@ Please:
   }
 
   const statusStyle = getStatusStyle(policyStatus)
-  const StatusIcon = statusStyle.icon
 
-  const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: 'Overview', icon: Info },
-    { id: 'violations', label: `Violations (${violationCount})`, icon: AlertCircle },
-    { id: 'spec', label: 'Policy Spec', icon: FileText },
-    { id: 'ai', label: 'AI Analysis', icon: Stethoscope },
-  ]
+  const TABS = getTabsWithCount(violationCount)
 
   return (
     <div className="flex flex-col h-full -m-6">
       {/* Header */}
-      <div className="px-6 pt-6 pb-4">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-6 text-sm">
-            <button onClick={() => state.stack.length > 1 ? pop() : closeDrillDown()} className="flex items-center gap-1 text-muted-foreground hover:text-foreground transition-colors min-h-11 min-w-11 px-2 py-2">
-              <ChevronLeft className="w-4 h-4" />
-              {t('drilldown.goBack', 'Back')}
-            </button>
-            {namespace && (
-              <button
-                onClick={() => drillToNamespace(cluster, namespace)}
-                className={cn('group flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 transition-all hover:border-purple-500/30 hover:bg-purple-500/10', TOUCH_TARGET_SIZE_CLASS)}
-              >
-                <Layers className="w-4 h-4 text-purple-400" />
-                <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
-                <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
-                <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                </svg>
-              </button>
-            )}
-            <button
-              onClick={() => drillToCluster(cluster)}
-              className={cn('group flex items-center gap-2 rounded-lg border border-transparent px-3 py-2 transition-all hover:border-blue-500/30 hover:bg-blue-500/10', TOUCH_TARGET_SIZE_CLASS)}
-            >
-              <Server className="w-4 h-4 text-blue-400" />
-              <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
-              <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
-              <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-          </div>
-
-          {/* Status badge */}
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-muted-foreground">{policyType === 'kyverno' ? 'Kyverno' : 'OPA'}</span>
-            <span className={cn('px-2.5 py-1 rounded-lg text-xs font-medium flex items-center gap-1', statusStyle.bg, statusStyle.text, 'border', statusStyle.border)}>
-              <StatusIcon className="w-3 h-3" />
-              {policyStatus}
-            </span>
-          </div>
-        </div>
-      </div>
+      <PolicyDrillDownHeader
+        cluster={cluster}
+        namespace={namespace}
+        policyType={policyType}
+        policyStatus={policyStatus}
+        statusStyle={statusStyle}
+        canGoBack={state.stack.length > 1}
+        onBack={() => state.stack.length > 1 ? pop() : closeDrillDown()}
+        onNamespaceClick={namespace ? () => drillToNamespace(cluster, namespace) : undefined}
+        onClusterClick={() => drillToCluster(cluster)}
+      />
 
       {/* AI Action Bar */}
       <div className="px-6 pb-4">
@@ -337,28 +165,11 @@ Please:
       </div>
 
       {/* Tabs */}
-      <div className="border-b border-border px-6">
-        <div className="flex gap-1">
-          {TABS.map((tab) => {
-            const Icon = tab.icon
-            return (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={cn(
-                  cn('flex items-center gap-2 border-b-2 px-4 py-2 text-sm font-medium transition-colors', TOUCH_TARGET_SIZE_CLASS),
-                  activeTab === tab.id
-                    ? 'text-primary border-primary'
-                    : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
-                )}
-              >
-                <Icon className="w-4 h-4" />
-                {tab.label}
-              </button>
-            )
-          })}
-        </div>
-      </div>
+      <PolicyTabBar
+        activeTab={activeTab}
+        tabs={TABS}
+        onSelect={setActiveTab}
+      />
 
       {/* Tab Content */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
@@ -414,20 +225,7 @@ Please:
 
             {/* Policy Rules (Kyverno) */}
             {policyType === 'kyverno' && policySpec?.rules && policySpec.rules.length > 0 && (
-              <div className="p-4 rounded-lg border border-border bg-card/50">
-                <h4 className="text-sm font-medium text-foreground mb-3">Rules ({policySpec.rules.length})</h4>
-                <div className="space-y-2">
-                  {policySpec.rules.map((rule, i) => (
-                    <div key={i} className="p-3 rounded-lg bg-secondary/50 flex items-center justify-between">
-                      <span className="text-sm font-medium text-foreground">{rule.name}</span>
-                      <div className="flex gap-2">
-                        {rule.validate && <StatusBadge color="blue" size="xs">Validate</StatusBadge>}
-                        {rule.mutate && <StatusBadge color="purple" size="xs">Mutate</StatusBadge>}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </div>
+              <PolicyRulesList rules={policySpec.rules} />
             )}
           </div>
         )}
@@ -442,37 +240,14 @@ Please:
             ) : violations && violations.length > 0 ? (
               <div className="space-y-2">
                 {violations.map((violation, i) => (
-                  <div
+                  <ViolationRow
                     key={i}
-                    onClick={() => {
-                      if (violation.kind === 'Pod' && violation.namespace) {
-                        drillToPod(cluster, violation.namespace, violation.resource)
-                      }
-                    }}
-                    className={cn(
-                      'flex items-start gap-3 p-3 rounded-lg border border-red-500/30 bg-red-500/10',
-                      violation.kind === 'Pod' && violation.namespace && 'cursor-pointer hover:bg-red-500/20 transition-colors'
-                    )}
-                  >
-                    <XCircle className="w-4 h-4 text-red-400 mt-0.5 shrink-0" />
-                    <div className="flex-1 min-w-0">
-                      <div className="flex items-center gap-2">
-                        <span className="text-sm font-medium text-foreground">{violation.kind}/{violation.resource}</span>
-                        {violation.namespace && (
-                          <span className="text-xs text-muted-foreground">in {violation.namespace}</span>
-                        )}
-                      </div>
-                      <p className="text-sm text-muted-foreground mt-1">{violation.message}</p>
-                      {violation.timestamp && (
-                        <span className="text-xs text-muted-foreground">{violation.timestamp}</span>
-                      )}
-                    </div>
-                    {violation.kind === 'Pod' && violation.namespace && (
-                      <svg className="w-4 h-4 text-muted-foreground" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                      </svg>
-                    )}
-                  </div>
+                    violation={violation}
+                    onClick={violation.kind === 'Pod' && violation.namespace
+                      ? () => drillToPod(cluster, violation.namespace!, violation.resource)
+                      : undefined
+                    }
+                  />
                 ))}
               </div>
             ) : (

--- a/web/src/components/drilldown/views/ReplicaSetDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/ReplicaSetDrillDown.parts.tsx
@@ -1,0 +1,173 @@
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
+import { PodInfo } from './useReplicaSetDrillDown'
+import { Tag, Box, Info, Activity, FileText, Code } from 'lucide-react'
+
+export type ReplicaSetTab = 'overview' | 'events' | 'describe' | 'yaml'
+
+interface TabBarProps {
+  activeTab: ReplicaSetTab
+  onTabChange: (tab: ReplicaSetTab) => void
+}
+
+export function TabBar({ activeTab, onTabChange }: TabBarProps) {
+  const { t } = useTranslation()
+
+  const tabs = [
+    { id: 'overview' as const, label: t('drilldown.overview', 'Overview'), icon: Info },
+    { id: 'events' as const, label: t('drilldown.events', 'Events'), icon: Activity },
+    { id: 'describe' as const, label: t('drilldown.describe', 'Describe'), icon: FileText },
+    { id: 'yaml' as const, label: t('drilldown.yaml', 'YAML'), icon: Code },
+  ]
+
+  return (
+    <div className="flex gap-1 border-b border-border pb-2 mb-4">
+      {tabs.map(tab => (
+        <button
+          key={tab.id}
+          onClick={() => onTabChange(tab.id)}
+          className={cn(
+            'flex items-center gap-1.5 px-3 py-1.5 rounded-t text-xs font-medium transition-colors',
+            activeTab === tab.id
+              ? 'bg-primary/10 text-primary border-b-2 border-primary'
+              : 'text-muted-foreground hover:text-foreground hover:bg-secondary/50'
+          )}
+        >
+          <tab.icon className="w-3.5 h-3.5" />
+          {tab.label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+interface HeaderProps {
+  replicas: number
+  readyReplicas: number
+  replicasetName: string
+}
+
+export function Header({ replicas, readyReplicas, replicasetName }: HeaderProps) {
+  return (
+    <div className="flex items-center gap-3 mb-4">
+      <div className="p-2.5 rounded-lg bg-cyan-500/20">
+        <Box className="w-6 h-6 text-cyan-400" />
+      </div>
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">{replicasetName}</h2>
+        <p className="text-sm text-muted-foreground">
+          ReplicaSet · {readyReplicas}/{replicas} ready
+        </p>
+      </div>
+    </div>
+  )
+}
+
+interface LabelsProps {
+  labels: Record<string, string>
+}
+
+export function LabelsSection({ labels }: LabelsProps) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+        <Tag className="w-4 h-4 text-yellow-400" />
+        {t('drilldown.labels', 'Labels')}
+      </h3>
+      <div className="flex flex-wrap gap-1.5">
+        {Object.entries(labels).map(([key, value]) => (
+          <span
+            key={key}
+            className="px-2 py-1 rounded bg-secondary/50 text-xs font-mono text-foreground"
+          >
+            {key}={value}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface PodListProps {
+  pods: PodInfo[]
+  onPodClick: (podName: string) => void
+}
+
+export function PodList({ pods, onPodClick }: PodListProps) {
+  const { t } = useTranslation()
+
+  if (pods.length === 0) return null
+
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-medium text-foreground flex items-center gap-1.5">
+        <Box className="w-4 h-4 text-blue-400" />
+        {t('drilldown.pods', 'Pods')} ({pods.length})
+      </h3>
+      <div className="space-y-1">
+        {pods.map(pod => (
+          <button
+            key={pod.name}
+            onClick={() => onPodClick(pod.name)}
+            className="w-full flex items-center justify-between p-2 rounded bg-secondary/30 hover:bg-secondary/50 transition-colors text-left"
+          >
+            <div className="flex items-center gap-2">
+              <Box className="w-4 h-4 text-blue-400" />
+              <span className="text-sm font-mono text-foreground">{pod.name}</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <span
+                className={cn(
+                  'px-2 py-0.5 rounded text-xs font-medium',
+                  pod.status === 'Running' ? 'bg-green-500/20 text-green-400' : 'bg-yellow-500/20 text-yellow-400'
+                )}
+              >
+                {pod.status}
+              </span>
+              {pod.restarts > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  {pod.restarts} restart{pod.restarts !== 1 ? 's' : ''}
+                </span>
+              )}
+            </div>
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface CopyButtonProps {
+  text: string
+  field: string
+  copiedField: string | null
+  onCopy: (field: string, value: string) => void
+}
+
+export function CopyButton({ text, field, copiedField, onCopy }: CopyButtonProps) {
+  const { t } = useTranslation()
+
+  return (
+    <button
+      onClick={() => onCopy(field, text)}
+      className={cn(
+        'absolute top-2 right-2 p-1.5 rounded bg-secondary/80 hover:bg-secondary text-muted-foreground hover:text-foreground transition-colors',
+        copiedField === field && 'text-green-400'
+      )}
+      title={t('drilldown.copyToClipboard', 'Copy to clipboard')}
+    >
+      {copiedField === field ? (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+        </svg>
+      ) : (
+        <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+        </svg>
+      )}
+    </button>
+  )
+}

--- a/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
+++ b/web/src/components/drilldown/views/ReplicaSetDrillDown.tsx
@@ -1,17 +1,14 @@
-import { useState, useEffect, useRef, useMemo } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useState, useMemo } from 'react'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
 import { ClusterBadge } from '../../ui/ClusterBadge'
 import { FileText, Code, Info, Tag, Zap, Loader2, Copy, Check, ChevronLeft, Layers, Server, Box } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { StatusBadge } from '../../ui/StatusBadge'
-import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { getHealthColors } from '../../../lib/statusColors'
 import { StatusIndicator } from '../../charts/StatusIndicator'
 import { Gauge } from '../../charts/Gauge'
 import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../../lib/clipboard'
+import { useReplicaSetDrillDown } from './useReplicaSetDrillDown'
 
 interface Props {
   data: Record<string, unknown>
@@ -24,149 +21,27 @@ export function ReplicaSetDrillDown({ data }: Props) {
   const cluster = data.cluster as string
   const namespace = data.namespace as string
   const replicasetName = data.replicaset as string
-  const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster, drillToPod, drillToDeployment } = useDrillDownActions()
   const { state, pop } = useDrillDown()
-  const { runKubectl } = useDrillDownWebSocket(cluster)
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [replicas, setReplicas] = useState<number>(0)
-  const [readyReplicas, setReadyReplicas] = useState<number>(0)
-  const [pods, setPods] = useState<Array<{ name: string; status: string; restarts: number }>>([])
-  const [ownerDeployment, setOwnerDeployment] = useState<string | null>(null)
-  const [labels, setLabels] = useState<Record<string, string> | null>(null)
-  const [eventsOutput, setEventsOutput] = useState<string | null>(null)
-  const [eventsLoading, setEventsLoading] = useState(false)
-  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
-  const [describeLoading, setDescribeLoading] = useState(false)
-  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
-  const [yamlLoading, setYamlLoading] = useState(false)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
-  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-
-  // Fetch ReplicaSet data
-  const fetchData = async () => {
-    if (!agentConnected) return
-
-    try {
-      const output = await runKubectl(['get', 'replicaset', replicasetName, '-n', namespace, '-o', 'json'])
-      if (output) {
-        let rs
-        try {
-          rs = JSON.parse(output)
-        } catch {
-          console.warn('[ReplicaSetDrillDown] Failed to parse ReplicaSet JSON output')
-          return
-        }
-        setReplicas(rs.spec?.replicas || 0)
-        setReadyReplicas(rs.status?.readyReplicas || 0)
-        setLabels(rs.metadata?.labels || {})
-
-        // Get owner deployment
-        const ownerRef = rs.metadata?.ownerReferences?.find((o: { kind: string }) => o.kind === 'Deployment')
-        if (ownerRef) {
-          setOwnerDeployment(ownerRef.name)
-        }
-
-        // Get pods managed by this ReplicaSet
-        const selector = Object.entries(rs.spec?.selector?.matchLabels || {})
-          .map(([k, v]) => `${k}=${v}`)
-          .join(',')
-        if (selector) {
-          const podsOutput = await runKubectl(['get', 'pods', '-n', namespace, '-l', selector, '-o', 'json'])
-          if (podsOutput) {
-            let podList
-            try {
-              podList = JSON.parse(podsOutput)
-            } catch {
-              console.warn('[ReplicaSetDrillDown] Failed to parse Pods JSON output')
-              setPods([])
-              return
-            }
-            const podInfo = podList.items?.map((p: { metadata: { name: string }; status: { phase: string; containerStatuses?: Array<{ restartCount: number }> } }) => ({
-              name: p.metadata.name,
-              status: p.status.phase,
-              restarts: p.status.containerStatuses?.reduce((sum: number, c: { restartCount: number }) => sum + c.restartCount, 0) || 0
-            })) || []
-            setPods(podInfo)
-          }
-        }
-      }
-    } catch {
-      // Ignore fetch errors
-    }
-  }
-
-  const fetchEvents = async () => {
-    if (!agentConnected || eventsOutput) return
-    setEventsLoading(true)
-    const output = await runKubectl(['get', 'events', '-n', namespace, '--field-selector', `involvedObject.name=${replicasetName}`, '-o', 'wide'])
-    setEventsOutput(output)
-    setEventsLoading(false)
-  }
-
-  const fetchDescribe = async () => {
-    if (!agentConnected || describeOutput) return
-    setDescribeLoading(true)
-    const output = await runKubectl(['describe', 'replicaset', replicasetName, '-n', namespace])
-    setDescribeOutput(output)
-    setDescribeLoading(false)
-  }
-
-  const fetchYaml = async () => {
-    if (!agentConnected || yamlOutput) return
-    setYamlLoading(true)
-    const output = await runKubectl(['get', 'replicaset', replicasetName, '-n', namespace, '-o', 'yaml'])
-    setYamlOutput(output)
-    setYamlLoading(false)
-  }
-
-  // Track if we've already loaded data to prevent refetching
-  const hasLoadedRef = useRef(false)
-
-  // Pre-fetch tab data when agent connects
-  // Batched to limit concurrent WebSocket connections (max 2 at a time)
-  useEffect(() => {
-    if (!agentConnected || hasLoadedRef.current) return
-    hasLoadedRef.current = true
-
-    const loadData = async () => {
-      // Batch 1: Overview data (2 concurrent)
-      await Promise.all([
-        fetchData(),
-        fetchEvents(),
-      ])
-
-      // Batch 2: Describe + YAML (2 concurrent, lower priority)
-      await Promise.all([
-        fetchDescribe(),
-        fetchYaml(),
-      ])
-    }
-
-    loadData()
-  }, [agentConnected, fetchData, fetchDescribe, fetchEvents, fetchYaml])
-
-  useEffect(() => {
-    return () => {
-      if (copiedFieldTimeoutRef.current) {
-        clearTimeout(copiedFieldTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = (field: string, value: string) => {
-    copyToClipboard(value)
-    setCopiedField(field)
-    if (copiedFieldTimeoutRef.current) {
-      clearTimeout(copiedFieldTimeoutRef.current)
-    }
-    copiedFieldTimeoutRef.current = setTimeout(() => {
-      setCopiedField(null)
-      copiedFieldTimeoutRef.current = null
-    }, UI_FEEDBACK_TIMEOUT_MS)
-  }
+  const {
+    agentConnected,
+    replicas,
+    readyReplicas,
+    pods,
+    ownerDeployment,
+    labels,
+    eventsOutput,
+    eventsLoading,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    handleCopy,
+  } = useReplicaSetDrillDown(cluster, namespace, replicasetName)
 
   const isHealthy = readyReplicas === replicas && replicas > 0
   const healthColors = getHealthColors(isHealthy)

--- a/web/src/components/drilldown/views/useEventsDrillDown.ts
+++ b/web/src/components/drilldown/views/useEventsDrillDown.ts
@@ -1,0 +1,113 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { getDemoMode } from '../../../hooks/useDemoMode'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../../lib/constants'
+import { POLL_INTERVAL_MS, UI_FEEDBACK_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../../lib/constants/network'
+import { agentFetch } from '../../../hooks/mcp/shared'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+export interface ClusterEvent {
+  type: string
+  reason: string
+  message: string
+  object: string
+  namespace: string
+  cluster: string
+  count: number
+  age?: string
+  firstSeen?: string
+  lastSeen?: string
+}
+
+export type TypeFilter = 'all' | 'Warning' | 'Normal'
+
+export interface UseEventsDrillDownResult {
+  events: ClusterEvent[]
+  isLoading: boolean
+  error: string | null
+  copied: boolean
+  refetch: (silent?: boolean) => Promise<void>
+  copyCommand: () => void
+}
+
+/**
+ * Owns all remote data loading for the Events drill-down
+ * so the view component stays presentational.
+ */
+export function useEventsDrillDown(
+  clusterShort: string,
+  namespace: string | undefined,
+  objectName: string | undefined
+): UseEventsDrillDownResult {
+  const [events, setEvents] = useState<ClusterEvent[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const refreshIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // Fetch events from local agent (no auth required)
+  const refetch = useCallback(async (silent = false) => {
+    // Skip agent requests in demo mode (no local agent on Netlify)
+    if (getDemoMode()) {
+      setIsLoading(false)
+      return
+    }
+    if (!silent) setIsLoading(true)
+    setError(null)
+    try {
+      // Use local agent - for node events, check default namespace with higher limit
+      const params = new URLSearchParams()
+      params.append('cluster', clusterShort)
+      // For node events, use default namespace where node events are stored
+      if (objectName && !namespace) {
+        params.append('namespace', 'default')
+      } else if (namespace) {
+        params.append('namespace', namespace)
+      }
+      if (objectName) {
+        params.append('object', objectName)
+      }
+      params.append('limit', '100')
+
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/events?${params}`, {
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+      })
+      if (response.ok) {
+        const data = await response.json()
+        setEvents(data.events || [])
+      } else {
+        setError('Failed to fetch events')
+      }
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch events')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [clusterShort, namespace, objectName])
+
+  // Initial fetch and auto-refresh every 30 seconds
+  useEffect(() => {
+    refetch()
+    refreshIntervalRef.current = setInterval(() => refetch(true), POLL_INTERVAL_MS)
+    return () => {
+      if (refreshIntervalRef.current) clearInterval(refreshIntervalRef.current)
+    }
+  }, [refetch])
+
+  const copyCommand = useCallback(() => {
+    const cmd = objectName
+      ? `kubectl --context ${clusterShort} get events --field-selector involvedObject.name=${objectName}${namespace ? ` -n ${namespace}` : ''}`
+      : `kubectl --context ${clusterShort} get events${namespace ? ` -n ${namespace}` : ' -A'} --sort-by=.lastTimestamp`
+    copyToClipboard(cmd)
+    setCopied(true)
+    setTimeout(() => setCopied(false), UI_FEEDBACK_TIMEOUT_MS)
+  }, [clusterShort, namespace, objectName])
+
+  return {
+    events,
+    isLoading,
+    error,
+    copied,
+    refetch,
+    copyCommand,
+  }
+}

--- a/web/src/components/drilldown/views/useNamespaceDrillDown.ts
+++ b/web/src/components/drilldown/views/useNamespaceDrillDown.ts
@@ -1,0 +1,96 @@
+import { usePodIssues, useDeploymentIssues, useEvents, useDeployments, useServices, usePods } from '../../../hooks/useMCP'
+import { useCachedPVCs } from '../../../hooks/useCachedData'
+
+export interface PodIssue {
+  name: string
+  namespace: string
+  status: string
+  restarts: number
+  reason?: string
+  issues?: string[]
+}
+
+export interface DeploymentIssue {
+  name: string
+  namespace: string
+  cluster?: string
+  replicas: number
+  readyReplicas: number
+  reason?: string
+  message?: string
+}
+
+export interface NamespaceEvent {
+  type: string
+  reason: string
+  message: string
+  object: string
+  namespace: string
+}
+
+export interface Pod {
+  name: string
+  status: string
+}
+
+export interface Deployment {
+  name: string
+  replicas: number
+  readyReplicas: number
+}
+
+export interface Service {
+  name: string
+  type: string
+}
+
+export interface PVC {
+  name: string
+  status: string
+  capacity?: string
+}
+
+export interface UseNamespaceDrillDownResult {
+  podIssues: PodIssue[]
+  deploymentIssues: DeploymentIssue[]
+  nsEvents: NamespaceEvent[]
+  allDeployments: Deployment[]
+  allServices: Service[]
+  allPVCs: PVC[]
+  allPods: Pod[]
+}
+
+/**
+ * Owns all data fetching for the Namespace drill-down
+ * so the view component stays presentational.
+ */
+export function useNamespaceDrillDown(cluster: string, namespace: string): UseNamespaceDrillDownResult {
+  const clusterShort = cluster.split('/').pop() || cluster
+
+  const { issues: allPodIssues } = usePodIssues(cluster)
+  const { issues: allDeploymentIssues } = useDeploymentIssues()
+  const { events } = useEvents(cluster, namespace, 20)
+
+  // Resource hooks for the Resources tab
+  const { deployments: allDeployments } = useDeployments(clusterShort, namespace)
+  const { services: allServices } = useServices(clusterShort, namespace)
+  const { pvcs: allPVCs } = useCachedPVCs(clusterShort, namespace)
+  const { pods: allPods } = usePods(clusterShort, namespace)
+
+  const podIssues = allPodIssues.filter(p => p.namespace === namespace) as PodIssue[]
+
+  const deploymentIssues = allDeploymentIssues.filter(d => d.namespace === namespace &&
+    (d.cluster === cluster || d.cluster?.includes(cluster.split('/')[0]))) as DeploymentIssue[]
+
+  const nsEvents = events.filter(e => e.namespace === namespace) as NamespaceEvent[]
+
+  return {
+    podIssues,
+    deploymentIssues,
+    nsEvents,
+    allDeployments: (allDeployments || []) as Deployment[],
+    allServices: (allServices || []) as Service[],
+    allPVCs: (allPVCs || []) as PVC[],
+    allPods: (allPods || []) as Pod[],
+  }
+}

--- a/web/src/components/drilldown/views/usePVCDrillDown.ts
+++ b/web/src/components/drilldown/views/usePVCDrillDown.ts
@@ -1,0 +1,155 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+export interface UsePVCDrillDownResult {
+  agentConnected: boolean
+  status: string
+  capacity: string
+  accessModes: string[]
+  storageClass: string
+  volumeName: string
+  volumeMode: string
+  labels: Record<string, string> | null
+  annotations: Record<string, string> | null
+  describeOutput: string | null
+  describeLoading: boolean
+  yamlOutput: string | null
+  yamlLoading: boolean
+  copiedField: string | null
+  isLoading: boolean
+  handleCopy: (text: string, field: string) => Promise<void>
+  fetchDescribe: () => Promise<void>
+  fetchYaml: () => Promise<void>
+}
+
+/**
+ * Owns all remote data loading for the PVC drill-down (status, labels, describe, yaml)
+ * so the view component stays presentational.
+ */
+export function usePVCDrillDown(
+  cluster: string,
+  namespace: string,
+  pvcName: string,
+  initialData: Record<string, unknown>
+): UsePVCDrillDownResult {
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [status, setStatus] = useState<string>(initialData.status as string || '')
+  const [capacity, setCapacity] = useState<string>(initialData.capacity as string || '')
+  const [accessModes, setAccessModes] = useState<string[]>((initialData.accessModes as string[]) || [])
+  const [storageClass, setStorageClass] = useState<string>(initialData.storageClass as string || '')
+  const [volumeName, setVolumeName] = useState<string>(initialData.volumeName as string || '')
+  const [volumeMode, setVolumeMode] = useState<string>('')
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [annotations, setAnnotations] = useState<Record<string, string> | null>(null)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Fetch PVC data from cluster
+  const fetchData = useCallback(async () => {
+    if (!agentConnected) return
+
+    setIsLoading(true)
+    try {
+      const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'json'])
+      if (output) {
+        let pvc
+        try {
+          pvc = JSON.parse(output)
+        } catch {
+          setLabels(null)
+          setAnnotations(null)
+          return
+        }
+        setStatus(pvc.status?.phase || '')
+        setCapacity(pvc.status?.capacity?.storage || pvc.spec?.resources?.requests?.storage || '')
+        setAccessModes(pvc.spec?.accessModes || [])
+        setStorageClass(pvc.spec?.storageClassName || '')
+        setVolumeName(pvc.spec?.volumeName || '')
+        setVolumeMode(pvc.spec?.volumeMode || 'Filesystem')
+        setLabels(pvc.metadata?.labels || null)
+        setAnnotations(pvc.metadata?.annotations || null)
+      }
+    } catch {
+      // Parse error — keep data from props
+    } finally {
+      setIsLoading(false)
+    }
+  }, [agentConnected, runKubectl, pvcName, namespace])
+
+  const fetchedRef = useRef(false)
+  useEffect(() => {
+    if (!fetchedRef.current) {
+      fetchedRef.current = true
+      void fetchData()
+    }
+  }, [fetchData])
+
+  const fetchDescribe = useCallback(async () => {
+    if (!agentConnected || describeLoading) return
+    setDescribeLoading(true)
+    const output = await runKubectl(['describe', 'pvc', pvcName, '-n', namespace])
+    setDescribeOutput(output || 'No output received')
+    setDescribeLoading(false)
+  }, [agentConnected, describeLoading, runKubectl, pvcName, namespace])
+
+  const fetchYaml = useCallback(async () => {
+    if (!agentConnected || yamlLoading) return
+    setYamlLoading(true)
+    const output = await runKubectl(['get', 'pvc', pvcName, '-n', namespace, '-o', 'yaml'])
+    setYamlOutput(output || 'No output received')
+    setYamlLoading(false)
+  }, [agentConnected, yamlLoading, runKubectl, pvcName, namespace])
+
+  useEffect(() => {
+    return () => {
+      if (copiedFieldTimeoutRef.current) {
+        clearTimeout(copiedFieldTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = useCallback(async (text: string, field: string) => {
+    const ok = await copyToClipboard(text)
+    if (ok) {
+      setCopiedField(field)
+      if (copiedFieldTimeoutRef.current) {
+        clearTimeout(copiedFieldTimeoutRef.current)
+      }
+      copiedFieldTimeoutRef.current = setTimeout(() => {
+        setCopiedField(null)
+        copiedFieldTimeoutRef.current = null
+      }, UI_FEEDBACK_TIMEOUT_MS)
+    }
+  }, [])
+
+  return {
+    agentConnected,
+    status,
+    capacity,
+    accessModes,
+    storageClass,
+    volumeName,
+    volumeMode,
+    labels,
+    annotations,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    isLoading,
+    handleCopy,
+    fetchDescribe,
+    fetchYaml,
+  }
+}

--- a/web/src/components/drilldown/views/usePolicyDrillDown.ts
+++ b/web/src/components/drilldown/views/usePolicyDrillDown.ts
@@ -1,0 +1,164 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+
+export interface Violation {
+  resource: string
+  kind: string
+  namespace?: string
+  message: string
+  timestamp?: string
+}
+
+interface ViolationRaw {
+  name?: string
+  kind?: string
+  namespace?: string
+  message?: string
+}
+
+export interface PolicySpec {
+  match?: Record<string, unknown>
+  parameters?: Record<string, unknown>
+  validationFailureAction?: string
+  background?: boolean
+  rules?: Array<{
+    name: string
+    match?: Record<string, unknown>
+    validate?: Record<string, unknown>
+    mutate?: Record<string, unknown>
+  }>
+}
+
+export interface UsePolicyDrillDownResult {
+  agentConnected: boolean
+  violations: Violation[] | null
+  violationsLoading: boolean
+  policySpec: PolicySpec | null
+  specLoading: boolean
+}
+
+/**
+ * Owns all remote data loading for the Policy drill-down (violations and spec)
+ * so the view component stays presentational.
+ */
+export function usePolicyDrillDown(
+  cluster: string,
+  policyName: string,
+  policyType: string,
+  policyKind: string,
+  namespace?: string
+): UsePolicyDrillDownResult {
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [violations, setViolations] = useState<Violation[] | null>(null)
+  const [violationsLoading, setViolationsLoading] = useState(false)
+  const [policySpec, setPolicySpec] = useState<PolicySpec | null>(null)
+  const [specLoading, setSpecLoading] = useState(false)
+
+  // Fetch violations
+  const fetchViolations = useCallback(async () => {
+    if (!agentConnected || violations) return
+    setViolationsLoading(true)
+    try {
+      let output: string
+      if (policyType === 'kyverno') {
+        // For Kyverno, fetch policy reports
+        output = await runKubectl([
+          'get', 'policyreport,clusterpolicyreport', '-A', '-o', 'json'
+        ])
+        if (output) {
+          const data = JSON.parse(output)
+          const items = data.items || []
+          const policyViolations: Violation[] = []
+
+          for (const report of items) {
+            const results = report.results || []
+            for (const result of results) {
+              if (result.policy === policyName && result.result === 'fail') {
+                policyViolations.push({
+                  resource: result.resources?.[0]?.name || 'Unknown',
+                  kind: result.resources?.[0]?.kind || 'Unknown',
+                  namespace: result.resources?.[0]?.namespace,
+                  message: result.message || 'Policy violation',
+                  timestamp: typeof result.timestamp === 'string'
+                    ? result.timestamp
+                    : result.timestamp && typeof result.timestamp === 'object' && 'seconds' in result.timestamp
+                      ? (() => { const d = new Date(Number(result.timestamp.seconds) * 1000); return isNaN(d.getTime()) ? undefined : d.toISOString() })()
+                      : undefined,
+                })
+              }
+            }
+          }
+          setViolations(policyViolations)
+        }
+      } else {
+        // For OPA Gatekeeper, fetch constraint status
+        output = await runKubectl([
+          'get', policyKind.toLowerCase(), policyName, '-o', 'json'
+        ])
+        if (output) {
+          const constraint = JSON.parse(output)
+          const statusViolations = constraint.status?.violations || []
+          setViolations(statusViolations.map((v: ViolationRaw) => ({
+            resource: v.name || 'Unknown',
+            kind: v.kind || 'Unknown',
+            namespace: v.namespace,
+            message: v.message || 'Policy violation',
+          })))
+        }
+      }
+    } catch {
+      setViolations([])
+    }
+    setViolationsLoading(false)
+  }, [agentConnected, violations, runKubectl, policyType, policyName, policyKind])
+
+  // Fetch policy spec
+  const fetchSpec = useCallback(async () => {
+    if (!agentConnected || policySpec) return
+    setSpecLoading(true)
+    try {
+      let output: string
+      if (policyType === 'kyverno') {
+        const resource = namespace ? `policy/${policyName}` : `clusterpolicy/${policyName}`
+        const nsArgs = namespace ? ['-n', namespace] : []
+        output = await runKubectl(['get', resource, ...nsArgs, '-o', 'json'])
+      } else {
+        output = await runKubectl([
+          'get', policyKind.toLowerCase(), policyName, '-o', 'json'
+        ])
+      }
+
+      if (output) {
+        const policy = JSON.parse(output)
+        setPolicySpec(policy.spec || {})
+      }
+    } catch {
+      setPolicySpec({})
+    }
+    setSpecLoading(false)
+  }, [agentConnected, policySpec, runKubectl, policyType, policyName, policyKind, namespace])
+
+  // Track if we've already loaded data
+  const hasLoadedRef = useRef(false)
+
+  useEffect(() => {
+    if (!agentConnected || hasLoadedRef.current) return
+    hasLoadedRef.current = true
+
+    const loadData = async () => {
+      await Promise.all([fetchViolations(), fetchSpec()])
+    }
+    loadData()
+  }, [agentConnected, fetchViolations, fetchSpec])
+
+  return {
+    agentConnected,
+    violations,
+    violationsLoading,
+    policySpec,
+    specLoading,
+  }
+}

--- a/web/src/components/drilldown/views/useReplicaSetDrillDown.ts
+++ b/web/src/components/drilldown/views/useReplicaSetDrillDown.ts
@@ -1,0 +1,194 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+export interface PodInfo {
+  name: string
+  status: string
+  restarts: number
+}
+
+export interface UseReplicaSetDrillDownResult {
+  agentConnected: boolean
+  replicas: number
+  readyReplicas: number
+  pods: PodInfo[]
+  ownerDeployment: string | null
+  labels: Record<string, string> | null
+  eventsOutput: string | null
+  eventsLoading: boolean
+  describeOutput: string | null
+  describeLoading: boolean
+  yamlOutput: string | null
+  yamlLoading: boolean
+  copiedField: string | null
+  handleCopy: (field: string, value: string) => void
+}
+
+/**
+ * Owns all remote data loading for the ReplicaSet drill-down
+ * so the view component stays presentational.
+ */
+export function useReplicaSetDrillDown(
+  cluster: string,
+  namespace: string,
+  replicasetName: string
+): UseReplicaSetDrillDownResult {
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [replicas, setReplicas] = useState<number>(0)
+  const [readyReplicas, setReadyReplicas] = useState<number>(0)
+  const [pods, setPods] = useState<PodInfo[]>([])
+  const [ownerDeployment, setOwnerDeployment] = useState<string | null>(null)
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [eventsOutput, setEventsOutput] = useState<string | null>(null)
+  const [eventsLoading, setEventsLoading] = useState(false)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Fetch ReplicaSet data
+  const fetchData = useCallback(async () => {
+    if (!agentConnected) return
+
+    try {
+      const output = await runKubectl(['get', 'replicaset', replicasetName, '-n', namespace, '-o', 'json'])
+      if (output) {
+        let rs
+        try {
+          rs = JSON.parse(output)
+        } catch {
+          console.warn('[ReplicaSetDrillDown] Failed to parse ReplicaSet JSON output')
+          return
+        }
+        setReplicas(rs.spec?.replicas || 0)
+        setReadyReplicas(rs.status?.readyReplicas || 0)
+        setLabels(rs.metadata?.labels || {})
+
+        // Get owner deployment
+        const ownerRef = rs.metadata?.ownerReferences?.find((o: { kind: string }) => o.kind === 'Deployment')
+        if (ownerRef) {
+          setOwnerDeployment(ownerRef.name)
+        }
+
+        // Get pods managed by this ReplicaSet
+        const selector = Object.entries(rs.spec?.selector?.matchLabels || {})
+          .map(([k, v]) => `${k}=${v}`)
+          .join(',')
+        if (selector) {
+          const podsOutput = await runKubectl(['get', 'pods', '-n', namespace, '-l', selector, '-o', 'json'])
+          if (podsOutput) {
+            let podList
+            try {
+              podList = JSON.parse(podsOutput)
+            } catch {
+              console.warn('[ReplicaSetDrillDown] Failed to parse Pods JSON output')
+              setPods([])
+              return
+            }
+            const podInfo = podList.items?.map((p: { metadata: { name: string }; status: { phase: string; containerStatuses?: Array<{ restartCount: number }> } }) => ({
+              name: p.metadata.name,
+              status: p.status.phase,
+              restarts: p.status.containerStatuses?.reduce((sum: number, c: { restartCount: number }) => sum + c.restartCount, 0) || 0
+            })) || []
+            setPods(podInfo)
+          }
+        }
+      }
+    } catch {
+      // Ignore fetch errors
+    }
+  }, [agentConnected, runKubectl, replicasetName, namespace])
+
+  const fetchEvents = useCallback(async () => {
+    if (!agentConnected || eventsOutput) return
+    setEventsLoading(true)
+    const output = await runKubectl(['get', 'events', '-n', namespace, '--field-selector', `involvedObject.name=${replicasetName}`, '-o', 'wide'])
+    setEventsOutput(output)
+    setEventsLoading(false)
+  }, [agentConnected, eventsOutput, runKubectl, namespace, replicasetName])
+
+  const fetchDescribe = useCallback(async () => {
+    if (!agentConnected || describeOutput) return
+    setDescribeLoading(true)
+    const output = await runKubectl(['describe', 'replicaset', replicasetName, '-n', namespace])
+    setDescribeOutput(output)
+    setDescribeLoading(false)
+  }, [agentConnected, describeOutput, runKubectl, replicasetName, namespace])
+
+  const fetchYaml = useCallback(async () => {
+    if (!agentConnected || yamlOutput) return
+    setYamlLoading(true)
+    const output = await runKubectl(['get', 'replicaset', replicasetName, '-n', namespace, '-o', 'yaml'])
+    setYamlOutput(output)
+    setYamlLoading(false)
+  }, [agentConnected, yamlOutput, runKubectl, replicasetName, namespace])
+
+  // Track if we've already loaded data to prevent refetching
+  const hasLoadedRef = useRef(false)
+
+  // Pre-fetch tab data when agent connects
+  useEffect(() => {
+    if (!agentConnected || hasLoadedRef.current) return
+    hasLoadedRef.current = true
+
+    const loadData = async () => {
+      // Batch 1: Overview data (2 concurrent)
+      await Promise.all([
+        fetchData(),
+        fetchEvents(),
+      ])
+
+      // Batch 2: Describe + YAML (2 concurrent, lower priority)
+      await Promise.all([
+        fetchDescribe(),
+        fetchYaml(),
+      ])
+    }
+
+    loadData()
+  }, [agentConnected, fetchData, fetchDescribe, fetchEvents, fetchYaml])
+
+  useEffect(() => {
+    return () => {
+      if (copiedFieldTimeoutRef.current) {
+        clearTimeout(copiedFieldTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = useCallback((field: string, value: string) => {
+    copyToClipboard(value)
+    setCopiedField(field)
+    if (copiedFieldTimeoutRef.current) {
+      clearTimeout(copiedFieldTimeoutRef.current)
+    }
+    copiedFieldTimeoutRef.current = setTimeout(() => {
+      setCopiedField(null)
+      copiedFieldTimeoutRef.current = null
+    }, UI_FEEDBACK_TIMEOUT_MS)
+  }, [])
+
+  return {
+    agentConnected,
+    replicas,
+    readyReplicas,
+    pods,
+    ownerDeployment,
+    labels,
+    eventsOutput,
+    eventsLoading,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    handleCopy,
+  }
+}


### PR DESCRIPTION
Fixes #21868
Fixes #21861
Fixes #21862
Fixes #21876
Fixes #21879

## Summary

This PR splits 5 oversized drilldown component files into smaller, more maintainable pieces following the existing pattern established by `CRDDrillDown`.

Each drilldown now has:
- `use{Name}DrillDown.ts`: Data fetching and state management hook
- `{Name}DrillDown.parts.tsx`: Reusable UI sub-components
- `{Name}DrillDown.tsx`: Main component (presentational)

## Results

| Component | Lines Before | Lines After | Hooks Before | Hooks After |
|-----------|-------------|-------------|--------------|-------------|
| PolicyDrillDown | 553 | 328 | 15 | 7 |
| PVCDrillDown | 414 | 252 | 12 | 5 |
| ReplicaSetDrillDown | 435 | 310 | 12 | 6 |
| EventsDrillDown | 458 | 251 | 13 | 7 |
| NamespaceDrillDown | 443 | 330 | 10 | 7 |

All files now meet acceptance criteria: **<350 lines AND <10 hook calls**