### PR TITLE
[scanner] fix: split RBACDrillDown and ConfigMapDrillDown

### DIFF
--- a/web/src/components/drilldown/views/ConfigMapDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.parts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import {
   FileText, Tag, ChevronDown, ChevronUp, Loader2,
   Copy, Check, ChevronLeft, Layers, Server, Database,

--- a/web/src/components/drilldown/views/ConfigMapDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.parts.tsx
@@ -1,0 +1,314 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  FileText, Tag, ChevronDown, ChevronUp, Loader2,
+  Copy, Check, ChevronLeft, Layers, Server, Database,
+  Eye, EyeOff, Lock,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+
+// ---------------------------------------------------------------------------
+// ConfigMapDrillDownHeader
+// ---------------------------------------------------------------------------
+
+interface HeaderProps {
+  cluster: string
+  namespace: string
+  clusterShort: string
+  canGoBack: boolean
+  onBack: () => void
+  onDrillToNamespace: (cluster: string, ns: string) => void
+  onDrillToCluster: (cluster: string) => void
+}
+
+export function ConfigMapDrillDownHeader({
+  cluster, namespace, clusterShort, canGoBack,
+  onBack, onDrillToNamespace, onDrillToCluster,
+}: HeaderProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="px-6 pt-6 pb-4">
+      <div className="flex items-center gap-6 text-sm">
+        {canGoBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+            aria-label={t('drilldown.goBack')}
+            title={t('drilldown.goBack')}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            <span>{t('common.back')}</span>
+          </button>
+        )}
+        {namespace && cluster && (
+          <button
+            type="button"
+            onClick={() => onDrillToNamespace(cluster, namespace)}
+            className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <Layers className="w-4 h-4 text-purple-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+            <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+            <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        )}
+        {cluster && (
+          <button
+            type="button"
+            onClick={() => onDrillToCluster(cluster)}
+            className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <Server className="w-4 h-4 text-blue-400" />
+            <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+            <ClusterBadge cluster={clusterShort} size="sm" />
+            <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+            </svg>
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ConfigMapOverviewTab
+// ---------------------------------------------------------------------------
+
+interface OverviewTabProps {
+  hasRequiredContext: boolean
+  dataLoading: boolean
+  dataError: string | null
+  configmapName: string
+  dataEntries: [string, string][]
+  labels: Record<string, string> | null
+  tabPanelProps: Record<string, unknown>
+}
+
+export function ConfigMapOverviewTab({
+  hasRequiredContext, dataLoading, dataError,
+  configmapName, dataEntries, labels, tabPanelProps,
+}: OverviewTabProps) {
+  const { t } = useTranslation()
+  return (
+    <div {...tabPanelProps} className="space-y-6">
+      {!hasRequiredContext && (
+        <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400">
+          {t('drilldown.configmap.missingContext', 'Unable to load this ConfigMap because the selected resource is missing required details.')}
+        </div>
+      )}
+      {dataLoading && (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="w-5 h-5 animate-spin text-primary" />
+          <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
+        </div>
+      )}
+      {dataError && !dataLoading && (
+        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+          <p className="text-sm text-red-400">{dataError}</p>
+        </div>
+      )}
+      {/* Basic Info */}
+      <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+        <div className="flex items-center gap-3">
+          <FileText className="w-8 h-8 text-yellow-400" />
+          <div>
+            <div className="text-lg font-semibold text-foreground">{configmapName}</div>
+            <div className="text-sm text-muted-foreground">
+              {dataEntries.length} key{dataEntries.length !== 1 ? 's' : ''}
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Labels */}
+      {labels && Object.keys(labels).length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
+            <Tag className="w-4 h-4 text-blue-400" />
+            Labels
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(labels).slice(0, 5).map(([key, value]) => (
+              <span key={key} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
+                {key}={value}
+              </span>
+            ))}
+            {Object.keys(labels).length > 5 && (
+              <span className="text-xs text-muted-foreground">+{Object.keys(labels).length - 5} more</span>
+            )}
+          </div>
+        </div>
+      )}
+      {/* Data Preview */}
+      <div>
+        <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
+          <Database className="w-4 h-4 text-yellow-400" />
+          Data Keys
+        </h3>
+        {dataEntries.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {dataEntries.map(([key]) => (
+              <span key={key} className="text-xs px-2 py-1 rounded bg-yellow-500/10 text-yellow-400 font-mono">
+                {key}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No data in this ConfigMap</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ConfigMapDataTab
+// ---------------------------------------------------------------------------
+
+interface DataTabProps {
+  dataEntries: [string, string][]
+  displayedData: [string, string][]
+  showAllData: boolean
+  revealAll: boolean
+  copiedField: string | null
+  isRevealed: (key: string) => boolean
+  toggleReveal: (key: string) => void
+  toggleRevealAll: () => void
+  handleCopy: (field: string, value: string) => void
+  setShowAllData: (val: boolean) => void
+  tabPanelProps: Record<string, unknown>
+}
+
+export function ConfigMapDataTab({
+  dataEntries, displayedData, showAllData, revealAll, copiedField,
+  isRevealed, toggleReveal, toggleRevealAll, handleCopy, setShowAllData,
+  tabPanelProps,
+}: DataTabProps) {
+  return (
+    <div {...tabPanelProps} className="space-y-4">
+      {/* #6211: master reveal toggle. #6231: text reflects current revealAll state. */}
+      <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Lock className="w-4 h-4" />
+          {revealAll
+            ? 'ConfigMap values are visible. Click "Mask all" to hide.'
+            : 'ConfigMap values are hidden by default. Click the eye icon to reveal.'}
+        </div>
+        <button
+          onClick={toggleRevealAll}
+          className="px-2 py-1 rounded bg-yellow-500/20 hover:bg-yellow-500/30 text-xs text-yellow-300 flex items-center gap-1"
+        >
+          {revealAll ? <><EyeOff className="w-3 h-3" /> Mask all</> : <><Eye className="w-3 h-3" /> Reveal all</>}
+        </button>
+      </div>
+      {dataEntries.length > 0 ? (
+        <>
+          {displayedData.map(([key, value]) => (
+            <div key={key} className="rounded-lg bg-card/50 border border-border overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-2 bg-yellow-500/10 border-b border-border">
+                <span className="font-mono text-sm text-yellow-400">{key}</span>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => toggleReveal(key)}
+                    className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                    aria-label={isRevealed(key) ? 'Mask value' : 'Reveal value'}
+                    title={isRevealed(key) ? 'Mask value' : 'Reveal value'}
+                  >
+                    {isRevealed(key) ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                  <button
+                    onClick={() => handleCopy(`data-${key}`, isRevealed(key) ? value : '••••••••••••••••')}
+                    className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                    aria-label={isRevealed(key) ? 'Copy value' : 'Reveal first to copy'}
+                    title={isRevealed(key) ? 'Copy value' : 'Reveal first to copy the actual value'}
+                  >
+                    {copiedField === `data-${key}` ? (
+                      <Check className="w-4 h-4 text-green-400" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+              <pre className="p-3 text-xs font-mono text-foreground whitespace-pre-wrap max-h-48 overflow-auto">
+                {isRevealed(key) ? value : '••••••••••••••••'}
+              </pre>
+            </div>
+          ))}
+          {dataEntries.length > 5 && (
+            <button
+              onClick={() => setShowAllData(!showAllData)}
+              className="text-xs text-primary hover:text-primary/80 flex items-center gap-1"
+            >
+              {showAllData ? (
+                <>Show less <ChevronUp className="w-3 h-3" /></>
+              ) : (
+                <>Show all {dataEntries.length} keys <ChevronDown className="w-3 h-3" /></>
+              )}
+            </button>
+          )}
+        </>
+      ) : (
+        <div className="p-4 rounded-lg bg-card/50 border border-border text-center text-muted-foreground">
+          No data in this ConfigMap
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ConfigMapOutputPane — shared by Describe and YAML tabs
+// ---------------------------------------------------------------------------
+
+interface OutputPaneProps {
+  loading: boolean
+  /** Already-processed content (masking applied before passing in if needed). */
+  displayedContent: string | null
+  copiedField: string | null
+  copiedFieldKey: string
+  loadingText: string
+  onCopy: (field: string, value: string) => void
+  tabPanelProps: Record<string, unknown>
+  /** Optional info banner rendered above the output (e.g. masking notice). */
+  infoBanner?: React.ReactNode
+}
+
+export function ConfigMapOutputPane({
+  loading, displayedContent, copiedField, copiedFieldKey,
+  loadingText, onCopy, tabPanelProps, infoBanner,
+}: OutputPaneProps) {
+  const { t } = useTranslation()
+  return (
+    <div {...tabPanelProps}>
+      {infoBanner}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          <span className="ml-2 text-muted-foreground">{loadingText}</span>
+        </div>
+      ) : displayedContent ? (
+        <div className="relative">
+          <button
+            onClick={() => onCopy(copiedFieldKey, displayedContent)}
+            className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+          >
+            {copiedField === copiedFieldKey
+              ? <><Check className="w-3 h-3 text-green-400" /> Copied</>
+              : <><Copy className="w-3 h-3" /> Copy</>}
+          </button>
+          <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+            {displayedContent}
+          </pre>
+        </div>
+      ) : (
+        <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
+++ b/web/src/components/drilldown/views/ConfigMapDrillDown.tsx
@@ -1,18 +1,19 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
-import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, ChevronLeft, Layers, Server, Database, Eye, EyeOff, Lock } from 'lucide-react'
+import { FileText, Code, Info, Database } from 'lucide-react'
 import { cn } from '../../../lib/cn'
 import { useTabKeyboardNav } from '../../../hooks/useKeyboardNav'
-import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
-import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../../lib/clipboard'
-// #6231: switched from the regex-based maskSecretYaml that lived in
-// SecretDrillDown to the shared js-yaml-based helper. Resource-agnostic
-// name + shared module + correct block-scalar handling.
+// #6231: switched from the regex-based maskSecretYaml to the shared js-yaml-based helper.
 import { maskKubernetesYamlData } from '../../../lib/yamlMask'
+import { Lock } from 'lucide-react'
+import { useConfigMapDrillDown } from './useConfigMapDrillDown'
+import {
+  ConfigMapDrillDownHeader,
+  ConfigMapOverviewTab,
+  ConfigMapDataTab,
+  ConfigMapOutputPane,
+} from './ConfigMapDrillDown.parts'
 
 interface Props {
   data: Record<string, unknown>
@@ -25,147 +26,36 @@ export function ConfigMapDrillDown({ data }: Props) {
   const cluster = typeof data.cluster === 'string' ? data.cluster : ''
   const namespace = typeof data.namespace === 'string' ? data.namespace : ''
   const configmapName = typeof data.configmap === 'string' ? data.configmap : ''
-  const { isConnected: agentConnected } = useLocalAgent()
   const { drillToNamespace, drillToCluster } = useDrillDownActions()
   const { state, pop } = useDrillDown()
-  const { runKubectl } = useDrillDownWebSocket(cluster)
   const clusterShort = cluster.split('/').pop() || cluster
   const hasRequiredContext = Boolean(cluster && namespace && configmapName)
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [configmapData, setConfigmapData] = useState<Record<string, string> | null>(null)
-  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
-  const [describeLoading, setDescribeLoading] = useState(false)
-  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
-  const [yamlLoading, setYamlLoading] = useState(false)
-  const [dataLoading, setDataLoading] = useState(false)
-  const [dataError, setDataError] = useState<string | null>(null)
-  const [labels, setLabels] = useState<Record<string, string> | null>(null)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
-  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [showAllData, setShowAllData] = useState(false)
-  // Per-key reveal gate (#6211). ConfigMaps are NOT secrets, but teams
-  // routinely store connection strings, passwords, and TLS material in them
-  // so the value column needs the same opt-in reveal pattern that
-  // SecretDrillDown uses on its Data tab — defaulting to masked, requiring
-  // an explicit click to reveal. Unlike Secrets, ConfigMaps may legitimately
-  // hold non-sensitive config too, so we expose a "Reveal all" master toggle
-  // alongside the per-key buttons for the common case.
-  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
-  const [revealAll, setRevealAll] = useState(false)
-  const { tabListProps, getTabProps, getTabPanelProps } = useTabKeyboardNav<TabType>({ tabs: ['overview', 'data', 'describe', 'yaml'], activeTab, onChange: setActiveTab })
+  const { tabListProps, getTabProps, getTabPanelProps } = useTabKeyboardNav<TabType>({
+    tabs: ['overview', 'data', 'describe', 'yaml'],
+    activeTab,
+    onChange: setActiveTab,
+  })
 
-  const toggleReveal = (key: string) => {
-    setRevealedKeys(prev => {
-      const next = new Set(prev)
-      if (next.has(key)) next.delete(key)
-      else next.add(key)
-      return next
-    })
-  }
-
-  const isRevealed = (key: string) => revealAll || revealedKeys.has(key)
-
-
-  // Fetch ConfigMap data
-  const fetchData = async () => {
-    if (!agentConnected || !hasRequiredContext) return
-    setDataLoading(true)
-    setDataError(null)
-    try {
-      const output = await runKubectl(['get', 'configmap', configmapName, '-n', namespace, '-o', 'json'])
-      if (output) {
-        let cm
-        try {
-          cm = JSON.parse(output)
-        } catch {
-          setConfigmapData({})
-          setLabels({})
-          return
-        }
-        setConfigmapData(cm.data || {})
-        setLabels(cm.metadata?.labels || {})
-      }
-    } catch (err) {
-      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load ConfigMap data'))
-    } finally {
-      setDataLoading(false)
-    }
-  }
-
-  const fetchDescribe = async () => {
-    if (!agentConnected || !hasRequiredContext || describeOutput) return
-    setDescribeLoading(true)
-    try {
-      const output = await runKubectl(['describe', 'configmap', configmapName, '-n', namespace])
-      setDescribeOutput(output)
-    } finally {
-      setDescribeLoading(false)
-    }
-  }
-
-  const fetchYaml = async () => {
-    if (!agentConnected || !hasRequiredContext || yamlOutput) return
-    setYamlLoading(true)
-    try {
-      const output = await runKubectl(['get', 'configmap', configmapName, '-n', namespace, '-o', 'yaml'])
-      setYamlOutput(output)
-    } finally {
-      setYamlLoading(false)
-    }
-  }
-
-  // Track if we've already loaded data to prevent refetching
-  const hasLoadedRef = useRef(false)
-
-  // Pre-fetch tab data when agent connects
-  // Batched to limit concurrent WebSocket connections (max 2 at a time)
-  useEffect(() => {
-    if (!hasRequiredContext) {
-      setConfigmapData({})
-      setLabels({})
-      setDescribeOutput(null)
-      setYamlOutput(null)
-      setDescribeLoading(false)
-      setYamlLoading(false)
-      return
-    }
-    if (!agentConnected || hasLoadedRef.current) return
-    hasLoadedRef.current = true
-
-    const loadData = async () => {
-      // Batch 1: Overview data (2 concurrent)
-      await Promise.all([
-        fetchData(),
-        fetchDescribe(),
-      ])
-
-      // Batch 2: YAML (lower priority)
-      await fetchYaml()
-    }
-
-    loadData()
-  }, [agentConnected, fetchData, fetchDescribe, fetchYaml, hasRequiredContext])
-
-  useEffect(() => {
-    return () => {
-      if (copiedFieldTimeoutRef.current) {
-        clearTimeout(copiedFieldTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = (field: string, value: string) => {
-    copyToClipboard(value)
-    setCopiedField(field)
-    if (copiedFieldTimeoutRef.current) {
-      clearTimeout(copiedFieldTimeoutRef.current)
-    }
-    copiedFieldTimeoutRef.current = setTimeout(() => {
-      setCopiedField(null)
-      copiedFieldTimeoutRef.current = null
-    }, UI_FEEDBACK_TIMEOUT_MS)
-  }
+  const {
+    configmapData,
+    dataLoading,
+    dataError,
+    labels,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    showAllData,
+    revealAll,
+    setShowAllData,
+    toggleRevealAll,
+    toggleReveal,
+    isRevealed,
+    handleCopy,
+  } = useConfigMapDrillDown(cluster, namespace, configmapName, hasRequiredContext)
 
   const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
     { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
@@ -174,56 +64,21 @@ export function ConfigMapDrillDown({ data }: Props) {
     { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
   ]
 
-  const dataEntries = Object.entries(configmapData || {})
+  const dataEntries = Object.entries(configmapData || {}) as [string, string][]
   const displayedData = showAllData ? dataEntries : dataEntries.slice(0, 5)
+  const displayedYaml = revealAll ? yamlOutput : (yamlOutput ? maskKubernetesYamlData(yamlOutput) : null)
 
   return (
     <div className="flex flex-col h-full -m-6">
-      {/* Header */}
-      <div className="px-6 pt-6 pb-4">
-        <div className="flex items-center gap-6 text-sm">
-          {state.stack.length > 1 && (
-            <button
-              type="button"
-              onClick={pop}
-              className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
-              aria-label={t('drilldown.goBack')}
-              title={t('drilldown.goBack')}
-            >
-              <ChevronLeft className="w-4 h-4" />
-              <span>{t('common.back')}</span>
-            </button>
-          )}
-          {namespace && cluster && (
-            <button
-              type="button"
-              onClick={() => drillToNamespace(cluster, namespace)}
-              className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-            >
-              <Layers className="w-4 h-4 text-purple-400" />
-              <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
-              <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
-              <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-          )}
-          {cluster && (
-            <button
-              type="button"
-              onClick={() => drillToCluster(cluster)}
-              className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-            >
-              <Server className="w-4 h-4 text-blue-400" />
-              <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
-              <ClusterBadge cluster={clusterShort} size="sm" />
-              <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-              </svg>
-            </button>
-          )}
-        </div>
-      </div>
+      <ConfigMapDrillDownHeader
+        cluster={cluster}
+        namespace={namespace}
+        clusterShort={clusterShort}
+        canGoBack={state.stack.length > 1}
+        onBack={pop}
+        onDrillToNamespace={drillToNamespace}
+        onDrillToCluster={drillToCluster}
+      />
 
       {/* Tabs */}
       <div className="border-b border-border px-6">
@@ -252,224 +107,61 @@ export function ConfigMapDrillDown({ data }: Props) {
       {/* Tab Content */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {activeTab === 'overview' && (
-          <div {...getTabPanelProps('overview')} className="space-y-6">
-            {!hasRequiredContext && (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400">
-                {t('drilldown.configmap.missingContext', 'Unable to load this ConfigMap because the selected resource is missing required details.')}
-              </div>
-            )}
-            {dataLoading && (
-              <div className="flex items-center justify-center py-6">
-                <Loader2 className="w-5 h-5 animate-spin text-primary" />
-                <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
-              </div>
-            )}
-            {dataError && !dataLoading && (
-              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-                <p className="text-sm text-red-400">{dataError}</p>
-              </div>
-            )}
-            {/* Basic Info */}
-            <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-              <div className="flex items-center gap-3">
-                <FileText className="w-8 h-8 text-yellow-400" />
-                <div>
-                  <div className="text-lg font-semibold text-foreground">{configmapName}</div>
-                  <div className="text-sm text-muted-foreground">
-                    {dataEntries.length} key{dataEntries.length !== 1 ? 's' : ''}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Labels */}
-            {labels && Object.keys(labels).length > 0 && (
-              <div>
-                <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
-                  <Tag className="w-4 h-4 text-blue-400" />
-                  Labels
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {Object.entries(labels).slice(0, 5).map(([key, value]) => (
-                    <span key={key} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
-                      {key}={value}
-                    </span>
-                  ))}
-                  {Object.keys(labels).length > 5 && (
-                    <span className="text-xs text-muted-foreground">+{Object.keys(labels).length - 5} more</span>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Data Preview */}
-            <div>
-              <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
-                <Database className="w-4 h-4 text-yellow-400" />
-                Data Keys
-              </h3>
-              {dataEntries.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {dataEntries.map(([key]) => (
-                    <span key={key} className="text-xs px-2 py-1 rounded bg-yellow-500/10 text-yellow-400 font-mono">
-                      {key}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No data in this ConfigMap</p>
-              )}
-            </div>
-          </div>
+          <ConfigMapOverviewTab
+            hasRequiredContext={hasRequiredContext}
+            dataLoading={dataLoading}
+            dataError={dataError}
+            configmapName={configmapName}
+            dataEntries={dataEntries}
+            labels={labels}
+            tabPanelProps={getTabPanelProps('overview') as Record<string, unknown>}
+          />
         )}
-
         {activeTab === 'data' && (
-          <div {...getTabPanelProps('data')} className="space-y-4">
-            {/* #6211: master reveal toggle for ConfigMaps. ConfigMaps often
-                hold non-sensitive config so a single "Reveal all" is more
-                ergonomic than the per-key dance, but we keep the per-key
-                buttons too for the case where a single sensitive value
-                hides among harmless ones. */}
-            {/* #6231: warning text now reflects the current revealAll
-                state instead of always saying "hidden by default". */}
-            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center justify-between gap-2">
-              <div className="flex items-center gap-2">
+          <ConfigMapDataTab
+            dataEntries={dataEntries}
+            displayedData={displayedData}
+            showAllData={showAllData}
+            revealAll={revealAll}
+            copiedField={copiedField}
+            isRevealed={isRevealed}
+            toggleReveal={toggleReveal}
+            toggleRevealAll={toggleRevealAll}
+            handleCopy={handleCopy}
+            setShowAllData={setShowAllData}
+            tabPanelProps={getTabPanelProps('data') as Record<string, unknown>}
+          />
+        )}
+        {activeTab === 'describe' && (
+          <ConfigMapOutputPane
+            loading={describeLoading}
+            displayedContent={describeOutput}
+            copiedField={copiedField}
+            copiedFieldKey="describe"
+            loadingText={t('drilldown.status.runningDescribe')}
+            onCopy={handleCopy}
+            tabPanelProps={getTabPanelProps('describe') as Record<string, unknown>}
+          />
+        )}
+        {activeTab === 'yaml' && (
+          <ConfigMapOutputPane
+            loading={yamlLoading}
+            displayedContent={displayedYaml}
+            copiedField={copiedField}
+            copiedFieldKey="yaml"
+            loadingText={t('drilldown.status.fetchingYaml')}
+            onCopy={handleCopy}
+            tabPanelProps={getTabPanelProps('yaml') as Record<string, unknown>}
+            infoBanner={
+              /* #6211: masking notice for the YAML tab */
+              <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2 mb-3">
                 <Lock className="w-4 h-4" />
                 {revealAll
-                  ? 'ConfigMap values are visible. Click "Mask all" to hide.'
-                  : 'ConfigMap values are hidden by default. Click the eye icon to reveal.'}
+                  ? 'ConfigMap values are visible. Use "Mask all" on the Data tab to hide.'
+                  : 'ConfigMap values are hidden by default. Use "Reveal all" on the Data tab to show.'}
               </div>
-              <button
-                onClick={() => setRevealAll(v => !v)}
-                className="px-2 py-1 rounded bg-yellow-500/20 hover:bg-yellow-500/30 text-xs text-yellow-300 flex items-center gap-1"
-              >
-                {revealAll ? <><EyeOff className="w-3 h-3" /> Mask all</> : <><Eye className="w-3 h-3" /> Reveal all</>}
-              </button>
-            </div>
-            {dataEntries.length > 0 ? (
-              <>
-                {displayedData.map(([key, value]) => (
-                  <div key={key} className="rounded-lg bg-card/50 border border-border overflow-hidden">
-                    <div className="flex items-center justify-between px-3 py-2 bg-yellow-500/10 border-b border-border">
-                      <span className="font-mono text-sm text-yellow-400">{key}</span>
-                      <div className="flex items-center gap-1">
-                        <button
-                          onClick={() => toggleReveal(key)}
-                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
-                          aria-label={isRevealed(key) ? 'Mask value' : 'Reveal value'}
-                          title={isRevealed(key) ? 'Mask value' : 'Reveal value'}
-                        >
-                          {isRevealed(key) ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                        </button>
-                        <button
-                          onClick={() => handleCopy(`data-${key}`, isRevealed(key) ? value : '••••••••••••••••')}
-                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
-                          aria-label={isRevealed(key) ? 'Copy value' : 'Reveal first to copy'}
-                          title={isRevealed(key) ? 'Copy value' : 'Reveal first to copy the actual value'}
-                        >
-                          {copiedField === `data-${key}` ? (
-                            <Check className="w-4 h-4 text-green-400" />
-                          ) : (
-                            <Copy className="w-4 h-4" />
-                          )}
-                        </button>
-                      </div>
-                    </div>
-                    <pre className="p-3 text-xs font-mono text-foreground whitespace-pre-wrap max-h-48 overflow-auto">
-                      {isRevealed(key) ? value : '••••••••••••••••'}
-                    </pre>
-                  </div>
-                ))}
-                {dataEntries.length > 5 && (
-                  <button
-                    onClick={() => setShowAllData(!showAllData)}
-                    className="text-xs text-primary hover:text-primary/80 flex items-center gap-1"
-                  >
-                    {showAllData ? (
-                      <>Show less <ChevronUp className="w-3 h-3" /></>
-                    ) : (
-                      <>Show all {dataEntries.length} keys <ChevronDown className="w-3 h-3" /></>
-                    )}
-                  </button>
-                )}
-              </>
-            ) : (
-              <div className="p-4 rounded-lg bg-card/50 border border-border text-center text-muted-foreground">
-                No data in this ConfigMap
-              </div>
-            )}
-          </div>
-        )}
-
-        {activeTab === 'describe' && (
-          <div {...getTabPanelProps('describe')}>
-            {describeLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.runningDescribe')}</span>
-              </div>
-            ) : describeOutput ? (
-              <div className="relative">
-                <button
-                  onClick={() => handleCopy('describe', describeOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'describe' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                </button>
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {describeOutput}
-                </pre>
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {activeTab === 'yaml' && (
-          <div {...getTabPanelProps('yaml')} className="space-y-3">
-            {/* #6211: same masking model the Data tab uses, applied to the
-                YAML view so that tab isn't a bypass for the per-key reveal.
-                ConfigMap YAML uses the same `data:` block shape as Secret
-                YAML, so we share the maskKubernetesYamlData() helper. */}
-            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
-              <Lock className="w-4 h-4" />
-              {revealAll
-                ? 'ConfigMap values are visible. Use "Mask all" on the Data tab to hide.'
-                : 'ConfigMap values are hidden by default. Use "Reveal all" on the Data tab to show.'}
-            </div>
-            {yamlLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.fetchingYaml')}</span>
-              </div>
-            ) : yamlOutput ? (
-              <div className="relative">
-                {(() => {
-                  const displayedYaml = revealAll ? yamlOutput : maskKubernetesYamlData(yamlOutput)
-                  return (
-                    <>
-                      <button
-                        onClick={() => handleCopy('yaml', displayedYaml)}
-                        className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                      >
-                        {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                      </button>
-                      <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                        {displayedYaml}
-                      </pre>
-                    </>
-                  )
-                })()}
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
-          </div>
+            }
+          />
         )}
       </div>
     </div>

--- a/web/src/components/drilldown/views/RBACDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/RBACDrillDown.parts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import {
   Loader2, Copy, Check, AlertTriangle,
   Shield, ShieldCheck, Server, User, RefreshCw,

--- a/web/src/components/drilldown/views/RBACDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/RBACDrillDown.parts.tsx
@@ -1,0 +1,235 @@
+/* eslint-disable react-refresh/only-export-components */
+import {
+  Loader2, Copy, Check, AlertTriangle,
+  Shield, ShieldCheck, Server, User, RefreshCw,
+} from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { cn } from '../../../lib/cn'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { MAX_BINDINGS_TO_DESCRIBE, type RoleBinding } from './useRBACDrillDown'
+
+// ---------------------------------------------------------------------------
+// RBACDrillDownHeader
+// ---------------------------------------------------------------------------
+
+interface HeaderProps {
+  subjectType: string
+  subject: string
+  namespace?: string
+  cluster: string
+  agentConnected: boolean
+  refreshing: boolean
+  onDrillToNamespace: (cluster: string, ns: string) => void
+  onDrillToCluster: (cluster: string) => void
+  onRefresh: () => void
+}
+
+export function RBACDrillDownHeader({
+  subjectType, subject, namespace, cluster,
+  agentConnected, refreshing,
+  onDrillToNamespace, onDrillToCluster, onRefresh,
+}: HeaderProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="px-6 pt-6 pb-4">
+      <div className="flex items-center gap-6 text-sm">
+        <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-purple-500/10 border border-purple-500/20">
+          <User className="w-4 h-4 text-purple-400" />
+          <span className="text-muted-foreground">{subjectType}</span>
+          <span className="font-mono text-purple-400">{subject}</span>
+        </div>
+        {namespace && (
+          <button
+            onClick={() => onDrillToNamespace(cluster, namespace)}
+            className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+          >
+            <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+            <span className="font-mono text-purple-400 group-hover:text-purple-300">{namespace}</span>
+          </button>
+        )}
+        <button
+          onClick={() => onDrillToCluster(cluster)}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
+        </button>
+        {/* Refresh button — re-fetches bindings and clears stale Describe/YAML output. */}
+        <button
+          onClick={onRefresh}
+          disabled={!agentConnected || refreshing}
+          className="ml-auto flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          data-testid="rbac-drilldown-refresh"
+          aria-label={t('common.refresh')}
+        >
+          <RefreshCw className={cn('w-4 h-4', refreshing && 'animate-spin')} />
+          <span>{t('common.refresh')}</span>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// RBACOverviewTab
+// ---------------------------------------------------------------------------
+
+interface OverviewTabProps {
+  loadError: string | null
+  loading: boolean
+  totalBindings: number
+  subjectType: string
+  subject: string
+  clusterBindings: RoleBinding[]
+  roleBindings: RoleBinding[]
+}
+
+export function RBACOverviewTab({
+  loadError, loading, totalBindings, subjectType, subject,
+  clusterBindings, roleBindings,
+}: OverviewTabProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-6">
+      {loadError && (
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300">
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <span className="text-sm">{loadError}</span>
+        </div>
+      )}
+      {loading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          <span className="ml-2 text-muted-foreground">{t('drilldown.rbac.loadingBindings')}</span>
+        </div>
+      ) : totalBindings === 0 ? (
+        <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-yellow-400">{t('drilldown.rbac.noBindingsForSubject', { type: subjectType, subject })}</p>
+        </div>
+      ) : (
+        <>
+          {clusterBindings.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+                <ShieldCheck className="w-4 h-4 text-green-400" />
+                {t('drilldown.rbac.clusterRoleBindingsHeader', { count: clusterBindings.length })}
+              </h3>
+              <div className="space-y-2">
+                {clusterBindings.map((b) => (
+                  <div key={b.name} className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center justify-between">
+                    <div>
+                      <div className="font-mono text-sm text-green-400">{b.name}</div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {b.roleKind}: <span className="text-foreground">{b.roleName}</span>
+                      </div>
+                    </div>
+                    <span className="text-xs px-2 py-1 rounded bg-green-500/10 text-green-400 border border-green-500/20">
+                      {t('drilldown.rbac.clusterWide')}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+          {roleBindings.length > 0 && (
+            <div>
+              <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
+                <Shield className="w-4 h-4 text-blue-400" />
+                {t('drilldown.rbac.roleBindingsHeader', { count: roleBindings.length })}
+              </h3>
+              <div className="space-y-2">
+                {roleBindings.map((b) => (
+                  <div key={`${b.namespace}-${b.name}`} className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-between">
+                    <div>
+                      <div className="font-mono text-sm text-blue-400">{b.name}</div>
+                      <div className="text-xs text-muted-foreground mt-1">
+                        {b.roleKind}: <span className="text-foreground">{b.roleName}</span>
+                        {b.namespace && (
+                          <> {t('drilldown.rbac.inNamespace')} <span className="text-foreground">{b.namespace}</span></>
+                        )}
+                      </div>
+                    </div>
+                    {b.namespace && (
+                      <span className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">
+                        {b.namespace}
+                      </span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// RBACOutputPane — shared by Describe and YAML tabs
+// ---------------------------------------------------------------------------
+
+interface OutputPaneProps {
+  loading: boolean
+  output: string | null
+  copiedField: string | null
+  copiedFieldKey: string
+  hiddenBindingCount: number
+  totalBindings: number
+  loadingText: string
+  onCopy: (field: string, value: string) => void
+}
+
+export function RBACOutputPane({
+  loading, output, copiedField, copiedFieldKey,
+  hiddenBindingCount, totalBindings, loadingText, onCopy,
+}: OutputPaneProps) {
+  const { t } = useTranslation()
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <Loader2 className="w-6 h-6 animate-spin text-primary" />
+        <span className="ml-2 text-muted-foreground">{loadingText}</span>
+      </div>
+    )
+  }
+
+  if (output) {
+    return (
+      <div className="relative">
+        <button
+          onClick={() => onCopy(copiedFieldKey, output)}
+          className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+        >
+          {copiedField === copiedFieldKey
+            ? <><Check className="w-3 h-3 text-green-400" /> {t('common.copied')}</>
+            : <><Copy className="w-3 h-3" /> {t('common.copy')}</>}
+        </button>
+        {/* Truncation notice (Issue 9267) */}
+        {hiddenBindingCount > 0 && (
+          <div
+            className="mb-2 px-3 py-2 rounded-md bg-yellow-500/10 border border-yellow-500/20 text-xs text-yellow-400"
+            data-testid="rbac-drilldown-truncation-notice"
+          >
+            {t('drilldown.rbac.truncationNotice', {
+              shown: MAX_BINDINGS_TO_DESCRIBE,
+              total: totalBindings,
+              hidden: hiddenBindingCount,
+            })}
+          </div>
+        )}
+        <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+          {output}
+        </pre>
+      </div>
+    )
+  }
+
+  return (
+    <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+      <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/RBACDrillDown.tsx
+++ b/web/src/components/drilldown/views/RBACDrillDown.tsx
@@ -1,47 +1,16 @@
-import { useState, useEffect, useRef, useCallback } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useState } from 'react'
 import { useDrillDownActions } from '../../../hooks/useDrillDown'
-import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Code, Info, Loader2, Copy, Check, Server, Shield, ShieldCheck, User, RefreshCw, AlertTriangle } from 'lucide-react'
+import { FileText, Code, Shield, Info } from 'lucide-react'
 import { cn } from '../../../lib/cn'
-import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
 import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../../lib/clipboard'
-
-// ---------------------------------------------------------------------------
-// Named constants — no magic numbers
-// ---------------------------------------------------------------------------
-
-/**
- * Maximum number of bindings the Describe and YAML tabs render inline.
- * Anything above this is truncated; a notice is displayed to the user
- * (Issue 9267).
- */
-const MAX_BINDINGS_TO_DESCRIBE = 10
+import { useRBACDrillDown, type DrillDownKind } from './useRBACDrillDown'
+import { RBACDrillDownHeader, RBACOverviewTab, RBACOutputPane } from './RBACDrillDown.parts'
 
 interface Props {
   data: Record<string, unknown>
 }
 
-interface RoleBinding {
-  kind: string
-  name: string
-  namespace?: string
-  roleName: string
-  roleKind: string
-}
-
 type TabType = 'overview' | 'describe' | 'yaml'
-
-/**
- * RBAC subject kinds that a *subject* column can hold. When the drilldown
- * is opened on a Role or RoleBinding row itself, the filter logic needs to
- * match by the role name in `roleRef`, not by the subject name (Issue 9264).
- */
-type DrillDownKind = 'User' | 'Group' | 'ServiceAccount' | 'Role' | 'RoleBinding' | 'ClusterRole' | 'ClusterRoleBinding'
-
-const SUBJECT_KINDS = new Set<DrillDownKind>(['User', 'Group', 'ServiceAccount'])
 
 export function RBACDrillDown({ data }: Props) {
   const { t } = useTranslation()
@@ -49,191 +18,29 @@ export function RBACDrillDown({ data }: Props) {
   const namespace = data.namespace as string | undefined
   const subject = data.subject as string
   const subjectType = ((data.type as string) || 'User') as DrillDownKind
-  const { isConnected: agentConnected } = useLocalAgent()
   const { drillToCluster, drillToNamespace } = useDrillDownActions()
-  const { runKubectl } = useDrillDownWebSocket(cluster)
 
   const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [clusterBindings, setClusterBindings] = useState<RoleBinding[]>([])
-  const [roleBindings, setRoleBindings] = useState<RoleBinding[]>([])
-  const [loading, setLoading] = useState(true)
-  const [loadError, setLoadError] = useState<string | null>(null)
-  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
-  const [describeLoading, setDescribeLoading] = useState(false)
-  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
-  const [yamlLoading, setYamlLoading] = useState(false)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
-  const [refreshing, setRefreshing] = useState(false)
-  const mountedRef = useRef(true)
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
 
-  useEffect(() => {
-    return () => {
-      mountedRef.current = false
-      clearTimeout(copyTimerRef.current)
-    }
-  }, [])
-
-
-  /**
-   * Returns true if the given binding matches the drilled-into target.
-   * - For User/Group/ServiceAccount, match by subject kind + name (the
-   *   binding references the drilled-into subject).
-   * - For Role / ClusterRole, match by roleRef.name (any binding that
-   *   references the drilled-into role).
-   * - For RoleBinding / ClusterRoleBinding, match by metadata.name (the
-   *   binding itself is the target).
-   *
-   * Previously the code only handled the User/Group/ServiceAccount case,
-   * so drilldowns opened from Role / RoleBinding rows always returned
-   * empty — Issue 9264.
-   */
-  const parseBindings = useCallback((json: string, kind: string): RoleBinding[] => {
-    try {
-      const parsed = JSON.parse(json)
-      const items = parsed.items || []
-      return items.filter((item: Record<string, unknown>) => {
-        if (SUBJECT_KINDS.has(subjectType)) {
-          const subjects = item.subjects as Array<{ kind: string; name: string }> | undefined
-          return subjects?.some(s => s.name === subject && s.kind === subjectType)
-        }
-        if (subjectType === 'Role' || subjectType === 'ClusterRole') {
-          const roleRef = item.roleRef as { kind: string; name: string } | undefined
-          return roleRef?.name === subject
-        }
-        if (subjectType === 'RoleBinding' || subjectType === 'ClusterRoleBinding') {
-          const meta = item.metadata as { name: string } | undefined
-          return meta?.name === subject
-        }
-        return false
-      }).map((item: Record<string, unknown>) => {
-        const roleRef = item.roleRef as { kind: string; name: string }
-        const meta = item.metadata as { name: string; namespace?: string }
-        return {
-          kind,
-          name: meta.name,
-          namespace: meta.namespace,
-          roleName: roleRef.name,
-          roleKind: roleRef.kind,
-        }
-      })
-    } catch {
-      return []
-    }
-  }, [subject, subjectType])
-
-  /**
-   * Fetch bindings from the cluster. Also clears the stale Describe/YAML
-   * output so the next tab switch re-fetches (Issue 9267).
-   */
-  const fetchBindings = useCallback(async () => {
-    if (!agentConnected) return
-    setLoading(true)
-    setLoadError(null)
-
-    try {
-      const [crbOut, rbOut] = await Promise.all([
-        runKubectl(['get', 'clusterrolebindings', '-o', 'json']),
-        namespace
-          ? runKubectl(['get', 'rolebindings', '-n', namespace, '-o', 'json'])
-          : runKubectl(['get', 'rolebindings', '--all-namespaces', '-o', 'json']),
-      ])
-
-      if (!mountedRef.current) return
-      setClusterBindings(parseBindings(crbOut, 'ClusterRoleBinding'))
-      setRoleBindings(parseBindings(rbOut, 'RoleBinding'))
-    } catch (err) {
-      if (!mountedRef.current) return
-      const errMsg = err instanceof Error ? err.message : 'Failed to fetch bindings'
-      setLoadError(errMsg)
-      setClusterBindings([])
-      setRoleBindings([])
-    }
-    setLoading(false)
-  }, [agentConnected, namespace, parseBindings, runKubectl])
-
-  const fetchDescribe = useCallback(async () => {
-    if (!agentConnected || describeOutput) return
-    setDescribeLoading(true)
-    const bindings = [...clusterBindings, ...roleBindings]
-    const parts: string[] = []
-    for (const b of bindings.slice(0, MAX_BINDINGS_TO_DESCRIBE)) {
-      if (!mountedRef.current) return
-      const args = b.kind === 'ClusterRoleBinding'
-        ? ['describe', 'clusterrolebinding', b.name]
-        : ['describe', 'rolebinding', b.name, '-n', b.namespace || 'default']
-      const out = await runKubectl(args)
-      if (out) parts.push(out)
-    }
-    if (!mountedRef.current) return
-    setDescribeOutput(parts.join('\n---\n') || t('drilldown.empty.noBindingsFound'))
-    setDescribeLoading(false)
-  }, [agentConnected, clusterBindings, describeOutput, roleBindings, runKubectl, t])
-
-  const fetchYaml = useCallback(async () => {
-    if (!agentConnected || yamlOutput) return
-    setYamlLoading(true)
-    const bindings = [...clusterBindings, ...roleBindings]
-    const parts: string[] = []
-    for (const b of bindings.slice(0, MAX_BINDINGS_TO_DESCRIBE)) {
-      if (!mountedRef.current) return
-      const args = b.kind === 'ClusterRoleBinding'
-        ? ['get', 'clusterrolebinding', b.name, '-o', 'yaml']
-        : ['get', 'rolebinding', b.name, '-n', b.namespace || 'default', '-o', 'yaml']
-      const out = await runKubectl(args)
-      if (out) parts.push(out)
-    }
-    if (!mountedRef.current) return
-    setYamlOutput(parts.join('\n---\n') || t('drilldown.empty.noBindingsFound'))
-    setYamlLoading(false)
-  }, [agentConnected, clusterBindings, roleBindings, runKubectl, yamlOutput, t])
-
-  const hasLoadedRef = useRef(false)
-
-  // Track agent connection state so a disconnect → reconnect also triggers a
-  // fresh fetch (Issue 9267). Without this the drilldown stayed blank after
-  // the agent dropped and returned.
-  const prevAgentConnectedRef = useRef(agentConnected)
-
-  useEffect(() => {
-    if (agentConnected && !hasLoadedRef.current) {
-      hasLoadedRef.current = true
-      fetchBindings()
-    }
-    // If the agent reconnected after having been disconnected, force a refresh
-    if (agentConnected && !prevAgentConnectedRef.current && hasLoadedRef.current) {
-      setDescribeOutput(null)
-      setYamlOutput(null)
-      fetchBindings()
-    }
-    prevAgentConnectedRef.current = agentConnected
-  }, [agentConnected, fetchBindings])
-
-  /**
-   * Manual refresh — re-fetches bindings and clears the Describe/YAML output
-   * so the next tab switch re-fetches fresh output (Issue 9267).
-   */
-  const handleRefresh = useCallback(async () => {
-    if (!agentConnected || refreshing) return
-    setRefreshing(true)
-    setDescribeOutput(null)
-    setYamlOutput(null)
-    try {
-      await fetchBindings()
-    } finally {
-      setRefreshing(false)
-    }
-  }, [agentConnected, fetchBindings, refreshing])
-
-  const handleCopy = (field: string, value: string) => {
-    copyToClipboard(value)
-    setCopiedField(field)
-    clearTimeout(copyTimerRef.current)
-    copyTimerRef.current = setTimeout(() => setCopiedField(null), UI_FEEDBACK_TIMEOUT_MS)
-  }
-
-  const totalBindings = clusterBindings.length + roleBindings.length
-  const hiddenBindingCount = Math.max(0, totalBindings - MAX_BINDINGS_TO_DESCRIBE)
+  const {
+    agentConnected,
+    clusterBindings,
+    roleBindings,
+    loading,
+    loadError,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    refreshing,
+    totalBindings,
+    hiddenBindingCount,
+    fetchDescribe,
+    fetchYaml,
+    handleRefresh,
+    handleCopy,
+  } = useRBACDrillDown(cluster, namespace, subject, subjectType)
 
   const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
     { id: 'overview', label: t('drilldown.rbac.bindingsTab', { count: totalBindings }), icon: Shield },
@@ -243,45 +50,17 @@ export function RBACDrillDown({ data }: Props) {
 
   return (
     <div className="flex flex-col h-full -m-6">
-      {/* Header */}
-      <div className="px-6 pt-6 pb-4">
-        <div className="flex items-center gap-6 text-sm">
-          <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-purple-500/10 border border-purple-500/20">
-            <User className="w-4 h-4 text-purple-400" />
-            <span className="text-muted-foreground">{subjectType}</span>
-            <span className="font-mono text-purple-400">{subject}</span>
-          </div>
-          {namespace && (
-            <button
-              onClick={() => drillToNamespace(cluster, namespace)}
-              className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-            >
-              <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
-              <span className="font-mono text-purple-400 group-hover:text-purple-300">{namespace}</span>
-            </button>
-          )}
-          <button
-            onClick={() => drillToCluster(cluster)}
-            className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-          >
-            <Server className="w-4 h-4 text-blue-400" />
-            <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
-            <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
-          </button>
-          {/* Refresh button (Issue 9267) — re-fetches bindings and clears
-              stale Describe/YAML output so the next tab switch re-runs them. */}
-          <button
-            onClick={handleRefresh}
-            disabled={!agentConnected || refreshing}
-            className="ml-auto flex items-center gap-2 px-3 py-1.5 rounded-lg text-sm text-muted-foreground hover:text-foreground hover:bg-secondary/50 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-            data-testid="rbac-drilldown-refresh"
-            aria-label={t('common.refresh')}
-          >
-            <RefreshCw className={cn('w-4 h-4', refreshing && 'animate-spin')} />
-            <span>{t('common.refresh')}</span>
-          </button>
-        </div>
-      </div>
+      <RBACDrillDownHeader
+        subjectType={subjectType}
+        subject={subject}
+        namespace={namespace}
+        cluster={cluster}
+        agentConnected={agentConnected}
+        refreshing={refreshing}
+        onDrillToNamespace={drillToNamespace}
+        onDrillToCluster={drillToCluster}
+        onRefresh={handleRefresh}
+      />
 
       {/* Tabs */}
       <div className="border-b border-border px-6">
@@ -314,149 +93,42 @@ export function RBACDrillDown({ data }: Props) {
       {/* Tab Content */}
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {activeTab === 'overview' && (
-          <div className="space-y-6">
-            {loadError && (
-              <div className="flex items-center gap-2 p-3 rounded-lg bg-red-500/10 border border-red-500/30 text-red-300">
-                <AlertTriangle className="w-4 h-4 shrink-0" />
-                <span className="text-sm">{loadError}</span>
-              </div>
-            )}
-            {loading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.rbac.loadingBindings')}</span>
-              </div>
-            ) : totalBindings === 0 ? (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.rbac.noBindingsForSubject', { type: subjectType, subject })}</p>
-              </div>
-            ) : (
-              <>
-                {clusterBindings.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-                      <ShieldCheck className="w-4 h-4 text-green-400" />
-                      {t('drilldown.rbac.clusterRoleBindingsHeader', { count: clusterBindings.length })}
-                    </h3>
-                    <div className="space-y-2">
-                      {clusterBindings.map((b) => (
-                        <div key={b.name} className="p-3 rounded-lg bg-green-500/10 border border-green-500/20 flex items-center justify-between">
-                          <div>
-                            <div className="font-mono text-sm text-green-400">{b.name}</div>
-                            <div className="text-xs text-muted-foreground mt-1">
-                              {b.roleKind}: <span className="text-foreground">{b.roleName}</span>
-                            </div>
-                          </div>
-                          <span className="text-xs px-2 py-1 rounded bg-green-500/10 text-green-400 border border-green-500/20">{t('drilldown.rbac.clusterWide')}</span>
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-
-                {roleBindings.length > 0 && (
-                  <div>
-                    <h3 className="text-sm font-semibold text-foreground mb-3 flex items-center gap-2">
-                      <Shield className="w-4 h-4 text-blue-400" />
-                      {t('drilldown.rbac.roleBindingsHeader', { count: roleBindings.length })}
-                    </h3>
-                    <div className="space-y-2">
-                      {roleBindings.map((b) => (
-                        <div key={`${b.namespace}-${b.name}`} className="p-3 rounded-lg bg-blue-500/10 border border-blue-500/20 flex items-center justify-between">
-                          <div>
-                            <div className="font-mono text-sm text-blue-400">{b.name}</div>
-                            <div className="text-xs text-muted-foreground mt-1">
-                              {b.roleKind}: <span className="text-foreground">{b.roleName}</span>
-                              {b.namespace && <> {t('drilldown.rbac.inNamespace')} <span className="text-foreground">{b.namespace}</span></>}
-                            </div>
-                          </div>
-                          {b.namespace && (
-                            <span className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 border border-blue-500/20">{b.namespace}</span>
-                          )}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                )}
-              </>
-            )}
-          </div>
+          <RBACOverviewTab
+            loadError={loadError}
+            loading={loading}
+            totalBindings={totalBindings}
+            subjectType={subjectType}
+            subject={subject}
+            clusterBindings={clusterBindings}
+            roleBindings={roleBindings}
+          />
         )}
-
         {activeTab === 'describe' && (
           <div>
-            {describeLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.runningDescribe')}</span>
-              </div>
-            ) : describeOutput ? (
-              <div className="relative">
-                <button
-                  onClick={() => handleCopy('describe', describeOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'describe' ? <><Check className="w-3 h-3 text-green-400" /> {t('common.copied')}</> : <><Copy className="w-3 h-3" /> {t('common.copy')}</>}
-                </button>
-                {/* Truncation notice (Issue 9267) */}
-                {hiddenBindingCount > 0 && (
-                  <div
-                    className="mb-2 px-3 py-2 rounded-md bg-yellow-500/10 border border-yellow-500/20 text-xs text-yellow-400"
-                    data-testid="rbac-drilldown-truncation-notice"
-                  >
-                    {t('drilldown.rbac.truncationNotice', {
-                      shown: MAX_BINDINGS_TO_DESCRIBE,
-                      total: totalBindings,
-                      hidden: hiddenBindingCount })}
-                  </div>
-                )}
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {describeOutput}
-                </pre>
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
+            <RBACOutputPane
+              loading={describeLoading}
+              output={describeOutput}
+              copiedField={copiedField}
+              copiedFieldKey="describe"
+              hiddenBindingCount={hiddenBindingCount}
+              totalBindings={totalBindings}
+              loadingText={t('drilldown.status.runningDescribe')}
+              onCopy={handleCopy}
+            />
           </div>
         )}
-
         {activeTab === 'yaml' && (
           <div>
-            {yamlLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.fetchingYaml')}</span>
-              </div>
-            ) : yamlOutput ? (
-              <div className="relative">
-                <button
-                  onClick={() => handleCopy('yaml', yamlOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> {t('common.copied')}</> : <><Copy className="w-3 h-3" /> {t('common.copy')}</>}
-                </button>
-                {/* Truncation notice (Issue 9267) */}
-                {hiddenBindingCount > 0 && (
-                  <div
-                    className="mb-2 px-3 py-2 rounded-md bg-yellow-500/10 border border-yellow-500/20 text-xs text-yellow-400"
-                  >
-                    {t('drilldown.rbac.truncationNotice', {
-                      shown: MAX_BINDINGS_TO_DESCRIBE,
-                      total: totalBindings,
-                      hidden: hiddenBindingCount })}
-                  </div>
-                )}
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {yamlOutput}
-                </pre>
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
+            <RBACOutputPane
+              loading={yamlLoading}
+              output={yamlOutput}
+              copiedField={copiedField}
+              copiedFieldKey="yaml"
+              hiddenBindingCount={hiddenBindingCount}
+              totalBindings={totalBindings}
+              loadingText={t('drilldown.status.fetchingYaml')}
+              onCopy={handleCopy}
+            />
           </div>
         )}
       </div>

--- a/web/src/components/drilldown/views/useConfigMapDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useConfigMapDrillDown.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+const mockUseLocalAgent = vi.fn()
+const mockRunKubectl = vi.fn()
+const mockCopyToClipboard = vi.fn()
+
+vi.mock('../../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => mockUseLocalAgent(),
+}))
+
+vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
+  useDrillDownWebSocket: () => ({ runKubectl: mockRunKubectl }),
+}))
+
+vi.mock('../../../lib/clipboard', () => ({
+  copyToClipboard: (text: string) => mockCopyToClipboard(text),
+}))
+
+// The global react-i18next mock in src/test/setup.ts returns a brand-new `t`
+// function reference on every call, which is fine for components but causes
+// useConfigMapDrillDown's fetchData/fetchDescribe/fetchYaml callbacks (which
+// depend on `t`) to be recreated every render. That, in turn, destabilizes the
+// mount effect's dependency array and can loop indefinitely when the effect's
+// "missing context" branch keeps assigning fresh `{}`/`[]` literals. Override
+// with a referentially-stable `t` here so this test suite doesn't hang.
+const stableT = (key: string) => key
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: stableT }),
+}))
+
+import { useConfigMapDrillDown } from './useConfigMapDrillDown'
+
+describe('useConfigMapDrillDown', () => {
+  beforeEach(() => {
+    mockUseLocalAgent.mockReset()
+    mockRunKubectl.mockReset()
+    mockCopyToClipboard.mockReset()
+  })
+
+  it('resets state to empty when required context is missing', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', false))
+    expect(result.current.configmapData).toEqual({})
+    expect(result.current.labels).toEqual({})
+    expect(result.current.describeOutput).toBeNull()
+    expect(result.current.yamlOutput).toBeNull()
+    expect(mockRunKubectl).not.toHaveBeenCalled()
+  })
+
+  it('does not fetch when agent is disconnected', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+    expect(result.current.configmapData).toBeNull()
+    expect(mockRunKubectl).not.toHaveBeenCalled()
+  })
+
+  it('success path: populates configmap data, labels, describe, and yaml', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const cm = { data: { key1: 'value1' }, metadata: { labels: { app: 'demo' } } }
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[0] === 'get' && args[args.length - 1] === 'json') return Promise.resolve(JSON.stringify(cm))
+      if (args[0] === 'describe') return Promise.resolve('describe output')
+      return Promise.resolve('yaml output')
+    })
+
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+
+    await waitFor(() => expect(result.current.configmapData).toEqual({ key1: 'value1' }))
+    expect(result.current.labels).toEqual({ app: 'demo' })
+    await waitFor(() => expect(result.current.describeOutput).toBe('describe output'))
+    await waitFor(() => expect(result.current.yamlOutput).toBe('yaml output'))
+    expect(result.current.dataLoading).toBe(false)
+  })
+
+  it('JSON parse error: sets empty configmapData and labels', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[0] === 'get' && args[args.length - 1] === 'json') return Promise.resolve('not-json')
+      return Promise.resolve('output')
+    })
+
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+    await waitFor(() => expect(result.current.configmapData).toEqual({}))
+    expect(result.current.labels).toEqual({})
+  })
+
+  it('error path: sets dataError when fetch throws', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[0] === 'get' && args[args.length - 1] === 'json') return Promise.reject(new Error('kubectl blew up'))
+      return Promise.resolve('output')
+    })
+
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+    await waitFor(() => expect(result.current.dataError).toBe('kubectl blew up'))
+    expect(result.current.dataLoading).toBe(false)
+  })
+
+  it('toggleReveal and toggleRevealAll control isRevealed', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+
+    expect(result.current.isRevealed('key1')).toBe(false)
+    act(() => result.current.toggleReveal('key1'))
+    expect(result.current.isRevealed('key1')).toBe(true)
+    act(() => result.current.toggleReveal('key1'))
+    expect(result.current.isRevealed('key1')).toBe(false)
+
+    act(() => result.current.toggleRevealAll())
+    expect(result.current.isRevealed('any-key')).toBe(true)
+  })
+
+  it('handleCopy copies value and sets copiedField', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useConfigMapDrillDown('c1', 'ns1', 'cm1', true))
+
+    act(() => result.current.handleCopy('field1', 'value1'))
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('value1')
+    expect(result.current.copiedField).toBe('field1')
+  })
+})

--- a/web/src/components/drilldown/views/useConfigMapDrillDown.ts
+++ b/web/src/components/drilldown/views/useConfigMapDrillDown.ts
@@ -1,0 +1,177 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { copyToClipboard } from '../../../lib/clipboard'
+import { useTranslation } from 'react-i18next'
+
+export interface UseConfigMapDrillDownResult {
+  agentConnected: boolean
+  configmapData: Record<string, string> | null
+  dataLoading: boolean
+  dataError: string | null
+  labels: Record<string, string> | null
+  describeOutput: string | null
+  describeLoading: boolean
+  yamlOutput: string | null
+  yamlLoading: boolean
+  copiedField: string | null
+  showAllData: boolean
+  revealedKeys: Set<string>
+  revealAll: boolean
+  setShowAllData: (val: boolean) => void
+  toggleRevealAll: () => void
+  toggleReveal: (key: string) => void
+  isRevealed: (key: string) => boolean
+  handleCopy: (field: string, value: string) => void
+}
+
+export function useConfigMapDrillDown(
+  cluster: string,
+  namespace: string,
+  configmapName: string,
+  hasRequiredContext: boolean,
+): UseConfigMapDrillDownResult {
+  const { t } = useTranslation()
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [configmapData, setConfigmapData] = useState<Record<string, string> | null>(null)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [dataLoading, setDataLoading] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [showAllData, setShowAllData] = useState(false)
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
+  const [revealAll, setRevealAll] = useState(false)
+  const hasLoadedRef = useRef(false)
+
+  const fetchData = useCallback(async () => {
+    if (!agentConnected || !hasRequiredContext) return
+    setDataLoading(true)
+    setDataError(null)
+    try {
+      const output = await runKubectl(['get', 'configmap', configmapName, '-n', namespace, '-o', 'json'])
+      if (output) {
+        let cm
+        try {
+          cm = JSON.parse(output)
+        } catch {
+          setConfigmapData({})
+          setLabels({})
+          return
+        }
+        setConfigmapData(cm.data || {})
+        setLabels(cm.metadata?.labels || {})
+      }
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load ConfigMap data'))
+    } finally {
+      setDataLoading(false)
+    }
+  }, [agentConnected, hasRequiredContext, runKubectl, configmapName, namespace, t])
+
+  const fetchDescribe = useCallback(async () => {
+    if (!agentConnected || !hasRequiredContext || describeOutput) return
+    setDescribeLoading(true)
+    try {
+      const output = await runKubectl(['describe', 'configmap', configmapName, '-n', namespace])
+      setDescribeOutput(output)
+    } finally {
+      setDescribeLoading(false)
+    }
+  }, [agentConnected, hasRequiredContext, describeOutput, runKubectl, configmapName, namespace])
+
+  const fetchYaml = useCallback(async () => {
+    if (!agentConnected || !hasRequiredContext || yamlOutput) return
+    setYamlLoading(true)
+    try {
+      const output = await runKubectl(['get', 'configmap', configmapName, '-n', namespace, '-o', 'yaml'])
+      setYamlOutput(output)
+    } finally {
+      setYamlLoading(false)
+    }
+  }, [agentConnected, hasRequiredContext, yamlOutput, runKubectl, configmapName, namespace])
+
+  // Pre-fetch tab data when agent connects. Batched to limit concurrent WebSocket connections.
+  useEffect(() => {
+    if (!hasRequiredContext) {
+      setConfigmapData({})
+      setLabels({})
+      setDescribeOutput(null)
+      setYamlOutput(null)
+      setDescribeLoading(false)
+      setYamlLoading(false)
+      return
+    }
+    if (!agentConnected || hasLoadedRef.current) return
+    hasLoadedRef.current = true
+
+    const loadData = async () => {
+      // Batch 1: Overview data (2 concurrent)
+      await Promise.all([fetchData(), fetchDescribe()])
+      // Batch 2: YAML (lower priority)
+      await fetchYaml()
+    }
+    loadData()
+  }, [agentConnected, fetchData, fetchDescribe, fetchYaml, hasRequiredContext])
+
+  useEffect(() => {
+    return () => {
+      if (copiedFieldTimeoutRef.current) {
+        clearTimeout(copiedFieldTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = (field: string, value: string) => {
+    copyToClipboard(value)
+    setCopiedField(field)
+    if (copiedFieldTimeoutRef.current) {
+      clearTimeout(copiedFieldTimeoutRef.current)
+    }
+    copiedFieldTimeoutRef.current = setTimeout(() => {
+      setCopiedField(null)
+      copiedFieldTimeoutRef.current = null
+    }, UI_FEEDBACK_TIMEOUT_MS)
+  }
+
+  const toggleReveal = (key: string) => {
+    setRevealedKeys(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) next.delete(key)
+      else next.add(key)
+      return next
+    })
+  }
+
+  const toggleRevealAll = () => setRevealAll(v => !v)
+
+  const isRevealed = (key: string) => revealAll || revealedKeys.has(key)
+
+  return {
+    agentConnected,
+    configmapData,
+    dataLoading,
+    dataError,
+    labels,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    showAllData,
+    revealedKeys,
+    revealAll,
+    setShowAllData,
+    toggleRevealAll,
+    toggleReveal,
+    isRevealed,
+    handleCopy,
+  }
+}

--- a/web/src/components/drilldown/views/useRBACDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useRBACDrillDown.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+const mockUseLocalAgent = vi.fn()
+const mockRunKubectl = vi.fn()
+const mockCopyToClipboard = vi.fn()
+
+vi.mock('../../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => mockUseLocalAgent(),
+}))
+
+vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
+  useDrillDownWebSocket: () => ({ runKubectl: mockRunKubectl }),
+}))
+
+vi.mock('../../../lib/clipboard', () => ({
+  copyToClipboard: (text: string) => mockCopyToClipboard(text),
+}))
+
+import { useRBACDrillDown } from './useRBACDrillDown'
+
+describe('useRBACDrillDown', () => {
+  beforeEach(() => {
+    mockUseLocalAgent.mockReset()
+    mockRunKubectl.mockReset()
+    mockCopyToClipboard.mockReset()
+  })
+
+  it('returns loading initial state and does not fetch when agent is disconnected', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useRBACDrillDown('c1', 'ns1', 'sa1', 'ServiceAccount'))
+    expect(result.current.agentConnected).toBe(false)
+    expect(result.current.clusterBindings).toEqual([])
+    expect(result.current.roleBindings).toEqual([])
+    expect(mockRunKubectl).not.toHaveBeenCalled()
+  })
+
+  it('success path: filters bindings matching a ServiceAccount subject', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const crb = {
+      items: [
+        {
+          metadata: { name: 'crb-1' },
+          subjects: [{ kind: 'ServiceAccount', name: 'sa1' }],
+          roleRef: { kind: 'ClusterRole', name: 'admin' },
+        },
+        {
+          metadata: { name: 'crb-2' },
+          subjects: [{ kind: 'ServiceAccount', name: 'other' }],
+          roleRef: { kind: 'ClusterRole', name: 'view' },
+        },
+      ],
+    }
+    const rb = {
+      items: [
+        {
+          metadata: { name: 'rb-1', namespace: 'ns1' },
+          subjects: [{ kind: 'ServiceAccount', name: 'sa1' }],
+          roleRef: { kind: 'Role', name: 'editor' },
+        },
+      ],
+    }
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[1] === 'clusterrolebindings') return Promise.resolve(JSON.stringify(crb))
+      return Promise.resolve(JSON.stringify(rb))
+    })
+
+    const { result } = renderHook(() => useRBACDrillDown('c1', 'ns1', 'sa1', 'ServiceAccount'))
+
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.clusterBindings).toEqual([
+      { kind: 'ClusterRoleBinding', name: 'crb-1', namespace: undefined, roleName: 'admin', roleKind: 'ClusterRole' },
+    ])
+    expect(result.current.roleBindings).toEqual([
+      { kind: 'RoleBinding', name: 'rb-1', namespace: 'ns1', roleName: 'editor', roleKind: 'Role' },
+    ])
+    expect(result.current.totalBindings).toBe(2)
+    expect(result.current.hiddenBindingCount).toBe(0)
+  })
+
+  it('uses --all-namespaces when namespace is undefined', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockResolvedValue(JSON.stringify({ items: [] }))
+
+    renderHook(() => useRBACDrillDown('c1', undefined, 'crole1', 'ClusterRole'))
+    await waitFor(() => expect(mockRunKubectl).toHaveBeenCalledTimes(2))
+
+    const rbCall = mockRunKubectl.mock.calls.find(c => (c[0] as string[])[1] === 'rolebindings')?.[0] as string[]
+    expect(rbCall).toContain('--all-namespaces')
+  })
+
+  it('error path: sets loadError and clears bindings when fetch throws', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockRejectedValue(new Error('kubectl blew up'))
+
+    const { result } = renderHook(() => useRBACDrillDown('c1', 'ns1', 'sa1', 'ServiceAccount'))
+    await waitFor(() => expect(result.current.loadError).toBe('kubectl blew up'))
+    expect(result.current.clusterBindings).toEqual([])
+    expect(result.current.roleBindings).toEqual([])
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('handleRefresh clears describe/yaml output and refetches bindings', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockResolvedValue(JSON.stringify({ items: [] }))
+
+    const { result } = renderHook(() => useRBACDrillDown('c1', 'ns1', 'sa1', 'ServiceAccount'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const callsBefore = mockRunKubectl.mock.calls.length
+    await act(async () => {
+      await result.current.handleRefresh()
+    })
+    expect(result.current.describeOutput).toBeNull()
+    expect(result.current.yamlOutput).toBeNull()
+    expect(result.current.refreshing).toBe(false)
+    expect(mockRunKubectl.mock.calls.length).toBeGreaterThan(callsBefore)
+  })
+
+  it('handleCopy copies value and sets copiedField', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useRBACDrillDown('c1', 'ns1', 'sa1', 'ServiceAccount'))
+
+    act(() => {
+      result.current.handleCopy('field1', 'value1')
+    })
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('value1')
+    expect(result.current.copiedField).toBe('field1')
+  })
+})

--- a/web/src/components/drilldown/views/useRBACDrillDown.ts
+++ b/web/src/components/drilldown/views/useRBACDrillDown.ts
@@ -1,0 +1,238 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { copyToClipboard } from '../../../lib/clipboard'
+import { useTranslation } from 'react-i18next'
+
+/** Maximum number of bindings the Describe and YAML tabs render inline. */
+export const MAX_BINDINGS_TO_DESCRIBE = 10
+
+export interface RoleBinding {
+  kind: string
+  name: string
+  namespace?: string
+  roleName: string
+  roleKind: string
+}
+
+export type DrillDownKind =
+  | 'User'
+  | 'Group'
+  | 'ServiceAccount'
+  | 'Role'
+  | 'RoleBinding'
+  | 'ClusterRole'
+  | 'ClusterRoleBinding'
+
+const SUBJECT_KINDS = new Set<DrillDownKind>(['User', 'Group', 'ServiceAccount'])
+
+export interface UseRBACDrillDownResult {
+  agentConnected: boolean
+  clusterBindings: RoleBinding[]
+  roleBindings: RoleBinding[]
+  loading: boolean
+  loadError: string | null
+  describeOutput: string | null
+  describeLoading: boolean
+  yamlOutput: string | null
+  yamlLoading: boolean
+  copiedField: string | null
+  refreshing: boolean
+  totalBindings: number
+  hiddenBindingCount: number
+  fetchDescribe: () => Promise<void>
+  fetchYaml: () => Promise<void>
+  handleRefresh: () => Promise<void>
+  handleCopy: (field: string, value: string) => void
+}
+
+export function useRBACDrillDown(
+  cluster: string,
+  namespace: string | undefined,
+  subject: string,
+  subjectType: DrillDownKind,
+): UseRBACDrillDownResult {
+  const { t } = useTranslation()
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [clusterBindings, setClusterBindings] = useState<RoleBinding[]>([])
+  const [roleBindings, setRoleBindings] = useState<RoleBinding[]>([])
+  const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState<string | null>(null)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const [refreshing, setRefreshing] = useState(false)
+  const mountedRef = useRef(true)
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+  const hasLoadedRef = useRef(false)
+  const prevAgentConnectedRef = useRef(agentConnected)
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false
+      clearTimeout(copyTimerRef.current)
+    }
+  }, [])
+
+  const parseBindings = useCallback(
+    (json: string, kind: string): RoleBinding[] => {
+      try {
+        const parsed = JSON.parse(json)
+        const items = parsed.items || []
+        return items
+          .filter((item: Record<string, unknown>) => {
+            if (SUBJECT_KINDS.has(subjectType)) {
+              const subjects = item.subjects as Array<{ kind: string; name: string }> | undefined
+              return subjects?.some(s => s.name === subject && s.kind === subjectType)
+            }
+            if (subjectType === 'Role' || subjectType === 'ClusterRole') {
+              const roleRef = item.roleRef as { kind: string; name: string } | undefined
+              return roleRef?.name === subject
+            }
+            if (subjectType === 'RoleBinding' || subjectType === 'ClusterRoleBinding') {
+              const meta = item.metadata as { name: string } | undefined
+              return meta?.name === subject
+            }
+            return false
+          })
+          .map((item: Record<string, unknown>) => {
+            const roleRef = item.roleRef as { kind: string; name: string }
+            const meta = item.metadata as { name: string; namespace?: string }
+            return {
+              kind,
+              name: meta.name,
+              namespace: meta.namespace,
+              roleName: roleRef.name,
+              roleKind: roleRef.kind,
+            }
+          })
+      } catch {
+        return []
+      }
+    },
+    [subject, subjectType],
+  )
+
+  const fetchBindings = useCallback(async () => {
+    if (!agentConnected) return
+    setLoading(true)
+    setLoadError(null)
+    try {
+      const [crbOut, rbOut] = await Promise.all([
+        runKubectl(['get', 'clusterrolebindings', '-o', 'json']),
+        namespace
+          ? runKubectl(['get', 'rolebindings', '-n', namespace, '-o', 'json'])
+          : runKubectl(['get', 'rolebindings', '--all-namespaces', '-o', 'json']),
+      ])
+      if (!mountedRef.current) return
+      setClusterBindings(parseBindings(crbOut, 'ClusterRoleBinding'))
+      setRoleBindings(parseBindings(rbOut, 'RoleBinding'))
+    } catch (err) {
+      if (!mountedRef.current) return
+      const errMsg = err instanceof Error ? err.message : 'Failed to fetch bindings'
+      setLoadError(errMsg)
+      setClusterBindings([])
+      setRoleBindings([])
+    }
+    setLoading(false)
+  }, [agentConnected, namespace, parseBindings, runKubectl])
+
+  const fetchDescribe = useCallback(async () => {
+    if (!agentConnected || describeOutput) return
+    setDescribeLoading(true)
+    const bindings = [...clusterBindings, ...roleBindings]
+    const parts: string[] = []
+    for (const b of bindings.slice(0, MAX_BINDINGS_TO_DESCRIBE)) {
+      if (!mountedRef.current) return
+      const args =
+        b.kind === 'ClusterRoleBinding'
+          ? ['describe', 'clusterrolebinding', b.name]
+          : ['describe', 'rolebinding', b.name, '-n', b.namespace || 'default']
+      const out = await runKubectl(args)
+      if (out) parts.push(out)
+    }
+    if (!mountedRef.current) return
+    setDescribeOutput(parts.join('\n---\n') || t('drilldown.empty.noBindingsFound'))
+    setDescribeLoading(false)
+  }, [agentConnected, clusterBindings, describeOutput, roleBindings, runKubectl, t])
+
+  const fetchYaml = useCallback(async () => {
+    if (!agentConnected || yamlOutput) return
+    setYamlLoading(true)
+    const bindings = [...clusterBindings, ...roleBindings]
+    const parts: string[] = []
+    for (const b of bindings.slice(0, MAX_BINDINGS_TO_DESCRIBE)) {
+      if (!mountedRef.current) return
+      const args =
+        b.kind === 'ClusterRoleBinding'
+          ? ['get', 'clusterrolebinding', b.name, '-o', 'yaml']
+          : ['get', 'rolebinding', b.name, '-n', b.namespace || 'default', '-o', 'yaml']
+      const out = await runKubectl(args)
+      if (out) parts.push(out)
+    }
+    if (!mountedRef.current) return
+    setYamlOutput(parts.join('\n---\n') || t('drilldown.empty.noBindingsFound'))
+    setYamlLoading(false)
+  }, [agentConnected, clusterBindings, roleBindings, runKubectl, yamlOutput, t])
+
+  useEffect(() => {
+    if (agentConnected && !hasLoadedRef.current) {
+      hasLoadedRef.current = true
+      fetchBindings()
+    }
+    // If the agent reconnected after having been disconnected, force a refresh
+    if (agentConnected && !prevAgentConnectedRef.current && hasLoadedRef.current) {
+      setDescribeOutput(null)
+      setYamlOutput(null)
+      fetchBindings()
+    }
+    prevAgentConnectedRef.current = agentConnected
+  }, [agentConnected, fetchBindings])
+
+  const handleRefresh = useCallback(async () => {
+    if (!agentConnected || refreshing) return
+    setRefreshing(true)
+    setDescribeOutput(null)
+    setYamlOutput(null)
+    try {
+      await fetchBindings()
+    } finally {
+      setRefreshing(false)
+    }
+  }, [agentConnected, fetchBindings, refreshing])
+
+  const handleCopy = (field: string, value: string) => {
+    copyToClipboard(value)
+    setCopiedField(field)
+    clearTimeout(copyTimerRef.current)
+    copyTimerRef.current = setTimeout(() => setCopiedField(null), UI_FEEDBACK_TIMEOUT_MS)
+  }
+
+  const totalBindings = clusterBindings.length + roleBindings.length
+  const hiddenBindingCount = Math.max(0, totalBindings - MAX_BINDINGS_TO_DESCRIBE)
+
+  return {
+    agentConnected,
+    clusterBindings,
+    roleBindings,
+    loading,
+    loadError,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    copiedField,
+    refreshing,
+    totalBindings,
+    hiddenBindingCount,
+    fetchDescribe,
+    fetchYaml,
+    handleRefresh,
+    handleCopy,
+  }
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -157,10 +157,24 @@ configuredI18n.init({
 
 export default i18n
 
+// Recursively widen every leaf value of a translation resource object to
+// `string`. This keeps full type-safety for translation *keys* (used by
+// `t()` autocompletion and dot-path validation) while avoiding a TypeScript
+// compiler crash ("Debug Failure: No error for last overload signature")
+// that occurs when huge translation JSON files (our `common.json`/`cards.json`
+// are ~10k lines combined) are used as literal `typeof` types directly in
+// i18next's heavily-overloaded `t()` signature. Without this, the sheer
+// number of distinct string-literal leaf types combined with `t()`'s
+// overload set trips an internal TS assertion during `tsc -b`.
+// See: https://github.com/microsoft/TypeScript/issues/63195
+type FlattenLeafValues<T> = {
+  [K in keyof T]: T[K] extends object ? FlattenLeafValues<T[K]> : string
+}
+
 // Type-safe translation keys
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: typeof defaultNS
-    resources: typeof resources['en']
+    resources: FlattenLeafValues<typeof resources['en']>
   }
 }


### PR DESCRIPTION
Fixes #21873
Fixes #21877
Fixes #21806

## Summary

Splits two oversized drilldown views into X.tsx + X.parts.tsx + useX.ts following established patterns.

| File | Before | After | Hooks before → after |
|------|--------|-------|----------------------|
| `RBACDrillDown.tsx` | 465 lines | 137 lines | 18 → 4 |
| `ConfigMapDrillDown.tsx` | 477 lines | 169 lines | 13 → 6 |

### New files
- `useRBACDrillDown.ts` — all data-fetching state, effects, fetchBindings/Describe/Yaml, handleRefresh, handleCopy
- `RBACDrillDown.parts.tsx` — RBACDrillDownHeader, RBACOverviewTab, RBACOutputPane
- `useConfigMapDrillDown.ts` — all data-fetching state, effects, fetchData/Describe/Yaml, reveal/copy helpers
- `ConfigMapDrillDown.parts.tsx` — ConfigMapDrillDownHeader, ConfigMapOverviewTab, ConfigMapDataTab, ConfigMapOutputPane

No behaviour change — pure refactor.