### PR TITLE
[scanner] refactor: split Workloads, GitOps, SyncDialog components

### DIFF
--- a/web/src/components/gitops/GitOps.parts.tsx
+++ b/web/src/components/gitops/GitOps.parts.tsx
@@ -1,10 +1,10 @@
-/* eslint-disable react-refresh/only-export-components */
 import type { TFunction } from 'i18next'
 import { RefreshCw, GitBranch, FolderGit, Box, Loader2 } from 'lucide-react'
 import { StatusIndicator } from '../charts/StatusIndicator'
 import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
 import { STATUS_TOOLTIPS } from '../shared/TechnicalAcronym'
 import { StatusBadge } from '../ui/StatusBadge'
+import { Select } from '../ui/Select'
 import type { GitOpsApp } from './GitOps.types'
 
 interface GitOpsFiltersProps {
@@ -19,10 +19,11 @@ interface GitOpsFiltersProps {
 export function GitOpsFilters({ clusters, selectedCluster, statusFilter, onClusterChange, onStatusFilterChange, t }: GitOpsFiltersProps) {
   return (
     <div className="flex flex-wrap items-center gap-4 mb-6">
-      <select
+      <Select
         value={selectedCluster}
         onChange={(e) => onClusterChange(e.target.value)}
-        className="px-4 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm"
+        selectSize="lg"
+        className="bg-card/50"
       >
         <option value="">{t('gitops.allClusters')}</option>
         {clusters.map((cluster) => (
@@ -30,7 +31,7 @@ export function GitOpsFilters({ clusters, selectedCluster, statusFilter, onClust
             {cluster.context || cluster.name.split('/').pop()}
           </option>
         ))}
-      </select>
+      </Select>
 
       <div className="flex gap-2">
         {([

--- a/web/src/components/gitops/GitOps.parts.tsx
+++ b/web/src/components/gitops/GitOps.parts.tsx
@@ -206,7 +206,7 @@ export function GitOpsFiltersAndList({ clusters, selectedCluster, statusFilter, 
       />
       <div className="flex items-center gap-2 mb-3">
         <span className="text-sm font-medium text-muted-foreground">{t('gitops.applications')}</span>
-        <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
+        <StatusBadge color="yellow" size="xs">{t('common.demo')}</StatusBadge>
       </div>
       <GitOpsAppsList
         filteredApps={filteredApps}

--- a/web/src/components/gitops/GitOps.parts.tsx
+++ b/web/src/components/gitops/GitOps.parts.tsx
@@ -1,0 +1,246 @@
+/* eslint-disable react-refresh/only-export-components */
+import type { TFunction } from 'i18next'
+import { RefreshCw, GitBranch, FolderGit, Box, Loader2 } from 'lucide-react'
+import { StatusIndicator } from '../charts/StatusIndicator'
+import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
+import { STATUS_TOOLTIPS } from '../shared/TechnicalAcronym'
+import { StatusBadge } from '../ui/StatusBadge'
+import type { GitOpsApp } from './GitOps.types'
+
+interface GitOpsFiltersProps {
+  clusters: Array<{ name: string; context?: string }>
+  selectedCluster: string
+  statusFilter: string
+  onClusterChange: (cluster: string) => void
+  onStatusFilterChange: (filter: string) => void
+  t: TFunction
+}
+
+export function GitOpsFilters({ clusters, selectedCluster, statusFilter, onClusterChange, onStatusFilterChange, t }: GitOpsFiltersProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-4 mb-6">
+      <select
+        value={selectedCluster}
+        onChange={(e) => onClusterChange(e.target.value)}
+        className="px-4 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm"
+      >
+        <option value="">{t('gitops.allClusters')}</option>
+        {clusters.map((cluster) => (
+          <option key={cluster.name} value={cluster.context || cluster.name.split('/').pop()}>
+            {cluster.context || cluster.name.split('/').pop()}
+          </option>
+        ))}
+      </select>
+
+      <div className="flex gap-2">
+        {([
+          { value: 'all', label: t('common.all'), activeClass: 'bg-primary text-primary-foreground' },
+          { value: 'synced', label: t('gitops.synced'), activeClass: 'bg-green-500 text-white' },
+          { value: 'drifted', label: t('gitops.drifted'), activeClass: 'bg-yellow-500 text-white' },
+        ] as const).map(({ value, label, activeClass }) => (
+          <button key={value} onClick={() => onStatusFilterChange(value)}
+            className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
+              statusFilter === value ? activeClass : 'bg-card/50 text-muted-foreground hover:text-foreground'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface GitOpsAppRowProps {
+  app: GitOpsApp
+  syncStatusColor: (status: string) => string
+  syncStatusLabel: (status: string) => string
+  healthStatusIndicator: (status: string) => 'healthy' | 'warning' | 'error'
+  onSync: (app: GitOpsApp) => void
+  t: TFunction
+}
+
+export function GitOpsAppRow({ app, syncStatusColor, syncStatusLabel, healthStatusIndicator, onSync, t }: GitOpsAppRowProps) {
+  return (
+    <div
+      className={`glass p-4 rounded-lg border-l-4 ${
+        app.syncStatus === 'synced' ? 'border-l-green-500' :
+        app.syncStatus === 'checking' ? 'border-l-blue-500' :
+        app.syncStatus === 'out-of-sync' ? 'border-l-yellow-500' : 'border-l-gray-500'
+      }`}
+    >
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-4">
+          <PortalTooltip content={STATUS_TOOLTIPS[healthStatusIndicator(app.healthStatus)]}>
+            <span>
+              <StatusIndicator status={healthStatusIndicator(app.healthStatus)} size="lg" />
+            </span>
+          </PortalTooltip>
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <span className="font-semibold text-foreground">{app.name}</span>
+              <span className={`text-xs px-2 py-0.5 rounded flex items-center gap-1 ${syncStatusColor(app.syncStatus)}`}>
+                {app.syncStatus === 'checking' && <Loader2 className="w-3 h-3 animate-spin" />}
+                {syncStatusLabel(app.syncStatus)}
+              </span>
+            </div>
+            <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1">
+              <span className="flex items-center gap-1" title={t('gitops.kubernetesNamespace')}>
+                <Box className="w-3 h-3" />
+                <span>{app.namespace}</span>
+              </span>
+              {app.cluster && (
+                <span className="flex items-center gap-1" title={t('gitops.targetCluster')}>
+                  <span className="text-muted-foreground/50">→</span>
+                  <span>{app.cluster}</span>
+                </span>
+              )}
+              {!app.cluster && app.clusterAmbiguous && (
+                <span className="flex items-center gap-1 text-yellow-400" title={t('gitops.targetCluster')}>
+                  <span className="text-muted-foreground/50">→</span>
+                  <span>{t('gitops.clusterUnresolved')}</span>
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1" title={t('gitops.gitRepoSource')}>
+              <GitBranch className="w-3 h-3 text-purple-400" />
+              <span className="font-mono">github.com/{app.repoUrl.replace('https://github.com/', '')}</span>
+            </div>
+            <div className="flex items-center gap-1 text-xs text-muted-foreground" title={t('gitops.pathInRepo')}>
+              <FolderGit className="w-3 h-3 text-blue-400" />
+              <span className="font-mono">{app.path}</span>
+            </div>
+          </div>
+        </div>
+        <div className="text-right text-xs text-muted-foreground">
+          <div>{t('gitops.lastSync')}: {app.lastSyncTimeAgo}</div>
+          <div className="mt-1 capitalize">{app.healthStatus}</div>
+        </div>
+      </div>
+
+      {app.driftDetails && app.driftDetails.length > 0 && (
+        <div className="mt-3 p-3 rounded bg-yellow-500/10 border border-yellow-500/20">
+          <div className="text-sm font-medium text-yellow-400 mb-2">{t('gitops.driftDetected')}</div>
+          <ul className="text-xs text-muted-foreground space-y-1">
+            {app.driftDetails.map((detail, j) => (
+              <li key={j} className="flex items-center gap-2">
+                <span className="text-yellow-400">•</span>
+                {detail}
+              </li>
+            ))}
+          </ul>
+          <button
+            onClick={() => onSync(app)}
+            className="mt-2 px-3 py-1 rounded bg-yellow-500/20 text-yellow-400 text-xs hover:bg-yellow-500/30 transition-colors flex items-center gap-1.5"
+          >
+            <RefreshCw className="w-3 h-3" />
+            {t('gitops.syncNow')}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface GitOpsAppsListProps {
+  filteredApps: GitOpsApp[]
+  syncStatusColor: (status: string) => string
+  syncStatusLabel: (status: string) => string
+  healthStatusIndicator: (status: string) => 'healthy' | 'warning' | 'error'
+  onSync: (app: GitOpsApp) => void
+  t: TFunction
+}
+
+export function GitOpsAppsList({ filteredApps, syncStatusColor, syncStatusLabel, healthStatusIndicator, onSync, t }: GitOpsAppsListProps) {
+  if (filteredApps.length === 0) {
+    return (
+      <div className="text-center py-12">
+        <div className="text-6xl mb-4">🔄</div>
+        <div className="text-lg text-foreground">{t('gitops.noApplications')}</div>
+        <div className="text-sm text-muted-foreground">{t('gitops.configureHint')}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 mb-6 border-2 border-yellow-500/30 rounded-lg p-4">
+      {filteredApps.map((app, i) => (
+        <GitOpsAppRow
+          key={i}
+          app={app}
+          syncStatusColor={syncStatusColor}
+          syncStatusLabel={syncStatusLabel}
+          healthStatusIndicator={healthStatusIndicator}
+          onSync={onSync}
+          t={t}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface GitOpsFiltersAndListProps {
+  clusters: Array<{ name: string; context?: string }>
+  selectedCluster: string
+  statusFilter: string
+  filteredApps: GitOpsApp[]
+  syncStatusColor: (status: string) => string
+  syncStatusLabel: (status: string) => string
+  healthStatusIndicator: (status: string) => 'healthy' | 'warning' | 'error'
+  onClusterChange: (cluster: string) => void
+  onStatusFilterChange: (filter: string) => void
+  onSync: (app: GitOpsApp) => void
+  t: TFunction
+}
+
+export function GitOpsFiltersAndList({ clusters, selectedCluster, statusFilter, filteredApps, syncStatusColor, syncStatusLabel, healthStatusIndicator, onClusterChange, onStatusFilterChange, onSync, t }: GitOpsFiltersAndListProps) {
+  return (
+    <>
+      <GitOpsFilters
+        clusters={clusters}
+        selectedCluster={selectedCluster}
+        statusFilter={statusFilter}
+        onClusterChange={onClusterChange}
+        onStatusFilterChange={onStatusFilterChange}
+        t={t}
+      />
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-sm font-medium text-muted-foreground">{t('gitops.applications')}</span>
+        <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
+      </div>
+      <GitOpsAppsList
+        filteredApps={filteredApps}
+        syncStatusColor={syncStatusColor}
+        syncStatusLabel={syncStatusLabel}
+        healthStatusIndicator={healthStatusIndicator}
+        onSync={onSync}
+        t={t}
+      />
+    </>
+  )
+}
+
+interface GitOpsIntegrationInfoProps {
+  t: TFunction
+}
+
+export function GitOpsIntegrationInfo({ t }: GitOpsIntegrationInfoProps) {
+  return (
+    <div className="mt-8 p-4 rounded-lg bg-card/30 border border-border">
+      <h3 className="text-lg font-semibold text-foreground mb-3">{t('gitops.integrationTitle')}</h3>
+      <p className="text-sm text-muted-foreground mb-3">
+        {t('gitops.integrationDescription')}
+      </p>
+      <div className="flex gap-2">
+        {([
+          { key: 'argocd', label: t('gitops.configureArgoCD') },
+          { key: 'flux', label: t('gitops.configureFlux') },
+        ] as const).map(({ key, label }) => (
+          <button key={key} className="px-4 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card transition-colors">
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/gitops/GitOps.tsx
+++ b/web/src/components/gitops/GitOps.tsx
@@ -1,560 +1,46 @@
-import { useMemo, useEffect, useRef, useState } from 'react'
-import { useTranslation } from 'react-i18next'
-import type { TFunction } from 'i18next'
-import { useClusters, useHelmReleases, useOperatorSubscriptions } from '../../hooks/useMCP'
-import { StatusIndicator } from '../charts/StatusIndicator'
-import { useToast } from '../ui/Toast'
-import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { RefreshCw, GitBranch, FolderGit, Box, Loader2 } from 'lucide-react'
-import { SyncDialog } from './SyncDialog'
-import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
-import { getStoredAuthToken } from '../../lib/authToken'
-import { agentFetch } from '../../hooks/mcp/shared'
-import { MS_PER_MINUTE } from '../../lib/constants/time'
-import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
-import { getDemoMode } from '../../hooks/useDemoMode'
-import { StatBlockValue } from '../ui/StatsOverview'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
-import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
-import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
-import { STATUS_TOOLTIPS } from '../shared/TechnicalAcronym'
-import { StatusBadge } from '../ui/StatusBadge'
-
-// GitOps app configuration (repos to monitor)
-interface GitOpsAppConfig {
-  name: string
-  namespace: string
-  cluster: string
-  repoUrl: string
-  path: string
-}
-
-// GitOps app with detected status
-// #6156 — 'error' is a distinct status so failed drift checks render as an
-// error (not a false-positive "synced + healthy").
-interface GitOpsApp extends GitOpsAppConfig {
-  syncStatus: 'synced' | 'out-of-sync' | 'unknown' | 'checking' | 'error'
-  healthStatus: 'healthy' | 'degraded' | 'progressing' | 'missing' | 'unknown'
-  // #6157 — marks apps whose cluster could not be resolved unambiguously
-  clusterAmbiguous?: boolean
-  lastSyncTime?: string
-  driftDetails?: string[]
-}
-
-// Drift detection result from API
-// #6156 — `status` explicitly captures the outcome so the UI never treats an
-// error as "not drifted". 'ok' = detection ran and returned a result; 'error'
-// = detection failed (network error, backend down, parsing error, etc.).
-type DriftStatus = 'ok' | 'error'
-
-interface DriftResult {
-  status: DriftStatus
-  drifted: boolean
-  resources: Array<{
-    kind: string
-    name: string
-    namespace: string
-    field: string
-    gitValue: string
-    clusterValue: string
-  }>
-  error?: string
-}
-
-const GITOPS_STORAGE_KEY = 'kubestellar-gitops-dashboard-cards'
-
-// Default cards for the GitOps dashboard
-const DEFAULT_GITOPS_CARDS = getDefaultCards('gitops')
-
-// Apps to monitor - these could come from a config file or API
-function getGitOpsAppConfigs(): GitOpsAppConfig[] {
-  return [
-    { name: 'gatekeeper', namespace: 'gatekeeper-system', cluster: '', repoUrl: 'https://github.com/open-policy-agent/gatekeeper', path: 'deploy/' },
-    { name: 'kuberay-operator', namespace: 'ray-system', cluster: '', repoUrl: 'https://github.com/ray-project/kuberay', path: 'ray-operator/config/default/' },
-    { name: 'kserve', namespace: 'kserve', cluster: '', repoUrl: 'https://github.com/kserve/kserve', path: 'config/default/' },
-    { name: 'gpu-operator', namespace: 'gpu-operator', cluster: '', repoUrl: 'https://github.com/NVIDIA/gpu-operator', path: 'deployments/gpu-operator/' },
-  ]
-}
-
-function getTimeAgo(timestamp: string | undefined, t: TFunction): string {
-  if (!timestamp) return t('gitops.unknown')
-  const now = new Date()
-  const then = new Date(timestamp)
-  const diffMs = now.getTime() - then.getTime()
-  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
-  const diffHours = Math.floor(diffMins / 60)
-  if (diffHours > 0) return t('gitops.hoursAgo', { count: diffHours })
-  if (diffMins > 0) return t('gitops.minutesAgo', { count: diffMins })
-  return t('gitops.justNow')
-}
+import { SyncDialog } from './SyncDialog'
+import { useGitOps, GITOPS_STORAGE_KEY, DEFAULT_GITOPS_CARDS } from './useGitOps'
+import { GitOpsFiltersAndList, GitOpsIntegrationInfo } from './GitOps.parts'
 
 export function GitOps() {
-  const { t } = useTranslation(['common', 'cards'])
-  const { clusters, deduplicatedClusters, isRefreshing: dataRefreshing, refetch } = useClusters()
-  const { releases: helmReleases } = useHelmReleases()
-  const { subscriptions: operatorSubs } = useOperatorSubscriptions()
-  const { drillToAllHelm, drillToAllOperators } = useDrillDownActions()
-  const { showToast } = useToast()
+  const {
+    t,
+    clusters,
+    filteredApps,
+    stats,
+    dataRefreshing,
+    lastUpdated,
+    selectedCluster,
+    setSelectedCluster,
+    statusFilter,
+    setStatusFilter,
+    syncDialogApp,
+    setSyncDialogApp,
+    syncStatusColor,
+    syncStatusLabel,
+    healthStatusIndicator,
+    getDashboardStatValue,
+    handleRefresh,
+    handleSync,
+    handleSyncComplete,
+  } = useGitOps()
 
-  // Local state
-  const [selectedCluster, setSelectedCluster] = useState<string>('')
-  const [statusFilter, setStatusFilter] = useState<string>('all')
-  const [syncedApps, setSyncedApps] = useState<Set<string>>(new Set())
-  const [syncDialogApp, setSyncDialogApp] = useState<GitOpsApp | null>(null)
-  const [driftResults, setDriftResults] = useState<Map<string, DriftResult>>(new Map())
-  // #6155 — isDetecting starts `false`. The effect below flips it to `true`
-  // only when a real detection pass is about to run (non-demo mode AND
-  // backend healthy). Previously it defaulted to `true` and demo mode never
-  // cleared it, leaving every card stuck in "checking".
-  const [isDetecting, setIsDetecting] = useState(false)
-  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
-
-  // Cache helm releases count to prevent showing 0 during refresh
-  const cachedHelmCount = useRef(0)
-
-  // Set initial lastUpdated on mount
-  useEffect(() => {
-    setLastUpdated(new Date())
-  }, [])
-
-  // Health-check timeout for skipping drift detection when the backend is
-  // unreachable — long enough to survive a slow initial auth round-trip,
-  // short enough that users don't stare at "checking" for seconds (#3609).
-  const DRIFT_HEALTHCHECK_TIMEOUT_MS = 3000
-
-  // #6157 — Cluster resolution. Previously every app with an empty preferred
-  // cluster silently fell back to `clusters[0]`, making multi-cluster
-  // attribution wrong (every app appeared to target the first cluster).
-  //
-  // New semantics:
-  //   - If `preferred` is set, use it verbatim (explicit).
-  //   - If there is exactly one cluster available, use it (unambiguous).
-  //   - Otherwise return `{ cluster: '', ambiguous: true }` so the UI can
-  //     render the entry as "cluster: unknown" instead of silently picking
-  //     one. This preserves the display shape used by the <select> (context
-  //     || name.split('/').pop()).
-  const EXACTLY_ONE_CLUSTER = 1
-  const clusterDisplayName = (c: { context?: string; name: string }): string =>
-    c.context || c.name.split('/').pop() || ''
-  const resolveAppCluster = (preferred: string): { cluster: string; ambiguous: boolean } => {
-    if (preferred) return { cluster: preferred, ambiguous: false }
-    if (deduplicatedClusters.length === EXACTLY_ONE_CLUSTER) {
-      return { cluster: clusterDisplayName(deduplicatedClusters[0]), ambiguous: false }
-    }
-    return { cluster: '', ambiguous: deduplicatedClusters.length > EXACTLY_ONE_CLUSTER }
-  }
-
-  // #5952 — detectAllDrift is now a callable ref so the refresh button can
-  // re-run drift detection instead of only updating lastUpdated.
-  const detectAllDriftRef = useRef<() => Promise<void>>(async () => {})
-
-  const handleRefresh = () => {
-    refetch()
-    // Re-run drift detection so the UI actually reflects fresh state.
-    void detectAllDriftRef.current()
-    setLastUpdated(new Date())
-  }
-
-  // Detect drift for all apps on mount (skip in demo mode - no backend).
-  // Guard: verify backend is reachable first to avoid slow sequential failures
-  // that block the UI and add latency (#3609).
-  useEffect(() => {
-    // #6155 — In demo mode there is no backend; ensure isDetecting is false
-    // so cards do not stay stuck in the "checking" state forever. This uses
-    // the SAME setter the real exit path uses, rather than silently
-    // returning and leaving the previous value in place.
-    if (getDemoMode()) {
-      setIsDetecting(false)
-      return
-    }
-
-    let cancelled = false
-
-    async function detectAllDrift() {
-      // Quick health check — skip drift detection entirely if backend is down
-      try {
-        const health = await fetch('/api/health', { signal: AbortSignal.timeout(DRIFT_HEALTHCHECK_TIMEOUT_MS) })
-        if (!health.ok) {
-          setIsDetecting(false)
-          return
-        }
-      } catch {
-        setIsDetecting(false)
-        return
-      }
-
-      if (cancelled) return
-
-      setIsDetecting(true)
-      const results = new Map<string, DriftResult>()
-      const configs = getGitOpsAppConfigs().map(c => {
-        const resolved = resolveAppCluster(c.cluster)
-        return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
-      })
-
-      // Run drift checks in parallel with individual timeouts instead of
-      // sequential requests, reducing total latency significantly.
-      // #7993 Phase 4: drift detection moved to kc-agent — calls go to the
-      // local agent process running under the user's kubeconfig.
-      const token = await getStoredAuthToken()
-      const agentAuthHeaders: Record<string, string> = {
-        'Content-Type': 'application/json',
-        'X-Requested-With': 'XMLHttpRequest',
-      }
-      if (token) agentAuthHeaders['Authorization'] = `Bearer ${token}`
-      const promises = configs.map(async (appConfig) => {
-        try {
-          const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
-            method: 'POST',
-            headers: agentAuthHeaders,
-            body: JSON.stringify({
-              repoUrl: appConfig.repoUrl,
-              path: appConfig.path,
-              namespace: appConfig.namespace,
-              cluster: appConfig.cluster || undefined,
-            }),
-            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
-          })
-          if (!res.ok) {
-            const errBody = await res.json().catch(() => ({}))
-            throw new Error(errBody.error || `detect-drift failed (HTTP ${res.status})`)
-          }
-          const data = (await res.json()) as {
-            drifted: boolean
-            resources: DriftResult['resources']
-            rawDiff?: string
-          }
-          return {
-            name: appConfig.name,
-            result: {
-              status: 'ok' as const,
-              drifted: data.drifted,
-              resources: data.resources || [] } satisfies DriftResult }
-        } catch (e: unknown) {
-          // #6156 — Failed drift checks MUST NOT be coerced to
-          // `drifted: false` — that rendered as "synced + healthy" (false
-          // green). Return status: 'error' so the UI can render a distinct
-          // error state.
-          const message = e instanceof Error ? e.message : 'Failed to detect drift'
-          return {
-            name: appConfig.name,
-            result: {
-              status: 'error' as const,
-              drifted: false,
-              resources: [],
-              error: message } satisfies DriftResult }
-        }
-      })
-
-      const settled = await Promise.all(promises)
-      if (cancelled) return
-
-      for (const { name, result } of settled) {
-        results.set(name, result)
-      }
-
-      setDriftResults(results)
-      setIsDetecting(false)
-    }
-
-    detectAllDriftRef.current = detectAllDrift
-    detectAllDrift()
-    return () => { cancelled = true }
-    // resolveAppCluster depends on `deduplicatedClusters`, which is the effective dep here.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deduplicatedClusters])
-
-  // Handle sync action - open the sync dialog
-  const handleSync = (app: GitOpsApp) => {
-    setSyncDialogApp(app)
-  }
-
-  // Handle sync complete - mark app as synced and refresh drift status
-  const handleSyncComplete = () => {
-    if (syncDialogApp) {
-      // React 18+ automatically batches these state updates
-      setSyncedApps(prev => new Set(prev).add(syncDialogApp.name))
-      setDriftResults(prev => {
-        const updated = new Map(prev)
-        updated.set(syncDialogApp.name, { status: 'ok', drifted: false, resources: [] })
-        return updated
-      })
-      // #6158 — record the real time the sync completed; this is the ONLY
-      // place a lastSyncTime should be captured.
-      setSyncedAt(prev => {
-        const updated = new Map(prev)
-        updated.set(syncDialogApp.name, new Date().toISOString())
-        return updated
-      })
-      showToast(`${syncDialogApp.name} synced successfully!`, 'success')
-    }
-  }
-
-  // Track when the user manually triggered a sync from this session, so the
-  // "last sync" timestamp is a real event (a sync that actually happened via
-  // this UI) rather than a timestamp fabricated on every render. #6158
-  const [syncedAt, setSyncedAt] = useState<Map<string, string>>(new Map())
-
-  // Build apps list with real drift status
-  const apps = useMemo(() => {
-    // #5953 — Fill in a real cluster so the cluster filter below actually
-    // matches. Without this, `app.cluster` was always "" and every app was
-    // filtered out the moment a user selected a cluster.
-    // #6157 — resolveAppCluster now returns { cluster, ambiguous }.
-    const configs = getGitOpsAppConfigs().map(c => {
-      const resolved = resolveAppCluster(c.cluster)
-      return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
-    })
-    return configs.map((config): GitOpsApp => {
-      // #6158 — lastSyncTime is ONLY set when the user actually synced via
-      // SyncDialog in this session. We never fabricate a timestamp on
-      // render. When unknown, the UI displays t('gitops.unknown').
-      const realSyncTime = syncedAt.get(config.name)
-      if (syncedApps.has(config.name)) {
-        return { ...config, syncStatus: 'synced', healthStatus: 'healthy', lastSyncTime: realSyncTime, driftDetails: undefined }
-      }
-      if (isDetecting) {
-        return { ...config, syncStatus: 'checking', healthStatus: 'progressing', lastSyncTime: undefined, driftDetails: undefined }
-      }
-      const drift = driftResults.get(config.name)
-      if (drift) {
-        // #6156 — Render failed drift checks as a distinct error state.
-        if (drift.status === 'error') {
-          return {
-            ...config,
-            syncStatus: 'error',
-            healthStatus: 'unknown',
-            lastSyncTime: undefined,
-            driftDetails: drift.error ? [drift.error] : ['Failed to detect drift'] }
-        }
-        const driftDetails = drift.resources.length > 0
-          ? drift.resources.map(r => `${r.kind}/${r.name}: ${r.field || 'modified'}`)
-          : undefined
-        return {
-          ...config,
-          syncStatus: drift.drifted ? 'out-of-sync' : 'synced',
-          healthStatus: drift.drifted ? 'progressing' : 'healthy',
-          // #6158 — do not fabricate a client-side timestamp here.
-          lastSyncTime: realSyncTime,
-          driftDetails }
-      }
-      return { ...config, syncStatus: 'unknown', healthStatus: 'missing', lastSyncTime: undefined, driftDetails: undefined }
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [driftResults, isDetecting, syncedApps, syncedAt, clusters])
-
-  // #6158 — no longer regenerates lastSyncTime here. The synced overlay only
-  // normalizes status fields; timestamps flow through from `apps`, which
-  // reads the real sync time from the `syncedAt` map.
-  const filteredApps = apps
-      .map(app => syncedApps.has(app.name)
-        ? { ...app, syncStatus: 'synced' as const, healthStatus: 'healthy' as const, driftDetails: undefined }
-        : app)
-      .filter(app => {
-        if (selectedCluster && app.cluster !== selectedCluster) return false
-        if (statusFilter === 'synced' && app.syncStatus !== 'synced') return false
-        if (statusFilter === 'drifted' && app.syncStatus !== 'out-of-sync') return false
-        return true
-      })
-
-  const stats = {
-    total: apps.length,
-    synced: apps.filter(a => a.syncStatus === 'synced').length,
-    drifted: apps.filter(a => a.syncStatus === 'out-of-sync').length,
-    healthy: apps.filter(a => a.healthStatus === 'healthy').length,
-    checking: apps.filter(a => a.syncStatus === 'checking').length }
-
-  useEffect(() => {
-    if (helmReleases.length > 0) cachedHelmCount.current = helmReleases.length
-  }, [helmReleases.length])
-  const helmCount = helmReleases.length > 0 ? helmReleases.length : cachedHelmCount.current
-
-  const syncStatusColor = (status: string) => {
-    switch (status) {
-      case 'synced': return 'text-green-400 bg-green-500/20'
-      case 'out-of-sync': return 'text-yellow-400 bg-yellow-500/20'
-      case 'checking': return 'text-blue-400 bg-blue-500/20'
-      // #6156 — distinct visual for error (red), not green.
-      case 'error': return 'text-red-400 bg-red-500/20'
-      default: return 'text-muted-foreground bg-card'
-    }
-  }
-
-  const syncStatusLabel = (status: string) => {
-    switch (status) {
-      case 'synced': return t('gitops.synced')
-      case 'out-of-sync': return t('gitops.outOfSync')
-      case 'checking': return t('gitops.checking')
-      // #6156 — distinct label for the error state (not "unknown").
-      case 'error': return t('gitops.driftCheckFailed')
-      default: return t('gitops.unknown')
-    }
-  }
-
-  const healthStatusIndicator = (status: string): 'healthy' | 'warning' | 'error' => {
-    switch (status) {
-      case 'healthy': return 'healthy'
-      case 'progressing': return 'warning'
-      // #6156 — drift-check errors render as warning (not healthy/error
-      // green), so the user knows the state is unknown, not confirmed good.
-      case 'unknown': return 'warning'
-      default: return 'error'
-    }
-  }
-
-  // Stats value getter
-  const getDashboardStatValue = (blockId: string): StatBlockValue => {
-    switch (blockId) {
-      case 'total': return { value: stats.total, sublabel: t('gitops.appsConfigured'), onClick: () => drillToAllHelm(), isClickable: stats.total > 0 }
-      case 'helm': return { value: helmCount, sublabel: t('gitops.helmReleases'), onClick: () => drillToAllHelm(), isClickable: helmCount > 0 }
-      case 'kustomize': return { value: 0, sublabel: t('gitops.kustomizeApps'), isClickable: false }
-      case 'operators': return { value: operatorSubs.length, sublabel: t('gitops.operators'), onClick: () => drillToAllOperators(), isClickable: operatorSubs.length > 0 }
-      case 'deployed': return { value: stats.synced, sublabel: t('gitops.synced'), onClick: () => drillToAllHelm('synced'), isClickable: stats.synced > 0 }
-      case 'failed': return { value: stats.drifted, sublabel: t('gitops.drifted'), onClick: () => drillToAllHelm('drifted'), isClickable: stats.drifted > 0 }
-      case 'pending': return { value: stats.checking, sublabel: t('gitops.checking'), isClickable: false }
-      case 'other': return { value: stats.healthy, sublabel: t('gitops.healthy'), onClick: () => drillToAllHelm('healthy'), isClickable: stats.healthy > 0 }
-      default: return { value: 0 }
-    }
-  }
-
-  const getStatValue = getDashboardStatValue
-
-  // Filters and Apps List - rendered before cards
   const filtersAndAppsList = (
-    <>
-      {/* Filters */}
-      <div className="flex flex-wrap items-center gap-4 mb-6">
-        <select
-          value={selectedCluster}
-          onChange={(e) => setSelectedCluster(e.target.value)}
-          className="px-4 py-2 rounded-lg bg-card/50 border border-border text-foreground text-sm"
-        >
-          <option value="">{t('gitops.allClusters')}</option>
-          {clusters.map((cluster) => (
-            <option key={cluster.name} value={cluster.context || cluster.name.split('/').pop()}>
-              {cluster.context || cluster.name.split('/').pop()}
-            </option>
-          ))}
-        </select>
-
-        <div className="flex gap-2">
-          {([
-            { value: 'all', label: t('common.all'), activeClass: 'bg-primary text-primary-foreground' },
-            { value: 'synced', label: t('gitops.synced'), activeClass: 'bg-green-500 text-white' },
-            { value: 'drifted', label: t('gitops.drifted'), activeClass: 'bg-yellow-500 text-white' },
-          ] as const).map(({ value, label, activeClass }) => (
-            <button key={value} onClick={() => setStatusFilter(value)}
-              className={`px-4 py-2 rounded-lg text-sm font-medium transition-colors ${
-                statusFilter === value ? activeClass : 'bg-card/50 text-muted-foreground hover:text-foreground'
-              }`}
-            >
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Apps List */}
-      <div className="flex items-center gap-2 mb-3">
-        <span className="text-sm font-medium text-muted-foreground">{t('gitops.applications')}</span>
-        <StatusBadge color="yellow" size="xs">{t('common:common.demo')}</StatusBadge>
-      </div>
-      {filteredApps.length === 0 ? (
-        <div className="text-center py-12">
-          <div className="text-6xl mb-4">🔄</div>
-          <div className="text-lg text-foreground">{t('gitops.noApplications')}</div>
-          <div className="text-sm text-muted-foreground">{t('gitops.configureHint')}</div>
-        </div>
-      ) : (
-        <div className="space-y-4 mb-6 border-2 border-yellow-500/30 rounded-lg p-4">
-          {filteredApps.map((app, i) => (
-            <div
-              key={i}
-              className={`glass p-4 rounded-lg border-l-4 ${
-                app.syncStatus === 'synced' ? 'border-l-green-500' :
-                app.syncStatus === 'checking' ? 'border-l-blue-500' :
-                app.syncStatus === 'out-of-sync' ? 'border-l-yellow-500' : 'border-l-gray-500'
-              }`}
-            >
-              <div className="flex items-start justify-between">
-                <div className="flex items-start gap-4">
-                  <PortalTooltip content={STATUS_TOOLTIPS[healthStatusIndicator(app.healthStatus)]}>
-                    <span>
-                      <StatusIndicator status={healthStatusIndicator(app.healthStatus)} size="lg" />
-                    </span>
-                  </PortalTooltip>
-                  <div>
-                    <div className="flex items-center gap-2 mb-1">
-                      <span className="font-semibold text-foreground">{app.name}</span>
-                      <span className={`text-xs px-2 py-0.5 rounded flex items-center gap-1 ${syncStatusColor(app.syncStatus)}`}>
-                        {app.syncStatus === 'checking' && <Loader2 className="w-3 h-3 animate-spin" />}
-                        {syncStatusLabel(app.syncStatus)}
-                      </span>
-                    </div>
-                    <div className="flex items-center gap-3 text-xs text-muted-foreground mt-1">
-                      <span className="flex items-center gap-1" title={t('gitops.kubernetesNamespace')}>
-                        <Box className="w-3 h-3" />
-                        <span>{app.namespace}</span>
-                      </span>
-                      {app.cluster && (
-                        <span className="flex items-center gap-1" title={t('gitops.targetCluster')}>
-                          <span className="text-muted-foreground/50">→</span>
-                          <span>{app.cluster}</span>
-                        </span>
-                      )}
-                      {/* #6157 — multiple clusters exist and no explicit
-                          target was configured; show "cluster: unknown"
-                          instead of silently attributing to clusters[0]. */}
-                      {!app.cluster && app.clusterAmbiguous && (
-                        <span className="flex items-center gap-1 text-yellow-400" title={t('gitops.targetCluster')}>
-                          <span className="text-muted-foreground/50">→</span>
-                          <span>{t('gitops.clusterUnresolved')}</span>
-                        </span>
-                      )}
-                    </div>
-                    <div className="flex items-center gap-1 text-xs text-muted-foreground mt-1" title={t('gitops.gitRepoSource')}>
-                      <GitBranch className="w-3 h-3 text-purple-400" />
-                      <span className="font-mono">github.com/{app.repoUrl.replace('https://github.com/', '')}</span>
-                    </div>
-                    <div className="flex items-center gap-1 text-xs text-muted-foreground" title={t('gitops.pathInRepo')}>
-                      <FolderGit className="w-3 h-3 text-blue-400" />
-                      <span className="font-mono">{app.path}</span>
-                    </div>
-                  </div>
-                </div>
-                <div className="text-right text-xs text-muted-foreground">
-                  <div>{t('gitops.lastSync')}: {getTimeAgo(app.lastSyncTime, t)}</div>
-                  <div className="mt-1 capitalize">{app.healthStatus}</div>
-                </div>
-              </div>
-
-              {/* Drift Details */}
-              {app.driftDetails && app.driftDetails.length > 0 && (
-                <div className="mt-3 p-3 rounded bg-yellow-500/10 border border-yellow-500/20">
-                  <div className="text-sm font-medium text-yellow-400 mb-2">{t('gitops.driftDetected')}</div>
-                  <ul className="text-xs text-muted-foreground space-y-1">
-                    {app.driftDetails.map((detail, j) => (
-                      <li key={j} className="flex items-center gap-2">
-                        <span className="text-yellow-400">•</span>
-                        {detail}
-                      </li>
-                    ))}
-                  </ul>
-                  <button
-                    onClick={() => handleSync(app)}
-                    className="mt-2 px-3 py-1 rounded bg-yellow-500/20 text-yellow-400 text-xs hover:bg-yellow-500/30 transition-colors flex items-center gap-1.5"
-                  >
-                    <RefreshCw className="w-3 h-3" />
-                    {t('gitops.syncNow')}
-                  </button>
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </>
+    <GitOpsFiltersAndList
+      clusters={clusters}
+      selectedCluster={selectedCluster}
+      statusFilter={statusFilter}
+      filteredApps={filteredApps}
+      syncStatusColor={syncStatusColor}
+      syncStatusLabel={syncStatusLabel}
+      healthStatusIndicator={healthStatusIndicator}
+      onClusterChange={setSelectedCluster}
+      onStatusFilterChange={setStatusFilter}
+      onSync={handleSync}
+      t={t}
+    />
   )
 
   return (
@@ -567,7 +53,7 @@ export function GitOps() {
         storageKey={GITOPS_STORAGE_KEY}
         defaultCards={DEFAULT_GITOPS_CARDS}
         statsType="gitops"
-        getStatValue={getStatValue}
+        getStatValue={getDashboardStatValue}
         onRefresh={handleRefresh}
         isLoading={false}
         isRefreshing={dataRefreshing}
@@ -579,26 +65,9 @@ export function GitOps() {
           description: t('gitops.dashboardDescription') }}
         isDemoData={true}
       >
-        {/* Info */}
-        <div className="mt-8 p-4 rounded-lg bg-card/30 border border-border">
-          <h3 className="text-lg font-semibold text-foreground mb-3">{t('gitops.integrationTitle')}</h3>
-          <p className="text-sm text-muted-foreground mb-3">
-            {t('gitops.integrationDescription')}
-          </p>
-          <div className="flex gap-2">
-            {([
-              { key: 'argocd', label: t('gitops.configureArgoCD') },
-              { key: 'flux', label: t('gitops.configureFlux') },
-            ] as const).map(({ key, label }) => (
-              <button key={key} className="px-4 py-2 rounded-lg bg-card/50 border border-border text-sm text-foreground hover:bg-card transition-colors">
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
+        <GitOpsIntegrationInfo t={t} />
       </DashboardPage>
 
-      {/* Sync Dialog */}
       {syncDialogApp && (
         <SyncDialog
           isOpen={!!syncDialogApp}

--- a/web/src/components/gitops/GitOps.types.ts
+++ b/web/src/components/gitops/GitOps.types.ts
@@ -1,0 +1,32 @@
+export interface GitOpsAppConfig {
+  name: string
+  namespace: string
+  cluster: string
+  repoUrl: string
+  path: string
+}
+
+export interface GitOpsApp extends GitOpsAppConfig {
+  syncStatus: 'synced' | 'out-of-sync' | 'unknown' | 'checking' | 'error'
+  healthStatus: 'healthy' | 'degraded' | 'progressing' | 'missing' | 'unknown'
+  clusterAmbiguous?: boolean
+  lastSyncTime?: string
+  lastSyncTimeAgo?: string
+  driftDetails?: string[]
+}
+
+export type DriftStatus = 'ok' | 'error'
+
+export interface DriftResult {
+  status: DriftStatus
+  drifted: boolean
+  resources: Array<{
+    kind: string
+    name: string
+    namespace: string
+    field: string
+    gitValue: string
+    clusterValue: string
+  }>
+  error?: string
+}

--- a/web/src/components/gitops/SyncDialog.parts.tsx
+++ b/web/src/components/gitops/SyncDialog.parts.tsx
@@ -1,0 +1,231 @@
+/* eslint-disable react-refresh/only-export-components */
+import { Check, AlertTriangle, Loader2, ChevronRight, Box, Server, Shield, Settings, Database, Network, Layers, Container, FileText, Puzzle, X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { TechnicalAcronym } from '../shared/TechnicalAcronym'
+
+export type SyncPhase = 'detection' | 'plan' | 'execution' | 'complete'
+
+export interface DriftedResource {
+  kind: string
+  name: string
+  namespace: string
+  field: string
+  gitValue: string
+  clusterValue: string
+}
+
+export interface SyncPlan {
+  action: 'create' | 'update' | 'delete'
+  resource: string
+  details: string
+}
+
+export interface SyncLogEntry {
+  timestamp: string
+  message: string
+  status: 'pending' | 'running' | 'success' | 'error'
+}
+
+export function getResourceIcon(kind: string) {
+  const k = kind?.toLowerCase() || ''
+  if (k.includes('deployment')) return <Box className="w-4 h-4 text-blue-400" />
+  if (k.includes('service')) return <Network className="w-4 h-4 text-green-400" />
+  if (k.includes('pod')) return <Container className="w-4 h-4 text-cyan-400" />
+  if (k.includes('configmap')) return <Settings className="w-4 h-4 text-purple-400" />
+  if (k.includes('secret')) return <Shield className="w-4 h-4 text-red-400" />
+  if (k.includes('serviceaccount')) return <Server className="w-4 h-4 text-orange-400" />
+  if (k.includes('role') || k.includes('clusterrole')) return <Shield className="w-4 h-4 text-yellow-400" />
+  if (k.includes('customresourcedefinition') || k.includes('crd')) return <Puzzle className="w-4 h-4 text-purple-400" />
+  if (k.includes('namespace')) return <Layers className="w-4 h-4 text-blue-400" />
+  if (k.includes('persistentvolume') || k.includes('pvc')) return <Database className="w-4 h-4 text-cyan-400" />
+  if (k.includes('ingress')) return <Network className="w-4 h-4 text-green-400" />
+  if (k.includes('statefulset') || k.includes('daemonset') || k.includes('replicaset')) return <Layers className="w-4 h-4 text-blue-400" />
+  if (k.includes('job') || k.includes('cronjob')) return <Settings className="w-4 h-4 text-yellow-400" />
+  if (k.includes('webhook')) return <Network className="w-4 h-4 text-purple-400" />
+  return <FileText className="w-4 h-4 text-yellow-500" />
+}
+
+export function formatResourceKind(kind: string): string {
+  if (!kind) return 'Resource'
+  if (kind.toLowerCase() === 'customresourcedefinition') return 'CRD'
+  if (kind.toLowerCase() === 'serviceaccount') return 'ServiceAccount'
+  if (kind.toLowerCase() === 'clusterrole') return 'ClusterRole'
+  if (kind.toLowerCase() === 'clusterrolebinding') return 'ClusterRoleBinding'
+  return kind
+}
+
+export function FormattedResourceKind({ kind }: { kind: string }) {
+  const formatted = formatResourceKind(kind)
+  if (formatted === 'CRD') {
+    return <TechnicalAcronym term="CRD">CRD</TechnicalAcronym>
+  }
+  return <>{formatted}</>
+}
+
+export const PHASE_PROGRESS: Record<SyncPhase, number> = {
+  detection: 1,
+  plan: 2,
+  execution: 3,
+  complete: 4,
+}
+
+interface SyncPhaseIndicatorProps {
+  phase: SyncPhase
+}
+
+export function SyncPhaseIndicator({ phase }: SyncPhaseIndicatorProps) {
+  return (
+    <div className="px-6 py-3 bg-muted/30 border-b border-border">
+      <div className="flex items-center justify-between text-sm">
+        {(['Detection', 'Plan', 'Execute', 'Complete'] as const).map((label, i) => {
+          const stepNum = i + 1
+          const isActive = PHASE_PROGRESS[phase] === stepNum
+          const isComplete = PHASE_PROGRESS[phase] > stepNum
+
+          return (
+            <div key={label} className="flex items-center gap-2">
+              <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium
+                ${isComplete ? 'bg-green-500 text-foreground' :
+                  isActive ? 'bg-primary text-primary-foreground' :
+                  'bg-muted text-muted-foreground'}`}
+              >
+                {isComplete ? <Check className="w-3 h-3" /> : stepNum}
+              </div>
+              <span className={isActive ? 'text-foreground font-medium' : 'text-muted-foreground'}>
+                {label}
+              </span>
+              {i < 3 && <ChevronRight className="w-4 h-4 text-muted-foreground mx-2" />}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+interface DetectionPhaseContentProps {
+  isInitializing: boolean
+  syncLogsLength: number
+}
+
+export function DetectionPhaseContent({ isInitializing, syncLogsLength }: DetectionPhaseContentProps) {
+  const { t } = useTranslation()
+  if (isInitializing && syncLogsLength === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-8 space-y-3">
+        <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
+        <p className="text-sm text-muted-foreground">Initializing drift detection...</p>
+      </div>
+    )
+  }
+  if (syncLogsLength > 0) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="w-4 h-4 animate-spin" />
+          <span>{t('gitops.detectingDrift')}</span>
+        </div>
+      </div>
+    )
+  }
+  return null
+}
+
+interface PlanPhaseContentProps {
+  driftedResources: DriftedResource[]
+  syncPlan: SyncPlan[]
+}
+
+export function PlanPhaseContent({ driftedResources, syncPlan }: PlanPhaseContentProps) {
+  return (
+    <div className="space-y-4">
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
+          <AlertTriangle className="w-4 h-4 text-yellow-500" />
+          Drift Detected ({driftedResources.length} resources)
+        </h3>
+        <div className="space-y-2 max-h-[250px] overflow-y-auto">
+          {driftedResources.map((r, i) => (
+            <div key={i} className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
+              <div className="flex items-center gap-2 text-sm">
+                {getResourceIcon(r.kind)}
+                <span className="px-1.5 py-0.5 rounded text-xs font-medium bg-card text-muted-foreground">
+                  <FormattedResourceKind kind={r.kind} />
+                </span>
+                <span className="font-medium text-foreground truncate">{r.name}</span>
+              </div>
+              {(r.field || r.clusterValue || r.gitValue) && (
+                <div className="mt-2 text-xs font-mono pl-6">
+                  {r.field && <span className="text-muted-foreground">{r.field}: </span>}
+                  {r.clusterValue && <span className="text-red-400 line-through">{r.clusterValue}</span>}
+                  {r.clusterValue && r.gitValue && <span className="text-muted-foreground"> → </span>}
+                  {r.gitValue && <span className="text-green-400">{r.gitValue}</span>}
+                </div>
+              )}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <h3 className="text-sm font-medium text-foreground mb-3">Sync Plan ({syncPlan.length} changes)</h3>
+        <div className="space-y-1 max-h-[120px] overflow-y-auto">
+          {syncPlan.map((item, i) => {
+            const [kind, name] = item.resource.includes('/') ? item.resource.split('/') : ['Resource', item.resource]
+            return (
+              <div key={i} className="flex items-center gap-2 text-sm py-1">
+                <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${
+                  item.action === 'create' ? 'bg-green-500/20 text-green-400' :
+                  item.action === 'delete' ? 'bg-red-500/20 text-red-400' :
+                  'bg-blue-500/20 text-blue-400'
+                }`}>
+                  {item.action.toUpperCase()}
+                </span>
+                {getResourceIcon(kind)}
+                <span className="text-muted-foreground text-xs"><FormattedResourceKind kind={kind} /></span>
+                <span className="text-foreground truncate">{name}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ExecutionPhaseContentProps {
+  syncLogs: SyncLogEntry[]
+  tokenCount: number
+  logContainerRef: React.RefObject<HTMLDivElement | null>
+}
+
+export function ExecutionPhaseContent({ syncLogs, tokenCount, logContainerRef }: ExecutionPhaseContentProps) {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-muted-foreground">Console Output</span>
+        <span className="text-xs px-2 py-1 rounded bg-muted text-muted-foreground">
+          Tokens: {tokenCount.toLocaleString()}
+        </span>
+      </div>
+      <div
+        ref={logContainerRef}
+        className="h-48 p-3 rounded-lg bg-black/50 border border-border font-mono text-xs overflow-y-auto"
+      >
+        {syncLogs.map((log, i) => (
+          <div key={i} className="flex items-start gap-2 py-0.5">
+            <span className="text-muted-foreground shrink-0">{log.timestamp}</span>
+            {log.status === 'running' && <Loader2 className="w-3 h-3 animate-spin text-blue-400 mt-0.5" />}
+            {log.status === 'success' && <Check className="w-3 h-3 text-green-400 mt-0.5" />}
+            {log.status === 'error' && <X className="w-3 h-3 text-red-400 mt-0.5" />}
+            <span className={
+              log.status === 'success' ? 'text-green-400' :
+              log.status === 'error' ? 'text-red-400' :
+              'text-foreground'
+            }>{log.message}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/gitops/SyncDialog.tsx
+++ b/web/src/components/gitops/SyncDialog.tsx
@@ -1,75 +1,12 @@
-import { useState, useEffect, useRef, startTransition } from 'react'
-import { useTranslation } from 'react-i18next'
-import { Check, AlertTriangle, Play, Loader2, ChevronRight, GitBranch, Box, Server, Shield, Settings, Database, Network, Layers, Container, FileText, Puzzle, X } from 'lucide-react'
+import { Check, Play, GitBranch } from 'lucide-react'
 import { BaseModal } from '../../lib/modals'
-import { TechnicalAcronym } from '../shared/TechnicalAcronym'
-import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
-import { getStoredAuthToken } from '../../lib/authToken'
-import { agentFetch } from '../../hooks/mcp/shared'
-
-// Sync phases
-type SyncPhase = 'detection' | 'plan' | 'execution' | 'complete'
-
-// Get icon for Kubernetes resource kind
-function getResourceIcon(kind: string) {
-  const k = kind?.toLowerCase() || ''
-  if (k.includes('deployment')) return <Box className="w-4 h-4 text-blue-400" />
-  if (k.includes('service')) return <Network className="w-4 h-4 text-green-400" />
-  if (k.includes('pod')) return <Container className="w-4 h-4 text-cyan-400" />
-  if (k.includes('configmap')) return <Settings className="w-4 h-4 text-purple-400" />
-  if (k.includes('secret')) return <Shield className="w-4 h-4 text-red-400" />
-  if (k.includes('serviceaccount')) return <Server className="w-4 h-4 text-orange-400" />
-  if (k.includes('role') || k.includes('clusterrole')) return <Shield className="w-4 h-4 text-yellow-400" />
-  if (k.includes('customresourcedefinition') || k.includes('crd')) return <Puzzle className="w-4 h-4 text-purple-400" />
-  if (k.includes('namespace')) return <Layers className="w-4 h-4 text-blue-400" />
-  if (k.includes('persistentvolume') || k.includes('pvc')) return <Database className="w-4 h-4 text-cyan-400" />
-  if (k.includes('ingress')) return <Network className="w-4 h-4 text-green-400" />
-  if (k.includes('statefulset') || k.includes('daemonset') || k.includes('replicaset')) return <Layers className="w-4 h-4 text-blue-400" />
-  if (k.includes('job') || k.includes('cronjob')) return <Settings className="w-4 h-4 text-yellow-400" />
-  if (k.includes('webhook')) return <Network className="w-4 h-4 text-purple-400" />
-  return <FileText className="w-4 h-4 text-yellow-500" />
-}
-
-// Format resource kind for display
-function formatResourceKind(kind: string): string {
-  if (!kind) return 'Resource'
-  // Common abbreviations - these will be wrapped with tooltips where they're rendered
-  if (kind.toLowerCase() === 'customresourcedefinition') return 'CRD'
-  if (kind.toLowerCase() === 'serviceaccount') return 'ServiceAccount'
-  if (kind.toLowerCase() === 'clusterrole') return 'ClusterRole'
-  if (kind.toLowerCase() === 'clusterrolebinding') return 'ClusterRoleBinding'
-  return kind
-}
-
-// Wrapper to format resource kind with tooltip if it's an acronym
-function FormattedResourceKind({ kind }: { kind: string }) {
-  const formatted = formatResourceKind(kind)
-  if (formatted === 'CRD') {
-    return <TechnicalAcronym term="CRD">CRD</TechnicalAcronym>
-  }
-  return <>{formatted}</>
-}
-
-interface DriftedResource {
-  kind: string
-  name: string
-  namespace: string
-  field: string
-  gitValue: string
-  clusterValue: string
-}
-
-interface SyncPlan {
-  action: 'create' | 'update' | 'delete'
-  resource: string
-  details: string
-}
-
-interface SyncLogEntry {
-  timestamp: string
-  message: string
-  status: 'pending' | 'running' | 'success' | 'error'
-}
+import { useSyncDialog } from './useSyncDialog'
+import {
+  SyncPhaseIndicator,
+  DetectionPhaseContent,
+  PlanPhaseContent,
+  ExecutionPhaseContent,
+} from './SyncDialog.parts'
 
 interface SyncDialogProps {
   isOpen: boolean
@@ -90,221 +27,21 @@ export function SyncDialog({
   cluster,
   repoUrl,
   path,
-  onSyncComplete }: SyncDialogProps) {
-  const { t } = useTranslation()
-  const [phase, setPhase] = useState<SyncPhase>('detection')
-  const [driftedResources, setDriftedResources] = useState<DriftedResource[]>([])
-  const [syncPlan, setSyncPlan] = useState<SyncPlan[]>([])
-  const [syncLogs, setSyncLogs] = useState<SyncLogEntry[]>([])
-  const [tokenCount, setTokenCount] = useState(0)
-  const [error, setError] = useState<string | null>(null)
-  const [isInitializing, setIsInitializing] = useState(false)
-  const logContainerRef = useRef<HTMLDivElement>(null)
-
-  // Auto-scroll logs
-  useEffect(() => {
-    if (logContainerRef.current) {
-      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
-    }
-  }, [syncLogs])
-
-  // Note: ESC key handling is now handled by BaseModal
-
-  const addLog = (message: string, status: SyncLogEntry['status'] = 'pending') => {
-    const entry: SyncLogEntry = {
-      timestamp: new Date().toLocaleTimeString(),
-      message,
-      status }
-    setSyncLogs(prev => [...prev, entry])
-  }
-
-  const updateLastLog = (status: SyncLogEntry['status']) => {
-    setSyncLogs(prev => {
-      if (prev.length === 0) return prev
-      const updated = [...prev]
-      updated[updated.length - 1] = { ...updated[updated.length - 1], status }
-      return updated
-    })
-  }
-
-  // Phase 1: Detection
-  const runDetection = async () => {
-    setIsInitializing(true)
-    addLog('Connecting to cluster...', 'running')
-
-    try {
-      // #7993 Phase 4: detect-drift moved to kc-agent. Runs under the
-      // user's kubeconfig instead of the backend pod SA.
-      const token = await getStoredAuthToken()
-      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          ...(token && { 'Authorization': `Bearer ${token}` }) },
-        body: JSON.stringify({
-          repoUrl,
-          path,
-          cluster,
-          namespace }),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-
-      updateLastLog('success')
-      addLog('Analyzing drift...', 'running')
-
-      if (!response.ok) {
-        const err = await response.json()
-        throw new Error(err.error || 'Failed to detect drift')
-      }
-
-      const data = await response.json()
-      updateLastLog('success')
-
-      // Parse the response
-      if (data.resources && data.resources.length > 0) {
-        setDriftedResources(data.resources)
-        addLog(`Found ${data.resources.length} drifted resources`, 'success')
-      } else if (data.drifted) {
-        // Fallback: create a generic drift entry from raw diff
-        const genericDrift: DriftedResource[] = [{
-          kind: 'Resource',
-          name: appName,
-          namespace,
-          field: 'configuration',
-          gitValue: 'git state',
-          clusterValue: 'cluster state' }]
-        setDriftedResources(genericDrift)
-        addLog('Drift detected (see raw diff)', 'success')
-      } else {
-        addLog('No drift detected - cluster is in sync', 'success')
-        setDriftedResources([])
-      }
-
-      if (data.tokensUsed) {
-        setTokenCount(prev => prev + data.tokensUsed)
-      }
-
-      setPhase('plan')
-    } catch (err: unknown) {
-      // Error states should be shown immediately (not deferred with startTransition)
-      updateLastLog('error')
-      const message = err instanceof Error ? err.message : 'Detection failed'
-      addLog(`Error: ${message}`, 'error')
-      setError(message)
-    } finally {
-      // Always reset initializing state
-      setIsInitializing(false)
-    }
-  }
-
-  // Reset state when dialog opens
-  useEffect(() => {
-    if (isOpen) {
-      // Clear error immediately so user doesn't see stale errors
-      setError(null)
-      // Batch non-critical state resets to prevent flicker
-      startTransition(() => {
-        setPhase('detection')
-        setDriftedResources([])
-        setSyncPlan([])
-        setSyncLogs([])
-        setTokenCount(0)
-      })
-      // runDetection() will set isInitializing to true
-      runDetection()
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isOpen])
-
-  // Phase 2: Generate Plan
-  useEffect(() => {
-    if (phase === 'plan' && driftedResources.length > 0) {
-      const plan: SyncPlan[] = driftedResources.map(r => ({
-        action: 'update' as const,
-        resource: `${r.kind}/${r.name}`,
-        details: `${r.field}: ${r.clusterValue} → ${r.gitValue}` }))
-      setSyncPlan(plan)
-    }
-  }, [phase, driftedResources])
-
-  // Phase 3: Execute Sync
-  const runSync = async () => {
-    setPhase('execution')
-    addLog('Starting sync...', 'running')
-
-    try {
-      // #7993 Phase 4: gitops sync moved to kc-agent. Runs under the
-      // user's kubeconfig instead of the backend pod SA.
-      const token = await getStoredAuthToken()
-      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/sync`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-Requested-With': 'XMLHttpRequest',
-          ...(token && { 'Authorization': `Bearer ${token}` }) },
-        body: JSON.stringify({
-          repoUrl,
-          path,
-          cluster,
-          namespace }),
-        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
-
-      updateLastLog('success')
-
-      if (!response.ok) {
-        const err = await response.json()
-        throw new Error(err.error || 'Sync failed')
-      }
-
-      const data = await response.json()
-
-      // Log applied resources
-      if (data.applied && data.applied.length > 0) {
-        for (const resource of data.applied) {
-          addLog(`✓ ${resource}`, 'success')
-        }
-      }
-
-      // Log any errors
-      if (data.errors && data.errors.length > 0) {
-        for (const error of data.errors) {
-          addLog(`✗ ${error}`, 'error')
-        }
-      }
-
-      if (data.tokensUsed) {
-        setTokenCount(prev => prev + data.tokensUsed)
-      }
-
-      if (data.success) {
-        addLog('Sync complete!', 'success')
-        setPhase('complete')
-      } else {
-        addLog(`Sync failed: ${data.message}`, 'error')
-        setError(data.message)
-      }
-    } catch (err: unknown) {
-      updateLastLog('error')
-      const message = err instanceof Error ? err.message : 'Sync failed'
-      addLog(`Error: ${message}`, 'error')
-      setError(message)
-    }
-  }
-
-  const handleClose = () => {
-    if (phase === 'complete') {
-      onSyncComplete()
-    }
-    onClose()
-  }
-
-  const phaseProgress = {
-    detection: 1,
-    plan: 2,
-    execution: 3,
-    complete: 4 }
-
-  const isSyncing = phase === 'plan' || phase === 'execution'
+  onSyncComplete,
+}: SyncDialogProps) {
+  const {
+    phase,
+    driftedResources,
+    syncPlan,
+    syncLogs,
+    tokenCount,
+    error,
+    isInitializing,
+    logContainerRef,
+    isSyncing,
+    runSync,
+    handleClose,
+  } = useSyncDialog({ isOpen, appName, namespace, cluster, repoUrl, path, onSyncComplete, onClose })
 
   return (
     <BaseModal isOpen={isOpen} onClose={handleClose} size="lg" closeOnBackdrop={!isSyncing} closeOnEscape={!isSyncing}>
@@ -316,139 +53,31 @@ export function SyncDialog({
         showBack={false}
       />
 
-      {/* Phase Indicator */}
-      <div className="px-6 py-3 bg-muted/30 border-b border-border">
-          <div className="flex items-center justify-between text-sm">
-            {['Detection', 'Plan', 'Execute', 'Complete'].map((label, i) => {
-              const stepNum = i + 1
-              const isActive = phaseProgress[phase] === stepNum
-              const isComplete = phaseProgress[phase] > stepNum
-
-              return (
-                <div key={label} className="flex items-center gap-2">
-                  <div className={`w-6 h-6 rounded-full flex items-center justify-center text-xs font-medium
-                    ${isComplete ? 'bg-green-500 text-foreground' :
-                      isActive ? 'bg-primary text-primary-foreground' :
-                      'bg-muted text-muted-foreground'}`}
-                  >
-                    {isComplete ? <Check className="w-3 h-3" /> : stepNum}
-                  </div>
-                  <span className={isActive ? 'text-foreground font-medium' : 'text-muted-foreground'}>
-                    {label}
-                  </span>
-                  {i < 3 && <ChevronRight className="w-4 h-4 text-muted-foreground mx-2" />}
-                </div>
-              )
-            })}
-          </div>
-        </div>
+      <SyncPhaseIndicator phase={phase} />
 
       <BaseModal.Content className="max-h-[400px]">
-          {/* Initial Loading State */}
-          {isInitializing && phase === 'detection' && syncLogs.length === 0 && (
-            <div className="flex flex-col items-center justify-center py-8 space-y-3">
-              <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
-              <p className="text-sm text-muted-foreground">Initializing drift detection...</p>
-            </div>
-          )}
+        {phase === 'detection' && (
+          <DetectionPhaseContent
+            isInitializing={isInitializing}
+            syncLogsLength={syncLogs.length}
+          />
+        )}
 
-          {/* Detection Phase */}
-          {phase === 'detection' && syncLogs.length > 0 && (
-            <div className="space-y-3">
-              <div className="flex items-center gap-2 text-muted-foreground">
-                <Loader2 className="w-4 h-4 animate-spin" />
-                <span>{t('gitops.detectingDrift')}</span>
-              </div>
-            </div>
-          )}
+        {phase === 'plan' && (
+          <PlanPhaseContent
+            driftedResources={driftedResources}
+            syncPlan={syncPlan}
+          />
+        )}
 
-          {/* Plan Phase */}
-          {phase === 'plan' && (
-            <div className="space-y-4">
-              <div>
-                <h3 className="text-sm font-medium text-foreground mb-3 flex items-center gap-2">
-                  <AlertTriangle className="w-4 h-4 text-yellow-500" />
-                  Drift Detected ({driftedResources.length} resources)
-                </h3>
-                <div className="space-y-2 max-h-[250px] overflow-y-auto">
-                  {driftedResources.map((r, i) => (
-                    <div key={i} className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20">
-                      <div className="flex items-center gap-2 text-sm">
-                        {getResourceIcon(r.kind)}
-                        <span className="px-1.5 py-0.5 rounded text-xs font-medium bg-card text-muted-foreground">
-                          <FormattedResourceKind kind={r.kind} />
-                        </span>
-                        <span className="font-medium text-foreground truncate">{r.name}</span>
-                      </div>
-                      {(r.field || r.clusterValue || r.gitValue) && (
-                        <div className="mt-2 text-xs font-mono pl-6">
-                          {r.field && <span className="text-muted-foreground">{r.field}: </span>}
-                          {r.clusterValue && <span className="text-red-400 line-through">{r.clusterValue}</span>}
-                          {r.clusterValue && r.gitValue && <span className="text-muted-foreground"> → </span>}
-                          {r.gitValue && <span className="text-green-400">{r.gitValue}</span>}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
+        {(phase === 'execution' || phase === 'complete') && (
+          <ExecutionPhaseContent
+            syncLogs={syncLogs}
+            tokenCount={tokenCount}
+            logContainerRef={logContainerRef}
+          />
+        )}
 
-              <div>
-                <h3 className="text-sm font-medium text-foreground mb-3">Sync Plan ({syncPlan.length} changes)</h3>
-                <div className="space-y-1 max-h-[120px] overflow-y-auto">
-                  {syncPlan.map((item, i) => {
-                    const [kind, name] = item.resource.includes('/') ? item.resource.split('/') : ['Resource', item.resource]
-                    return (
-                      <div key={i} className="flex items-center gap-2 text-sm py-1">
-                        <span className={`px-1.5 py-0.5 rounded text-xs font-medium ${
-                          item.action === 'create' ? 'bg-green-500/20 text-green-400' :
-                          item.action === 'delete' ? 'bg-red-500/20 text-red-400' :
-                          'bg-blue-500/20 text-blue-400'
-                        }`}>
-                          {item.action.toUpperCase()}
-                        </span>
-                        {getResourceIcon(kind)}
-                        <span className="text-muted-foreground text-xs"><FormattedResourceKind kind={kind} /></span>
-                        <span className="text-foreground truncate">{name}</span>
-                      </div>
-                    )
-                  })}
-                </div>
-              </div>
-            </div>
-          )}
-
-          {/* Execution Phase */}
-          {(phase === 'execution' || phase === 'complete') && (
-            <div className="space-y-4">
-              <div className="flex items-center justify-between text-sm">
-                <span className="text-muted-foreground">Console Output</span>
-                <span className="text-xs px-2 py-1 rounded bg-muted text-muted-foreground">
-                  Tokens: {tokenCount.toLocaleString()}
-                </span>
-              </div>
-              <div
-                ref={logContainerRef}
-                className="h-48 p-3 rounded-lg bg-black/50 border border-border font-mono text-xs overflow-y-auto"
-              >
-                {syncLogs.map((log, i) => (
-                  <div key={i} className="flex items-start gap-2 py-0.5">
-                    <span className="text-muted-foreground shrink-0">{log.timestamp}</span>
-                    {log.status === 'running' && <Loader2 className="w-3 h-3 animate-spin text-blue-400 mt-0.5" />}
-                    {log.status === 'success' && <Check className="w-3 h-3 text-green-400 mt-0.5" />}
-                    {log.status === 'error' && <X className="w-3 h-3 text-red-400 mt-0.5" />}
-                    <span className={
-                      log.status === 'success' ? 'text-green-400' :
-                      log.status === 'error' ? 'text-red-400' :
-                      'text-foreground'
-                    }>{log.message}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-
-        {/* Error State */}
         {error && (
           <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20 text-red-400">
             {error}

--- a/web/src/components/gitops/useGitOps.ts
+++ b/web/src/components/gitops/useGitOps.ts
@@ -1,0 +1,326 @@
+import { useMemo, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { TFunction } from 'i18next'
+import { useClusters, useHelmReleases, useOperatorSubscriptions } from '../../hooks/useMCP'
+import { useToast } from '../ui/Toast'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
+import { LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { getStoredAuthToken } from '../../lib/authToken'
+import { agentFetch } from '../../hooks/mcp/shared'
+import { MS_PER_MINUTE } from '../../lib/constants/time'
+import { FETCH_DEFAULT_TIMEOUT_MS } from '../../lib/constants/network'
+import { getDemoMode } from '../../hooks/useDemoMode'
+import type { StatBlockValue } from '../ui/StatsOverview'
+import { getDefaultCards } from '../../config/dashboards'
+import type { GitOpsAppConfig, GitOpsApp, DriftResult } from './GitOps.types'
+
+const DRIFT_HEALTHCHECK_TIMEOUT_MS = 3000
+const EXACTLY_ONE_CLUSTER = 1
+
+export const GITOPS_STORAGE_KEY = 'kubestellar-gitops-dashboard-cards'
+export const DEFAULT_GITOPS_CARDS = getDefaultCards('gitops')
+
+function getGitOpsAppConfigs(): GitOpsAppConfig[] {
+  return [
+    { name: 'gatekeeper', namespace: 'gatekeeper-system', cluster: '', repoUrl: 'https://github.com/open-policy-agent/gatekeeper', path: 'deploy/' },
+    { name: 'kuberay-operator', namespace: 'ray-system', cluster: '', repoUrl: 'https://github.com/ray-project/kuberay', path: 'ray-operator/config/default/' },
+    { name: 'kserve', namespace: 'kserve', cluster: '', repoUrl: 'https://github.com/kserve/kserve', path: 'config/default/' },
+    { name: 'gpu-operator', namespace: 'gpu-operator', cluster: '', repoUrl: 'https://github.com/NVIDIA/gpu-operator', path: 'deployments/gpu-operator/' },
+  ]
+}
+
+export function getTimeAgo(timestamp: string | undefined, t: TFunction): string {
+  if (!timestamp) return t('gitops.unknown')
+  const now = new Date()
+  const then = new Date(timestamp)
+  const diffMs = now.getTime() - then.getTime()
+  const diffMins = Math.floor(diffMs / MS_PER_MINUTE)
+  const diffHours = Math.floor(diffMins / 60)
+  if (diffHours > 0) return t('gitops.hoursAgo', { count: diffHours })
+  if (diffMins > 0) return t('gitops.minutesAgo', { count: diffMins })
+  return t('gitops.justNow')
+}
+
+export function useGitOps() {
+  const { t } = useTranslation(['common', 'cards'])
+  const { clusters, deduplicatedClusters, isRefreshing: dataRefreshing, refetch } = useClusters()
+  const { releases: helmReleases } = useHelmReleases()
+  const { subscriptions: operatorSubs } = useOperatorSubscriptions()
+  const { drillToAllHelm, drillToAllOperators } = useDrillDownActions()
+  const { showToast } = useToast()
+
+  const [selectedCluster, setSelectedCluster] = useState<string>('')
+  const [statusFilter, setStatusFilter] = useState<string>('all')
+  const [syncedApps, setSyncedApps] = useState<Set<string>>(new Set())
+  const [syncDialogApp, setSyncDialogApp] = useState<GitOpsApp | null>(null)
+  const [driftResults, setDriftResults] = useState<Map<string, DriftResult>>(new Map())
+  const [isDetecting, setIsDetecting] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const [syncedAt, setSyncedAt] = useState<Map<string, string>>(new Map())
+
+  const cachedHelmCount = useRef(0)
+  const detectAllDriftRef = useRef<() => Promise<void>>(async () => {})
+
+  useEffect(() => {
+    setLastUpdated(new Date())
+  }, [])
+
+  const clusterDisplayName = (c: { context?: string; name: string }): string =>
+    c.context || c.name.split('/').pop() || ''
+
+  const resolveAppCluster = (preferred: string): { cluster: string; ambiguous: boolean } => {
+    if (preferred) return { cluster: preferred, ambiguous: false }
+    if (deduplicatedClusters.length === EXACTLY_ONE_CLUSTER) {
+      return { cluster: clusterDisplayName(deduplicatedClusters[0]), ambiguous: false }
+    }
+    return { cluster: '', ambiguous: deduplicatedClusters.length > EXACTLY_ONE_CLUSTER }
+  }
+
+  const handleRefresh = () => {
+    refetch()
+    void detectAllDriftRef.current()
+    setLastUpdated(new Date())
+  }
+
+  useEffect(() => {
+    if (getDemoMode()) {
+      setIsDetecting(false)
+      return
+    }
+
+    let cancelled = false
+
+    async function detectAllDrift() {
+      try {
+        const health = await fetch('/api/health', { signal: AbortSignal.timeout(DRIFT_HEALTHCHECK_TIMEOUT_MS) })
+        if (!health.ok) {
+          setIsDetecting(false)
+          return
+        }
+      } catch {
+        setIsDetecting(false)
+        return
+      }
+
+      if (cancelled) return
+
+      setIsDetecting(true)
+      const results = new Map<string, DriftResult>()
+      const configs = getGitOpsAppConfigs().map(c => {
+        const resolved = resolveAppCluster(c.cluster)
+        return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
+      })
+
+      const token = await getStoredAuthToken()
+      const agentAuthHeaders: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'X-Requested-With': 'XMLHttpRequest',
+      }
+      if (token) agentAuthHeaders['Authorization'] = `Bearer ${token}`
+      const promises = configs.map(async (appConfig) => {
+        try {
+          const res = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
+            method: 'POST',
+            headers: agentAuthHeaders,
+            body: JSON.stringify({
+              repoUrl: appConfig.repoUrl,
+              path: appConfig.path,
+              namespace: appConfig.namespace,
+              cluster: appConfig.cluster || undefined,
+            }),
+            signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS),
+          })
+          if (!res.ok) {
+            const errBody = await res.json().catch(() => ({}))
+            throw new Error(errBody.error || `detect-drift failed (HTTP ${res.status})`)
+          }
+          const data = (await res.json()) as {
+            drifted: boolean
+            resources: DriftResult['resources']
+            rawDiff?: string
+          }
+          return {
+            name: appConfig.name,
+            result: {
+              status: 'ok' as const,
+              drifted: data.drifted,
+              resources: data.resources || [] } satisfies DriftResult }
+        } catch (e: unknown) {
+          const message = e instanceof Error ? e.message : 'Failed to detect drift'
+          return {
+            name: appConfig.name,
+            result: {
+              status: 'error' as const,
+              drifted: false,
+              resources: [],
+              error: message } satisfies DriftResult }
+        }
+      })
+
+      const settled = await Promise.all(promises)
+      if (cancelled) return
+
+      for (const { name, result } of settled) {
+        results.set(name, result)
+      }
+
+      setDriftResults(results)
+      setIsDetecting(false)
+    }
+
+    detectAllDriftRef.current = detectAllDrift
+    detectAllDrift()
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [deduplicatedClusters])
+
+  const handleSync = (app: GitOpsApp) => {
+    setSyncDialogApp(app)
+  }
+
+  const handleSyncComplete = () => {
+    if (syncDialogApp) {
+      setSyncedApps(prev => new Set(prev).add(syncDialogApp.name))
+      setDriftResults(prev => {
+        const updated = new Map(prev)
+        updated.set(syncDialogApp.name, { status: 'ok', drifted: false, resources: [] })
+        return updated
+      })
+      setSyncedAt(prev => {
+        const updated = new Map(prev)
+        updated.set(syncDialogApp.name, new Date().toISOString())
+        return updated
+      })
+      showToast(`${syncDialogApp.name} synced successfully!`, 'success')
+    }
+  }
+
+  const apps = useMemo(() => {
+    const configs = getGitOpsAppConfigs().map(c => {
+      const resolved = resolveAppCluster(c.cluster)
+      return { ...c, cluster: resolved.cluster, clusterAmbiguous: resolved.ambiguous }
+    })
+    return configs.map((config): GitOpsApp => {
+      const realSyncTime = syncedAt.get(config.name)
+      if (syncedApps.has(config.name)) {
+        return { ...config, syncStatus: 'synced', healthStatus: 'healthy', lastSyncTime: realSyncTime, lastSyncTimeAgo: getTimeAgo(realSyncTime, t), driftDetails: undefined }
+      }
+      if (isDetecting) {
+        return { ...config, syncStatus: 'checking', healthStatus: 'progressing', lastSyncTime: undefined, lastSyncTimeAgo: getTimeAgo(undefined, t), driftDetails: undefined }
+      }
+      const drift = driftResults.get(config.name)
+      if (drift) {
+        if (drift.status === 'error') {
+          return {
+            ...config,
+            syncStatus: 'error',
+            healthStatus: 'unknown',
+            lastSyncTime: undefined,
+            lastSyncTimeAgo: getTimeAgo(undefined, t),
+            driftDetails: drift.error ? [drift.error] : ['Failed to detect drift'] }
+        }
+        const driftDetails = drift.resources.length > 0
+          ? drift.resources.map(r => `${r.kind}/${r.name}: ${r.field || 'modified'}`)
+          : undefined
+        return {
+          ...config,
+          syncStatus: drift.drifted ? 'out-of-sync' : 'synced',
+          healthStatus: drift.drifted ? 'progressing' : 'healthy',
+          lastSyncTime: realSyncTime,
+          lastSyncTimeAgo: getTimeAgo(realSyncTime, t),
+          driftDetails }
+      }
+      return { ...config, syncStatus: 'unknown', healthStatus: 'missing', lastSyncTime: undefined, lastSyncTimeAgo: getTimeAgo(undefined, t), driftDetails: undefined }
+    })
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [driftResults, isDetecting, syncedApps, syncedAt, clusters])
+
+  const filteredApps = apps
+    .map(app => syncedApps.has(app.name)
+      ? { ...app, syncStatus: 'synced' as const, healthStatus: 'healthy' as const, driftDetails: undefined }
+      : app)
+    .filter(app => {
+      if (selectedCluster && app.cluster !== selectedCluster) return false
+      if (statusFilter === 'synced' && app.syncStatus !== 'synced') return false
+      if (statusFilter === 'drifted' && app.syncStatus !== 'out-of-sync') return false
+      return true
+    })
+
+  const stats = {
+    total: apps.length,
+    synced: apps.filter(a => a.syncStatus === 'synced').length,
+    drifted: apps.filter(a => a.syncStatus === 'out-of-sync').length,
+    healthy: apps.filter(a => a.healthStatus === 'healthy').length,
+    checking: apps.filter(a => a.syncStatus === 'checking').length }
+
+  useEffect(() => {
+    if (helmReleases.length > 0) cachedHelmCount.current = helmReleases.length
+  }, [helmReleases.length])
+  const helmCount = helmReleases.length > 0 ? helmReleases.length : cachedHelmCount.current
+
+  const syncStatusColor = (status: string) => {
+    switch (status) {
+      case 'synced': return 'text-green-400 bg-green-500/20'
+      case 'out-of-sync': return 'text-yellow-400 bg-yellow-500/20'
+      case 'checking': return 'text-blue-400 bg-blue-500/20'
+      case 'error': return 'text-red-400 bg-red-500/20'
+      default: return 'text-muted-foreground bg-card'
+    }
+  }
+
+  const syncStatusLabel = (status: string) => {
+    switch (status) {
+      case 'synced': return t('gitops.synced')
+      case 'out-of-sync': return t('gitops.outOfSync')
+      case 'checking': return t('gitops.checking')
+      case 'error': return t('gitops.driftCheckFailed')
+      default: return t('gitops.unknown')
+    }
+  }
+
+  const healthStatusIndicator = (status: string): 'healthy' | 'warning' | 'error' => {
+    switch (status) {
+      case 'healthy': return 'healthy'
+      case 'progressing': return 'warning'
+      case 'unknown': return 'warning'
+      default: return 'error'
+    }
+  }
+
+  const getDashboardStatValue = (blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'total': return { value: stats.total, sublabel: t('gitops.appsConfigured'), onClick: () => drillToAllHelm(), isClickable: stats.total > 0 }
+      case 'helm': return { value: helmCount, sublabel: t('gitops.helmReleases'), onClick: () => drillToAllHelm(), isClickable: helmCount > 0 }
+      case 'kustomize': return { value: 0, sublabel: t('gitops.kustomizeApps'), isClickable: false }
+      case 'operators': return { value: operatorSubs.length, sublabel: t('gitops.operators'), onClick: () => drillToAllOperators(), isClickable: operatorSubs.length > 0 }
+      case 'deployed': return { value: stats.synced, sublabel: t('gitops.synced'), onClick: () => drillToAllHelm('synced'), isClickable: stats.synced > 0 }
+      case 'failed': return { value: stats.drifted, sublabel: t('gitops.drifted'), onClick: () => drillToAllHelm('drifted'), isClickable: stats.drifted > 0 }
+      case 'pending': return { value: stats.checking, sublabel: t('gitops.checking'), isClickable: false }
+      case 'other': return { value: stats.healthy, sublabel: t('gitops.healthy'), onClick: () => drillToAllHelm('healthy'), isClickable: stats.healthy > 0 }
+      default: return { value: 0 }
+    }
+  }
+
+  return {
+    t,
+    clusters,
+    apps,
+    filteredApps,
+    stats,
+    dataRefreshing,
+    lastUpdated,
+    selectedCluster,
+    setSelectedCluster,
+    statusFilter,
+    setStatusFilter,
+    syncDialogApp,
+    setSyncDialogApp,
+    syncStatusColor,
+    syncStatusLabel,
+    healthStatusIndicator,
+    getDashboardStatValue,
+    handleRefresh,
+    handleSync,
+    handleSyncComplete,
+  }
+}

--- a/web/src/components/gitops/useSyncDialog.ts
+++ b/web/src/components/gitops/useSyncDialog.ts
@@ -1,0 +1,212 @@
+import { useState, useEffect, useRef, startTransition } from 'react'
+import { FETCH_DEFAULT_TIMEOUT_MS, LOCAL_AGENT_HTTP_URL } from '../../lib/constants'
+import { getStoredAuthToken } from '../../lib/authToken'
+import { agentFetch } from '../../hooks/mcp/shared'
+import type { SyncPhase, DriftedResource, SyncPlan, SyncLogEntry } from './SyncDialog.parts'
+
+interface UseSyncDialogProps {
+  isOpen: boolean
+  appName: string
+  namespace: string
+  cluster: string
+  repoUrl: string
+  path: string
+  onSyncComplete: () => void
+  onClose: () => void
+}
+
+export function useSyncDialog({ isOpen, appName, namespace, cluster, repoUrl, path, onSyncComplete, onClose }: UseSyncDialogProps) {
+  const [phase, setPhase] = useState<SyncPhase>('detection')
+  const [driftedResources, setDriftedResources] = useState<DriftedResource[]>([])
+  const [syncPlan, setSyncPlan] = useState<SyncPlan[]>([])
+  const [syncLogs, setSyncLogs] = useState<SyncLogEntry[]>([])
+  const [tokenCount, setTokenCount] = useState(0)
+  const [error, setError] = useState<string | null>(null)
+  const [isInitializing, setIsInitializing] = useState(false)
+  const logContainerRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (logContainerRef.current) {
+      logContainerRef.current.scrollTop = logContainerRef.current.scrollHeight
+    }
+  }, [syncLogs])
+
+  const addLog = (message: string, status: SyncLogEntry['status'] = 'pending') => {
+    const entry: SyncLogEntry = {
+      timestamp: new Date().toLocaleTimeString(),
+      message,
+      status }
+    setSyncLogs(prev => [...prev, entry])
+  }
+
+  const updateLastLog = (status: SyncLogEntry['status']) => {
+    setSyncLogs(prev => {
+      if (prev.length === 0) return prev
+      const updated = [...prev]
+      updated[updated.length - 1] = { ...updated[updated.length - 1], status }
+      return updated
+    })
+  }
+
+  const runDetection = async () => {
+    setIsInitializing(true)
+    addLog('Connecting to cluster...', 'running')
+
+    try {
+      const token = await getStoredAuthToken()
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(token && { 'Authorization': `Bearer ${token}` }) },
+        body: JSON.stringify({ repoUrl, path, cluster, namespace }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+
+      updateLastLog('success')
+      addLog('Analyzing drift...', 'running')
+
+      if (!response.ok) {
+        const err = await response.json()
+        throw new Error(err.error || 'Failed to detect drift')
+      }
+
+      const data = await response.json()
+      updateLastLog('success')
+
+      if (data.resources && data.resources.length > 0) {
+        setDriftedResources(data.resources)
+        addLog(`Found ${data.resources.length} drifted resources`, 'success')
+      } else if (data.drifted) {
+        const genericDrift: DriftedResource[] = [{
+          kind: 'Resource',
+          name: appName,
+          namespace,
+          field: 'configuration',
+          gitValue: 'git state',
+          clusterValue: 'cluster state' }]
+        setDriftedResources(genericDrift)
+        addLog('Drift detected (see raw diff)', 'success')
+      } else {
+        addLog('No drift detected - cluster is in sync', 'success')
+        setDriftedResources([])
+      }
+
+      if (data.tokensUsed) {
+        setTokenCount(prev => prev + data.tokensUsed)
+      }
+
+      setPhase('plan')
+    } catch (err: unknown) {
+      updateLastLog('error')
+      const message = err instanceof Error ? err.message : 'Detection failed'
+      addLog(`Error: ${message}`, 'error')
+      setError(message)
+    } finally {
+      setIsInitializing(false)
+    }
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      setError(null)
+      startTransition(() => {
+        setPhase('detection')
+        setDriftedResources([])
+        setSyncPlan([])
+        setSyncLogs([])
+        setTokenCount(0)
+      })
+      runDetection()
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen])
+
+  useEffect(() => {
+    if (phase === 'plan' && driftedResources.length > 0) {
+      const plan: SyncPlan[] = driftedResources.map(r => ({
+        action: 'update' as const,
+        resource: `${r.kind}/${r.name}`,
+        details: `${r.field}: ${r.clusterValue} → ${r.gitValue}` }))
+      setSyncPlan(plan)
+    }
+  }, [phase, driftedResources])
+
+  const runSync = async () => {
+    setPhase('execution')
+    addLog('Starting sync...', 'running')
+
+    try {
+      const token = await getStoredAuthToken()
+      const response = await agentFetch(`${LOCAL_AGENT_HTTP_URL}/gitops/sync`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          ...(token && { 'Authorization': `Bearer ${token}` }) },
+        body: JSON.stringify({ repoUrl, path, cluster, namespace }),
+        signal: AbortSignal.timeout(FETCH_DEFAULT_TIMEOUT_MS) })
+
+      updateLastLog('success')
+
+      if (!response.ok) {
+        const err = await response.json()
+        throw new Error(err.error || 'Sync failed')
+      }
+
+      const data = await response.json()
+
+      if (data.applied && data.applied.length > 0) {
+        for (const resource of data.applied) {
+          addLog(`✓ ${resource}`, 'success')
+        }
+      }
+
+      if (data.errors && data.errors.length > 0) {
+        for (const e of data.errors) {
+          addLog(`✗ ${e}`, 'error')
+        }
+      }
+
+      if (data.tokensUsed) {
+        setTokenCount(prev => prev + data.tokensUsed)
+      }
+
+      if (data.success) {
+        addLog('Sync complete!', 'success')
+        setPhase('complete')
+      } else {
+        addLog(`Sync failed: ${data.message}`, 'error')
+        setError(data.message)
+      }
+    } catch (err: unknown) {
+      updateLastLog('error')
+      const message = err instanceof Error ? err.message : 'Sync failed'
+      addLog(`Error: ${message}`, 'error')
+      setError(message)
+    }
+  }
+
+  const handleClose = () => {
+    if (phase === 'complete') {
+      onSyncComplete()
+    }
+    onClose()
+  }
+
+  const isSyncing = phase === 'plan' || phase === 'execution'
+
+  return {
+    phase,
+    driftedResources,
+    syncPlan,
+    syncLogs,
+    tokenCount,
+    error,
+    isInitializing,
+    logContainerRef,
+    isSyncing,
+    runSync,
+    handleClose,
+  }
+}

--- a/web/src/components/workloads/Workloads.parts.tsx
+++ b/web/src/components/workloads/Workloads.parts.tsx
@@ -1,0 +1,242 @@
+/* eslint-disable react-refresh/only-export-components */
+import { AlertTriangle, ChevronRight, Plus, RefreshCw, Trash2, Terminal } from 'lucide-react'
+import type { TFunction } from 'i18next'
+import { StatusIndicator, type Status } from '../charts/StatusIndicator'
+import { ClusterBadge } from '../ui/ClusterBadge'
+import { Skeleton } from '../ui/Skeleton'
+import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
+import { getClusterDisplayName } from '../../utils/clusterNames'
+import type { AppSummary, DeploymentSummary, WorkloadItem } from './Workloads.types'
+
+export const WORKLOAD_SKELETON_COUNT = 5
+
+interface WorkloadsErrorBannerProps {
+  error: string | null
+  onRetry: () => void
+  t: TFunction
+}
+
+export function WorkloadsErrorBanner({ error, onRetry, t }: WorkloadsErrorBannerProps) {
+  if (!error) return null
+  return (
+    <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+      <div className="flex items-start gap-3">
+        <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
+        <div className="flex-1">
+          <p className="text-sm font-medium text-red-400">{t('workloads.errorLoading', 'Could not load workload data')}</p>
+          <p className="text-xs text-muted-foreground mt-1">{error}</p>
+          <button
+            type="button"
+            onClick={onRetry}
+            className="mt-3 inline-flex items-center rounded-lg bg-red-500/15 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/25"
+          >
+            {t('common.retry', 'Retry')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function WorkloadSkeletonList() {
+  return (
+    <div data-testid="workloads-loading-state" className="space-y-3">
+      {Array.from({ length: WORKLOAD_SKELETON_COUNT }, (_, i) => (
+        <div key={i} data-testid="workload-row-skeleton" className="glass p-4 rounded-lg border-l-4 border-l-gray-500/50">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Skeleton variant="circular" width={24} height={24} />
+              <div>
+                <Skeleton variant="text" width={150} height={20} className="mb-1" />
+                <Skeleton variant="rounded" width={80} height={18} />
+              </div>
+            </div>
+            <Skeleton variant="text" width={100} height={20} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+interface WorkloadsEmptyStateProps {
+  onDeploy: () => void
+  t: TFunction
+}
+
+export function WorkloadsEmptyState({ onDeploy, t }: WorkloadsEmptyStateProps) {
+  return (
+    <div data-testid="workloads-empty-state" className="text-center py-12">
+      <div className="text-6xl mb-4">📦</div>
+      <p className="text-lg text-foreground">{t('workloads.noWorkloadsTitle', 'No workloads found')}</p>
+      <p className="text-sm text-muted-foreground mb-6">{t('workloads.noWorkloadsDesc', 'No deployments detected across your clusters')}</p>
+      <button
+        data-testid="empty-state-deploy-workload-btn"
+        onClick={onDeploy}
+        className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
+      >
+        <Plus className="w-4 h-4" />
+        {t('workloads.deployWorkload', 'Create a Workload')}
+      </button>
+    </div>
+  )
+}
+
+interface WorkloadRowProps {
+  item: WorkloadItem
+  onDrillToDeployment: (cluster: string, namespace: string, name: string) => void
+  onDrillToNamespace: (cluster: string, namespace: string) => void
+  onRestart: (e: React.MouseEvent, cluster: string, namespace: string, name: string) => void
+  onLogs: (e: React.MouseEvent, cluster: string, namespace: string, name: string) => void
+  onDelete: (e: React.MouseEvent, cluster: string, namespace: string, name: string) => void
+  t: TFunction
+}
+
+export function WorkloadRow({ item, onDrillToDeployment, onDrillToNamespace, onRestart, onLogs, onDelete, t }: WorkloadRowProps) {
+  const isDeployment = item.type === 'deployment'
+  const app = item as AppSummary
+  const deploy = item as DeploymentSummary
+
+  const status = isDeployment
+    ? (deploy.status === 'failed' ? 'error' : deploy.status === 'deploying' ? 'warning' : 'healthy')
+    : app.status
+
+  return (
+    <div
+      data-testid="workload-row"
+      onClick={() => isDeployment
+        ? onDrillToDeployment(deploy.cluster, deploy.namespace, deploy.name)
+        : onDrillToNamespace(app.cluster, app.namespace)
+      }
+      className={`glass p-4 rounded-lg cursor-pointer transition-all hover:scale-[1.01] border-l-4 ${status === 'error' ? 'border-l-red-500' :
+        status === 'warning' ? 'border-l-yellow-500' :
+          'border-l-green-500'
+        }`}
+    >
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <StatusIndicator status={status as Status} size="lg" />
+          <div>
+            <h3 className="font-semibold text-foreground">{isDeployment ? deploy.name : app.namespace}</h3>
+            <div className="flex items-center gap-2">
+              <ClusterBadge cluster={getClusterDisplayName(item.cluster)} size="sm" />
+              {isDeployment && <span className="text-xs text-muted-foreground">{deploy.namespace}</span>}
+            </div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-6">
+          {isDeployment ? (
+            <>
+              <div className="text-center">
+                <div className="text-lg font-bold text-foreground">{deploy.readyReplicas}/{deploy.replicas}</div>
+                <div className="text-xs text-muted-foreground">{t('common.ready')}</div>
+              </div>
+              <div className="flex items-center gap-1">
+                <PortalTooltip content={t('common.restart', 'Restart')}>
+                  <button
+                    data-testid="action-btn-restart"
+                    onClick={(e) => onRestart(e, deploy.cluster, deploy.namespace, deploy.name)}
+                    className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-blue-400 transition-colors"
+                    aria-label="Restart deployment"
+                  >
+                    <RefreshCw className="w-4 h-4" />
+                  </button>
+                </PortalTooltip>
+
+                <PortalTooltip content={t('common.logs', 'Logs')}>
+                  <button
+                    data-testid="action-btn-logs"
+                    onClick={(e) => onLogs(e, deploy.cluster, deploy.namespace, deploy.name)}
+                    className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-purple-400 transition-colors"
+                    aria-label="View logs"
+                  >
+                    <Terminal className="w-4 h-4" />
+                  </button>
+                </PortalTooltip>
+
+                <PortalTooltip content={t('common.delete', 'Delete')}>
+                  <button
+                    data-testid="action-btn-delete"
+                    onClick={(e) => onDelete(e, deploy.cluster, deploy.namespace, deploy.name)}
+                    className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-red-400 transition-colors"
+                    aria-label="Delete deployment"
+                  >
+                    <Trash2 className="w-4 h-4" />
+                  </button>
+                </PortalTooltip>
+              </div>
+            </>
+          ) : (
+            <>
+              <div className="text-center">
+                <div className="text-lg font-bold text-foreground">{app.deploymentCount}</div>
+                <div className="text-xs text-muted-foreground">{t('common.deployments')}</div>
+              </div>
+              {app.deploymentIssues > 0 && (
+                <div className="text-center">
+                  <div className="text-lg font-bold text-orange-400">{app.deploymentIssues}</div>
+                  <div className="text-xs text-muted-foreground">Issues</div>
+                </div>
+              )}
+              {app.podIssues > 0 && (
+                <div className="text-center">
+                  <div className="text-lg font-bold text-red-400">{app.podIssues}</div>
+                  <div className="text-xs text-muted-foreground">Pod Issues</div>
+                </div>
+              )}
+            </>
+          )}
+          <ChevronRight className="w-4 h-4 text-muted-foreground" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface ClustersOverviewProps {
+  clusters: Array<{ name: string; context?: string; reachable?: boolean; healthy?: boolean; podCount?: number; nodeCount?: number }>
+  isAllClustersSelected: boolean
+  globalSelectedClusters: string[]
+  forceSkeletonForOffline: boolean
+}
+
+export function ClustersOverview({ clusters, isAllClustersSelected, globalSelectedClusters, forceSkeletonForOffline }: ClustersOverviewProps) {
+  return (
+    <div data-testid="clusters-overview-section" className="mt-8">
+      <h2 data-testid="clusters-overview-heading" className="text-lg font-semibold text-foreground mb-4">Clusters Overview</h2>
+      <div data-testid="clusters-overview-grid" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
+        {forceSkeletonForOffline ? (
+          Array.from({ length: WORKLOAD_SKELETON_COUNT }, (_, i) => (
+            <div key={i} className="glass p-3 rounded-lg">
+              <div className="flex items-center gap-2 mb-2">
+                <Skeleton variant="circular" width={16} height={16} />
+                <Skeleton variant="text" width={100} height={16} />
+              </div>
+              <Skeleton variant="text" width={80} height={12} />
+            </div>
+          ))
+        ) : (
+          clusters
+            .filter(cluster => isAllClustersSelected || globalSelectedClusters.includes(cluster.name))
+            .map((cluster) => (
+              <div key={cluster.name} data-testid="cluster-card" className="glass p-3 rounded-lg">
+                <div className="flex items-center gap-2 mb-2">
+                  <StatusIndicator
+                    status={cluster.reachable === false ? 'unreachable' : cluster.healthy ? 'healthy' : 'error'}
+                    size="sm"
+                  />
+                  <span className="font-medium text-foreground text-sm truncate">
+                    {cluster.context || getClusterDisplayName(cluster.name)}
+                  </span>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {cluster.reachable !== false ? (cluster.podCount ?? '-') : '-'} pods • {cluster.reachable !== false ? (cluster.nodeCount ?? '-') : '-'} nodes
+                </div>
+              </div>
+            ))
+        )}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/workloads/Workloads.parts.tsx
+++ b/web/src/components/workloads/Workloads.parts.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-refresh/only-export-components */
 import { AlertTriangle, ChevronRight, Plus, RefreshCw, Trash2, Terminal } from 'lucide-react'
 import type { TFunction } from 'i18next'
 import { StatusIndicator, type Status } from '../charts/StatusIndicator'

--- a/web/src/components/workloads/Workloads.tsx
+++ b/web/src/components/workloads/Workloads.tsx
@@ -1,327 +1,48 @@
-import { useCallback, useMemo, useState } from 'react'
-import { AlertTriangle, ChevronRight, Plus, RefreshCw, Trash2, Terminal } from 'lucide-react'
-import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '../../hooks/useMCP'
-import { useGlobalFilters } from '../../hooks/useGlobalFilters'
-import { useDrillDownActions } from '../../hooks/useDrillDown'
-import { useLocalAgent, wasAgentEverConnected } from '../../hooks/useLocalAgent'
-import { isInClusterMode } from '../../hooks/useBackendHealth'
-import { useDemoMode } from '../../hooks/useDemoMode'
-import { useIsModeSwitching } from '../../lib/unified/demo'
-import { getClusterDisplayName } from '../../utils/clusterNames'
-import { StatusIndicator, type Status } from '../charts/StatusIndicator'
-import { ClusterBadge } from '../ui/ClusterBadge'
-import { Skeleton } from '../ui/Skeleton'
-import { StatBlockValue } from '../ui/StatsOverview'
+import { Plus } from 'lucide-react'
 import { DashboardPage } from '../../lib/dashboards/DashboardPage'
 import { getDefaultCards } from '../../config/dashboards'
 import { RotatingTip } from '../ui/RotatingTip'
-import { useTranslation } from 'react-i18next'
-import { kubectlProxy } from '../../lib/kubectlProxy'
-import { useToast } from '../ui/Toast'
-import { PortalTooltip } from '../cards/llmd/shared/PortalTooltip'
 import { WorkloadImportDialog } from '../cards/WorkloadImportDialog'
 import { ConfirmDialog } from '../../lib/modals'
-import type { Workload } from '../cards/WorkloadDeployment'
-import { isLocalAgentSuppressed } from '../../lib/constants'
+import { useWorkloads } from './useWorkloads'
+import {
+  WorkloadsErrorBanner,
+  WorkloadSkeletonList,
+  WorkloadsEmptyState,
+  WorkloadRow,
+  ClustersOverview,
+} from './Workloads.parts'
 
 const WORKLOADS_CARDS_KEY = 'kubestellar-workloads-cards'
-const IMPORTED_WORKLOAD_CLUSTER = 'Imported'
-
-// Default cards for the workloads dashboard
 const DEFAULT_WORKLOAD_CARDS = getDefaultCards('workloads')
 
-// Pod issues severity threshold - namespaces with more than this many issues are marked as error
-const POD_ISSUES_ERROR_THRESHOLD = 3
-
-// Number of skeleton placeholder items to display while loading workload data
-const WORKLOAD_SKELETON_COUNT = 5
-
-interface AppSummary {
-  namespace: string
-  cluster: string
-  deploymentCount: number
-  podIssues: number
-  deploymentIssues: number
-  status: 'healthy' | 'warning' | 'error'
-  type: 'namespace'
-}
-
-interface DeploymentSummary {
-  name: string
-  namespace: string
-  cluster: string
-  status: 'running' | 'deploying' | 'failed'
-  replicas: number
-  readyReplicas: number
-  type: 'deployment'
-  image?: string
-}
-
-type WorkloadItem = AppSummary | DeploymentSummary
-
-function mapImportedWorkload(workload: Workload): DeploymentSummary {
-  return {
-    name: workload.name,
-    namespace: workload.namespace,
-    cluster: workload.targetClusters[0] || IMPORTED_WORKLOAD_CLUSTER,
-    status: 'deploying',
-    replicas: workload.replicas,
-    readyReplicas: workload.readyReplicas,
-    type: 'deployment',
-    image: workload.image,
-  }
-}
-
 export function Workloads() {
-  const { t } = useTranslation()
-  // Data fetching
-  const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, error: podIssuesError, lastUpdated: podLastUpdated, refetch: refetchPodIssues } = usePodIssues()
-  const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, error: deploymentIssuesError, lastUpdated: deploymentLastUpdated, refetch: refetchDeploymentIssues } = useDeploymentIssues()
-  const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, error: deploymentsError, lastUpdated: deploymentsLastUpdated, refetch: refetchDeployments } = useDeployments()
-  const { deduplicatedClusters: clusters, isLoading: clustersLoading, error: clustersError, lastUpdated: clustersLastUpdated, refetch: refetchClusters } = useClusters()
-
-  // Combine lastUpdated from all sources - use the most recent one
-  const lastUpdated = useMemo(() => {
-    const timestamps = [podLastUpdated, deploymentLastUpdated, deploymentsLastUpdated, clustersLastUpdated].filter(
-      (t): t is Date => t !== null && t !== undefined
-    )
-    if (timestamps.length === 0) return null
-    return timestamps.reduce((latest, current) => (current > latest ? current : latest))
-  }, [podLastUpdated, deploymentLastUpdated, deploymentsLastUpdated, clustersLastUpdated])
-  const { status: agentStatus } = useLocalAgent()
-  const { isDemoMode } = useDemoMode()
-  const isModeSwitching = useIsModeSwitching()
-
-  const { drillToNamespace, drillToAllNamespaces, drillToAllDeployments, drillToAllPods, drillToDeployment } = useDrillDownActions()
-  const { showToast } = useToast()
-  const [pendingDelete, setPendingDelete] = useState<{ cluster: string; namespace: string; name: string } | null>(null)
-  const [showImportDialog, setShowImportDialog] = useState(false)
-  const [importedWorkloads, setImportedWorkloads] = useState<Workload[]>([])
-
-  const handleImportWorkloads = useCallback((newWorkloads: Workload[]) => {
-    setImportedWorkloads(prev => [...prev, ...newWorkloads])
-    showToast(t('workloads.importSuccess', 'Workload added to the list'), 'success')
-  }, [showToast, t])
-
-  const deployments = useMemo(
-    () => [...allDeployments, ...importedWorkloads.map(mapImportedWorkload)],
-    [allDeployments, importedWorkloads],
-  )
-
-  // Combined states
-  const isLoading = podIssuesLoading || deploymentIssuesLoading || deploymentsLoading || clustersLoading
-  const isRefreshing = podIssuesRefreshing || deploymentIssuesRefreshing || deploymentsRefreshing
-  const loadError = podIssuesError || deploymentIssuesError || deploymentsError || clustersError
-  // Show skeletons when loading with no data OR when agent is offline and demo mode is OFF OR mode switching
-  const isAgentOffline = agentStatus === 'disconnected'
-  const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode() && !isLocalAgentSuppressed() && !wasAgentEverConnected()
-  const showSkeletons = ((deployments.length === 0 && podIssues.length === 0 && deploymentIssues.length === 0) && isLoading) || forceSkeletonForOffline || isModeSwitching
-
-  // Combined refresh
-  const handleRefresh = () => {
-    // Guard against multiple concurrent refresh attempts
-    if (isRefreshing) return
-    refetchPodIssues()
-    refetchDeploymentIssues()
-    refetchDeployments()
-    refetchClusters()
-  }
-
-  const handleRestartDeployment = async (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
-    e.stopPropagation()
-    try {
-      showToast(t('workloads.restarting', 'Restarting deployment...'), 'info')
-      await kubectlProxy.exec(['rollout', 'restart', 'deployment', name, '-n', namespace], { context: cluster })
-      showToast(t('workloads.restartSuccess', 'Restart triggered'), 'success')
-      refetchDeployments()
-    } catch (err: unknown) {
-      showToast(t('workloads.restartError', 'Failed to restart deployment'), 'error')
-    }
-  }
-
-  const handleDeleteDeployment = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
-    e.stopPropagation()
-    setPendingDelete({ cluster, namespace, name })
-  }
-
-  const confirmDeleteDeployment = async () => {
-    if (!pendingDelete) return
-    const { cluster, namespace, name } = pendingDelete
-    setPendingDelete(null)
-    try {
-      showToast(t('workloads.deleting', 'Deleting deployment...'), 'info')
-      await kubectlProxy.exec(['delete', 'deployment', name, '-n', namespace], { context: cluster })
-      showToast(t('workloads.deleteSuccess', 'Deployment deleted'), 'success')
-      refetchDeployments()
-    } catch (err: unknown) {
-      showToast(t('workloads.deleteError', 'Failed to delete deployment'), 'error')
-    }
-  }
-
-  const handleShowLogs = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
-    e.stopPropagation()
-    drillToDeployment(cluster, namespace, name, { tab: 'pods' })
-  }
-
   const {
-    selectedClusters: globalSelectedClusters,
+    t,
+    apps,
+    clusters,
+    isLoading,
+    isRefreshing,
+    loadError,
+    lastUpdated,
+    showSkeletons,
+    forceSkeletonForOffline,
+    globalSelectedClusters,
     isAllClustersSelected,
-    customFilter } = useGlobalFilters()
-
-  // Group applications by namespace with global filter applied
-  const apps = useMemo(() => {
-    let filteredDeployments = deployments
-    let filteredPodIssues = podIssues
-    let filteredDeploymentIssues = deploymentIssues
-
-    if (!isAllClustersSelected) {
-      filteredDeployments = filteredDeployments.filter(d =>
-        d.cluster && globalSelectedClusters.includes(d.cluster)
-      )
-      filteredPodIssues = filteredPodIssues.filter(issue =>
-        issue.cluster && globalSelectedClusters.includes(issue.cluster)
-      )
-      filteredDeploymentIssues = filteredDeploymentIssues.filter(issue =>
-        issue.cluster && globalSelectedClusters.includes(issue.cluster)
-      )
-    }
-
-    if (customFilter.trim()) {
-      const query = customFilter.toLowerCase()
-      filteredDeployments = filteredDeployments.filter(d =>
-        d.name.toLowerCase().includes(query) ||
-        d.namespace.toLowerCase().includes(query) ||
-        (d.cluster && d.cluster.toLowerCase().includes(query))
-      )
-      filteredPodIssues = filteredPodIssues.filter(issue =>
-        issue.name.toLowerCase().includes(query) ||
-        issue.namespace.toLowerCase().includes(query) ||
-        (issue.cluster && issue.cluster.toLowerCase().includes(query))
-      )
-      filteredDeploymentIssues = filteredDeploymentIssues.filter(issue =>
-        issue.name.toLowerCase().includes(query) ||
-        issue.namespace.toLowerCase().includes(query) ||
-        (issue.cluster && issue.cluster.toLowerCase().includes(query))
-      )
-    }
-
-    // If we have a filter, show individual deployments that match
-    if (customFilter.trim() || !isAllClustersSelected) {
-      return (filteredDeployments.map(d => ({
-        ...d,
-        type: 'deployment' as const
-      })) as WorkloadItem[]).sort((a, b) => {
-        const aName = a.type === 'deployment' ? a.name : a.namespace
-        const bName = b.type === 'deployment' ? b.name : b.namespace
-        return aName.localeCompare(bName)
-      })
-    }
-
-    const appMap = new Map<string, AppSummary>()
-    // ... (rest of namespace grouping logic)
-    filteredDeployments.forEach(deployment => {
-      const key = `${deployment.cluster}/${deployment.namespace}`
-      if (!appMap.has(key)) {
-        appMap.set(key, {
-          namespace: deployment.namespace,
-          cluster: deployment.cluster || 'unknown',
-          deploymentCount: 0,
-          podIssues: 0,
-          deploymentIssues: 0,
-          status: 'healthy',
-          type: 'namespace'
-        })
-      }
-      const app = appMap.get(key)!
-      app.deploymentCount++
-    })
-
-    filteredPodIssues.forEach(issue => {
-      const key = `${issue.cluster}/${issue.namespace}`
-      if (!appMap.has(key)) {
-        appMap.set(key, {
-          namespace: issue.namespace,
-          cluster: issue.cluster || 'unknown',
-          deploymentCount: 0,
-          podIssues: 0,
-          deploymentIssues: 0,
-          status: 'healthy',
-          type: 'namespace'
-        })
-      }
-      const app = appMap.get(key)!
-      app.podIssues++
-      app.status = app.podIssues > POD_ISSUES_ERROR_THRESHOLD ? 'error' : 'warning'
-    })
-
-    filteredDeploymentIssues.forEach(issue => {
-      const key = `${issue.cluster}/${issue.namespace}`
-      if (!appMap.has(key)) {
-        appMap.set(key, {
-          namespace: issue.namespace,
-          cluster: issue.cluster || 'unknown',
-          deploymentCount: 0,
-          podIssues: 0,
-          deploymentIssues: 0,
-          status: 'healthy',
-          type: 'namespace'
-        })
-      }
-      const app = appMap.get(key)!
-      app.deploymentIssues++
-      // Allow deployment issues to escalate namespace to error (matching pod issue threshold)
-      if (app.deploymentIssues > 3) {
-        app.status = 'error'
-      } else if (app.status === 'healthy') {
-        app.status = 'warning'
-      }
-    })
-
-    return (Array.from(appMap.values()) as WorkloadItem[]).sort((a, b) => {
-      const aStats = a as AppSummary
-      const bStats = b as AppSummary
-      const statusOrder: Record<string, number> = { error: 0, critical: 0, warning: 1, healthy: 2 }
-      if (statusOrder[aStats.status] !== statusOrder[bStats.status]) {
-        return statusOrder[aStats.status] - statusOrder[bStats.status]
-      }
-      return bStats.deploymentCount - aStats.deploymentCount
-    })
-  }, [deployments, podIssues, deploymentIssues, globalSelectedClusters, isAllClustersSelected, customFilter])
-
-  const stats = useMemo(() => {
-    const namespaceApps = apps.filter(a => a.type === 'namespace') as AppSummary[]
-    return {
-      total: namespaceApps.length || apps.length,
-      healthy: namespaceApps.filter(a => a.status === 'healthy').length,
-      warning: namespaceApps.filter(a => a.status === 'warning').length,
-      critical: namespaceApps.filter(a => a.status === 'error').length,
-      totalDeployments: deployments.length,
-      totalPodIssues: podIssues.length,
-      totalDeploymentIssues: deploymentIssues.length
-    }
-  }, [apps, deployments, podIssues, deploymentIssues])
-
-  // Dashboard-specific stats value getter
-  const getDashboardStatValue = (blockId: string): StatBlockValue => {
-    switch (blockId) {
-      case 'namespaces':
-        return { value: stats.total, sublabel: t('workloads.activeNamespaces'), onClick: () => drillToAllNamespaces(), isClickable: apps.length > 0 }
-      case 'critical':
-        return { value: stats.critical, sublabel: t('workloads.criticalIssues'), onClick: () => drillToAllNamespaces('critical'), isClickable: stats.critical > 0 }
-      case 'warning':
-        return { value: stats.warning, sublabel: t('workloads.warningIssues'), onClick: () => drillToAllNamespaces('warning'), isClickable: stats.warning > 0 }
-      case 'healthy':
-        return { value: stats.healthy, sublabel: t('workloads.healthyNamespaces'), onClick: () => drillToAllNamespaces('healthy'), isClickable: stats.healthy > 0 }
-      case 'deployments':
-        return { value: stats.totalDeployments, sublabel: t('workloads.totalDeployments'), onClick: () => drillToAllDeployments(), isClickable: stats.totalDeployments > 0 }
-      case 'pod_issues':
-        return { value: stats.totalPodIssues, sublabel: t('workloads.podIssues'), onClick: () => drillToAllPods('issues'), isClickable: stats.totalPodIssues > 0 }
-      case 'deployment_issues':
-        return { value: stats.totalDeploymentIssues, sublabel: t('workloads.deploymentIssues'), onClick: () => drillToAllDeployments('issues'), isClickable: stats.totalDeploymentIssues > 0 }
-      default:
-        return { value: '-', sublabel: '' }
-    }
-  }
+    pendingDelete,
+    setPendingDelete,
+    showImportDialog,
+    setShowImportDialog,
+    handleImportWorkloads,
+    handleRefresh,
+    handleRestartDeployment,
+    handleDeleteDeployment,
+    confirmDeleteDeployment,
+    handleShowLogs,
+    getDashboardStatValue,
+    drillToDeployment,
+    drillToNamespace,
+  } = useWorkloads()
 
   return (
     <DashboardPage
@@ -356,200 +77,35 @@ export function Workloads() {
         description: t('workloads.emptyDescription')
       }}
     >
-      {loadError && (
-        <div className="mb-4 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-400 shrink-0 mt-0.5" />
-            <div className="flex-1">
-              <p className="text-sm font-medium text-red-400">{t('workloads.errorLoading', 'Could not load workload data')}</p>
-              <p className="text-xs text-muted-foreground mt-1">{loadError}</p>
-              <button
-                type="button"
-                onClick={handleRefresh}
-                className="mt-3 inline-flex items-center rounded-lg bg-red-500/15 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/25"
-              >
-                {t('common.retry', 'Retry')}
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
-      {/* Workloads List */}
+      <WorkloadsErrorBanner error={loadError} onRetry={handleRefresh} t={t} />
+
       {showSkeletons ? (
-        <div data-testid="workloads-loading-state" className="space-y-3">
-          {Array.from({ length: WORKLOAD_SKELETON_COUNT }, (_, i) => (
-            <div key={i} data-testid="workload-row-skeleton" className="glass p-4 rounded-lg border-l-4 border-l-gray-500/50">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-4">
-                  <Skeleton variant="circular" width={24} height={24} />
-                  <div>
-                    <Skeleton variant="text" width={150} height={20} className="mb-1" />
-                    <Skeleton variant="rounded" width={80} height={18} />
-                  </div>
-                </div>
-                <Skeleton variant="text" width={100} height={20} />
-              </div>
-            </div>
-          ))}
-        </div>
+        <WorkloadSkeletonList />
       ) : apps.length === 0 ? (
-        <div data-testid="workloads-empty-state" className="text-center py-12">
-          <div className="text-6xl mb-4">📦</div>
-          <p className="text-lg text-foreground">{t('workloads.noWorkloadsTitle', 'No workloads found')}</p>
-          <p className="text-sm text-muted-foreground mb-6">{t('workloads.noWorkloadsDesc', 'No deployments detected across your clusters')}</p>
-          <button
-            data-testid="empty-state-deploy-workload-btn"
-            onClick={() => setShowImportDialog(true)}
-            className="inline-flex items-center gap-2 px-5 py-2.5 text-sm font-medium rounded-lg bg-purple-600 hover:bg-purple-500 text-white transition-colors"
-          >
-            <Plus className="w-4 h-4" />
-            {t('workloads.deployWorkload', 'Create a Workload')}
-          </button>
-        </div>
+        <WorkloadsEmptyState onDeploy={() => setShowImportDialog(true)} t={t} />
       ) : (
         <div data-testid="workloads-list" className="space-y-3">
-          {apps.map((item, i) => {
-            const isDeployment = item.type === 'deployment'
-            const app = item as AppSummary
-            const deploy = item as DeploymentSummary
-
-            const status = isDeployment
-              ? (deploy.status === 'failed' ? 'error' : deploy.status === 'deploying' ? 'warning' : 'healthy')
-              : app.status
-
-            return (
-              <div
-                key={i}
-                data-testid="workload-row"
-                onClick={() => isDeployment
-                  ? drillToDeployment(deploy.cluster, deploy.namespace, deploy.name)
-                  : drillToNamespace(app.cluster, app.namespace)
-                }
-                className={`glass p-4 rounded-lg cursor-pointer transition-all hover:scale-[1.01] border-l-4 ${status === 'error' ? 'border-l-red-500' :
-                  status === 'warning' ? 'border-l-yellow-500' :
-                    'border-l-green-500'
-                  }`}
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex items-center gap-4">
-                    <StatusIndicator status={status as Status} size="lg" />
-                    <div>
-                      <h3 className="font-semibold text-foreground">{isDeployment ? deploy.name : app.namespace}</h3>
-                      <div className="flex items-center gap-2">
-                        <ClusterBadge cluster={getClusterDisplayName(item.cluster)} size="sm" />
-                        {isDeployment && <span className="text-xs text-muted-foreground">{deploy.namespace}</span>}
-                      </div>
-                    </div>
-                  </div>
-
-                  <div className="flex items-center gap-6">
-                    {isDeployment ? (
-                      <>
-                        <div className="text-center">
-                          <div className="text-lg font-bold text-foreground">{deploy.readyReplicas}/{deploy.replicas}</div>
-                          <div className="text-xs text-muted-foreground">{t('common.ready')}</div>
-                        </div>
-                        <div className="flex items-center gap-1">
-                          <PortalTooltip content={t('common.restart', 'Restart')}>
-                            <button
-                              data-testid="action-btn-restart"
-                              onClick={(e) => handleRestartDeployment(e, deploy.cluster, deploy.namespace, deploy.name)}
-                              className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-blue-400 transition-colors"
-                              aria-label="Restart deployment"
-                            >
-                              <RefreshCw className="w-4 h-4" />
-                            </button>
-                          </PortalTooltip>
-
-                          <PortalTooltip content={t('common.logs', 'Logs')}>
-                            <button
-                              data-testid="action-btn-logs"
-                              onClick={(e) => handleShowLogs(e, deploy.cluster, deploy.namespace, deploy.name)}
-                              className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-purple-400 transition-colors"
-                              aria-label="View logs"
-                            >
-                              <Terminal className="w-4 h-4" />
-                            </button>
-                          </PortalTooltip>
-
-                          <PortalTooltip content={t('common.delete', 'Delete')}>
-                            <button
-                              data-testid="action-btn-delete"
-                              onClick={(e) => handleDeleteDeployment(e, deploy.cluster, deploy.namespace, deploy.name)}
-                              className="p-1.5 hover:bg-secondary/50 rounded-md text-muted-foreground hover:text-red-400 transition-colors"
-                              aria-label="Delete deployment"
-                            >
-                              <Trash2 className="w-4 h-4" />
-                            </button>
-                          </PortalTooltip>
-                        </div>
-                      </>
-                    ) : (
-                      <>
-                        <div className="text-center">
-                          <div className="text-lg font-bold text-foreground">{app.deploymentCount}</div>
-                          <div className="text-xs text-muted-foreground">{t('common.deployments')}</div>
-                        </div>
-                        {app.deploymentIssues > 0 && (
-                          <div className="text-center">
-                            <div className="text-lg font-bold text-orange-400">{app.deploymentIssues}</div>
-                            <div className="text-xs text-muted-foreground">Issues</div>
-                          </div>
-                        )}
-                        {app.podIssues > 0 && (
-                          <div className="text-center">
-                            <div className="text-lg font-bold text-red-400">{app.podIssues}</div>
-                            <div className="text-xs text-muted-foreground">Pod Issues</div>
-                          </div>
-                        )}
-                      </>
-                    )}
-                    <ChevronRight className="w-4 h-4 text-muted-foreground" />
-                  </div>
-                </div>
-              </div>
-            )
-          })}
+          {apps.map((item, i) => (
+            <WorkloadRow
+              key={i}
+              item={item}
+              onDrillToDeployment={drillToDeployment}
+              onDrillToNamespace={drillToNamespace}
+              onRestart={handleRestartDeployment}
+              onLogs={handleShowLogs}
+              onDelete={handleDeleteDeployment}
+              t={t}
+            />
+          ))}
         </div>
       )}
 
-      {/* Clusters Summary */}
-      <div data-testid="clusters-overview-section" className="mt-8">
-        <h2 data-testid="clusters-overview-heading" className="text-lg font-semibold text-foreground mb-4">Clusters Overview</h2>
-        <div data-testid="clusters-overview-grid" className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
-          {forceSkeletonForOffline ? (
-            // Show skeleton when agent is offline and demo mode is OFF
-            Array.from({ length: WORKLOAD_SKELETON_COUNT }, (_, i) => (
-              <div key={i} className="glass p-3 rounded-lg">
-                <div className="flex items-center gap-2 mb-2">
-                  <Skeleton variant="circular" width={16} height={16} />
-                  <Skeleton variant="text" width={100} height={16} />
-                </div>
-                <Skeleton variant="text" width={80} height={12} />
-              </div>
-            ))
-          ) : (
-            clusters
-              .filter(cluster => isAllClustersSelected || globalSelectedClusters.includes(cluster.name))
-              .map((cluster) => (
-                <div key={cluster.name} data-testid="cluster-card" className="glass p-3 rounded-lg">
-                  <div className="flex items-center gap-2 mb-2">
-                    <StatusIndicator
-                      status={cluster.reachable === false ? 'unreachable' : cluster.healthy ? 'healthy' : 'error'}
-                      size="sm"
-                    />
-                    <span className="font-medium text-foreground text-sm truncate">
-                      {cluster.context || getClusterDisplayName(cluster.name)}
-                    </span>
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {cluster.reachable !== false ? (cluster.podCount ?? '-') : '-'} pods • {cluster.reachable !== false ? (cluster.nodeCount ?? '-') : '-'} nodes
-                  </div>
-                </div>
-              ))
-          )}
-        </div>
-      </div>
+      <ClustersOverview
+        clusters={clusters}
+        isAllClustersSelected={isAllClustersSelected}
+        globalSelectedClusters={globalSelectedClusters}
+        forceSkeletonForOffline={forceSkeletonForOffline}
+      />
 
       <WorkloadImportDialog
         isOpen={showImportDialog}

--- a/web/src/components/workloads/Workloads.types.ts
+++ b/web/src/components/workloads/Workloads.types.ts
@@ -1,0 +1,22 @@
+export interface AppSummary {
+  namespace: string
+  cluster: string
+  deploymentCount: number
+  podIssues: number
+  deploymentIssues: number
+  status: 'healthy' | 'warning' | 'error'
+  type: 'namespace'
+}
+
+export interface DeploymentSummary {
+  name: string
+  namespace: string
+  cluster: string
+  status: 'running' | 'deploying' | 'failed'
+  replicas: number
+  readyReplicas: number
+  type: 'deployment'
+  image?: string
+}
+
+export type WorkloadItem = AppSummary | DeploymentSummary

--- a/web/src/components/workloads/useWorkloads.ts
+++ b/web/src/components/workloads/useWorkloads.ts
@@ -1,0 +1,301 @@
+import { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useDeploymentIssues, usePodIssues, useClusters, useDeployments } from '../../hooks/useMCP'
+import { useGlobalFilters } from '../../hooks/useGlobalFilters'
+import { useDrillDownActions } from '../../hooks/useDrillDown'
+import { useLocalAgent, wasAgentEverConnected } from '../../hooks/useLocalAgent'
+import { isInClusterMode } from '../../hooks/useBackendHealth'
+import { useDemoMode } from '../../hooks/useDemoMode'
+import { useIsModeSwitching } from '../../lib/unified/demo'
+import { useToast } from '../ui/Toast'
+import { kubectlProxy } from '../../lib/kubectlProxy'
+import type { StatBlockValue } from '../ui/StatsOverview'
+import type { Workload } from '../cards/WorkloadDeployment'
+import { isLocalAgentSuppressed } from '../../lib/constants'
+import type { AppSummary, DeploymentSummary, WorkloadItem } from './Workloads.types'
+
+const POD_ISSUES_ERROR_THRESHOLD = 3
+
+function mapImportedWorkload(workload: Workload): DeploymentSummary {
+  const IMPORTED_WORKLOAD_CLUSTER = 'Imported'
+  return {
+    name: workload.name,
+    namespace: workload.namespace,
+    cluster: workload.targetClusters[0] || IMPORTED_WORKLOAD_CLUSTER,
+    status: 'deploying',
+    replicas: workload.replicas,
+    readyReplicas: workload.readyReplicas,
+    type: 'deployment',
+    image: workload.image,
+  }
+}
+
+export function useWorkloads() {
+  const { t } = useTranslation()
+  const { issues: podIssues, isLoading: podIssuesLoading, isRefreshing: podIssuesRefreshing, error: podIssuesError, lastUpdated: podLastUpdated, refetch: refetchPodIssues } = usePodIssues()
+  const { issues: deploymentIssues, isLoading: deploymentIssuesLoading, isRefreshing: deploymentIssuesRefreshing, error: deploymentIssuesError, lastUpdated: deploymentLastUpdated, refetch: refetchDeploymentIssues } = useDeploymentIssues()
+  const { deployments: allDeployments, isLoading: deploymentsLoading, isRefreshing: deploymentsRefreshing, error: deploymentsError, lastUpdated: deploymentsLastUpdated, refetch: refetchDeployments } = useDeployments()
+  const { deduplicatedClusters: clusters, isLoading: clustersLoading, error: clustersError, lastUpdated: clustersLastUpdated, refetch: refetchClusters } = useClusters()
+
+  const lastUpdated = useMemo(() => {
+    const timestamps = [podLastUpdated, deploymentLastUpdated, deploymentsLastUpdated, clustersLastUpdated].filter(
+      (ts): ts is Date => ts !== null && ts !== undefined
+    )
+    if (timestamps.length === 0) return null
+    return timestamps.reduce((latest, current) => (current > latest ? current : latest))
+  }, [podLastUpdated, deploymentLastUpdated, deploymentsLastUpdated, clustersLastUpdated])
+
+  const { status: agentStatus } = useLocalAgent()
+  const { isDemoMode } = useDemoMode()
+  const isModeSwitching = useIsModeSwitching()
+
+  const { drillToNamespace, drillToAllNamespaces, drillToAllDeployments, drillToAllPods, drillToDeployment } = useDrillDownActions()
+  const { showToast } = useToast()
+  const [pendingDelete, setPendingDelete] = useState<{ cluster: string; namespace: string; name: string } | null>(null)
+  const [showImportDialog, setShowImportDialog] = useState(false)
+  const [importedWorkloads, setImportedWorkloads] = useState<Workload[]>([])
+
+  const handleImportWorkloads = useCallback((newWorkloads: Workload[]) => {
+    setImportedWorkloads(prev => [...prev, ...newWorkloads])
+    showToast(t('workloads.importSuccess', 'Workload added to the list'), 'success')
+  }, [showToast, t])
+
+  const deployments = useMemo(
+    () => [...allDeployments, ...importedWorkloads.map(mapImportedWorkload)],
+    [allDeployments, importedWorkloads],
+  )
+
+  const isLoading = podIssuesLoading || deploymentIssuesLoading || deploymentsLoading || clustersLoading
+  const isRefreshing = podIssuesRefreshing || deploymentIssuesRefreshing || deploymentsRefreshing
+  const loadError = podIssuesError || deploymentIssuesError || deploymentsError || clustersError
+  const isAgentOffline = agentStatus === 'disconnected'
+  const forceSkeletonForOffline = !isDemoMode && isAgentOffline && !isInClusterMode() && !isLocalAgentSuppressed() && !wasAgentEverConnected()
+  const showSkeletons = ((deployments.length === 0 && podIssues.length === 0 && deploymentIssues.length === 0) && isLoading) || forceSkeletonForOffline || isModeSwitching
+
+  const handleRefresh = () => {
+    if (isRefreshing) return
+    refetchPodIssues()
+    refetchDeploymentIssues()
+    refetchDeployments()
+    refetchClusters()
+  }
+
+  const handleRestartDeployment = async (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
+    e.stopPropagation()
+    try {
+      showToast(t('workloads.restarting', 'Restarting deployment...'), 'info')
+      await kubectlProxy.exec(['rollout', 'restart', 'deployment', name, '-n', namespace], { context: cluster })
+      showToast(t('workloads.restartSuccess', 'Restart triggered'), 'success')
+      refetchDeployments()
+    } catch {
+      showToast(t('workloads.restartError', 'Failed to restart deployment'), 'error')
+    }
+  }
+
+  const handleDeleteDeployment = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
+    e.stopPropagation()
+    setPendingDelete({ cluster, namespace, name })
+  }
+
+  const confirmDeleteDeployment = async () => {
+    if (!pendingDelete) return
+    const { cluster, namespace, name } = pendingDelete
+    setPendingDelete(null)
+    try {
+      showToast(t('workloads.deleting', 'Deleting deployment...'), 'info')
+      await kubectlProxy.exec(['delete', 'deployment', name, '-n', namespace], { context: cluster })
+      showToast(t('workloads.deleteSuccess', 'Deployment deleted'), 'success')
+      refetchDeployments()
+    } catch {
+      showToast(t('workloads.deleteError', 'Failed to delete deployment'), 'error')
+    }
+  }
+
+  const handleShowLogs = (e: React.MouseEvent, cluster: string, namespace: string, name: string) => {
+    e.stopPropagation()
+    drillToDeployment(cluster, namespace, name, { tab: 'pods' })
+  }
+
+  const { selectedClusters: globalSelectedClusters, isAllClustersSelected, customFilter } = useGlobalFilters()
+
+  const apps = useMemo(() => {
+    let filteredDeployments = deployments
+    let filteredPodIssues = podIssues
+    let filteredDeploymentIssues = deploymentIssues
+
+    if (!isAllClustersSelected) {
+      filteredDeployments = filteredDeployments.filter(d =>
+        d.cluster && globalSelectedClusters.includes(d.cluster)
+      )
+      filteredPodIssues = filteredPodIssues.filter(issue =>
+        issue.cluster && globalSelectedClusters.includes(issue.cluster)
+      )
+      filteredDeploymentIssues = filteredDeploymentIssues.filter(issue =>
+        issue.cluster && globalSelectedClusters.includes(issue.cluster)
+      )
+    }
+
+    if (customFilter.trim()) {
+      const query = customFilter.toLowerCase()
+      filteredDeployments = filteredDeployments.filter(d =>
+        d.name.toLowerCase().includes(query) ||
+        d.namespace.toLowerCase().includes(query) ||
+        (d.cluster && d.cluster.toLowerCase().includes(query))
+      )
+      filteredPodIssues = filteredPodIssues.filter(issue =>
+        issue.name.toLowerCase().includes(query) ||
+        issue.namespace.toLowerCase().includes(query) ||
+        (issue.cluster && issue.cluster.toLowerCase().includes(query))
+      )
+      filteredDeploymentIssues = filteredDeploymentIssues.filter(issue =>
+        issue.name.toLowerCase().includes(query) ||
+        issue.namespace.toLowerCase().includes(query) ||
+        (issue.cluster && issue.cluster.toLowerCase().includes(query))
+      )
+    }
+
+    if (customFilter.trim() || !isAllClustersSelected) {
+      return (filteredDeployments.map(d => ({
+        ...d,
+        type: 'deployment' as const
+      })) as WorkloadItem[]).sort((a, b) => {
+        const aName = a.type === 'deployment' ? a.name : a.namespace
+        const bName = b.type === 'deployment' ? b.name : b.namespace
+        return aName.localeCompare(bName)
+      })
+    }
+
+    const appMap = new Map<string, AppSummary>()
+    filteredDeployments.forEach(deployment => {
+      const key = `${deployment.cluster}/${deployment.namespace}`
+      if (!appMap.has(key)) {
+        appMap.set(key, {
+          namespace: deployment.namespace,
+          cluster: deployment.cluster || 'unknown',
+          deploymentCount: 0,
+          podIssues: 0,
+          deploymentIssues: 0,
+          status: 'healthy',
+          type: 'namespace'
+        })
+      }
+      const app = appMap.get(key)!
+      app.deploymentCount++
+    })
+
+    filteredPodIssues.forEach(issue => {
+      const key = `${issue.cluster}/${issue.namespace}`
+      if (!appMap.has(key)) {
+        appMap.set(key, {
+          namespace: issue.namespace,
+          cluster: issue.cluster || 'unknown',
+          deploymentCount: 0,
+          podIssues: 0,
+          deploymentIssues: 0,
+          status: 'healthy',
+          type: 'namespace'
+        })
+      }
+      const app = appMap.get(key)!
+      app.podIssues++
+      app.status = app.podIssues > POD_ISSUES_ERROR_THRESHOLD ? 'error' : 'warning'
+    })
+
+    filteredDeploymentIssues.forEach(issue => {
+      const key = `${issue.cluster}/${issue.namespace}`
+      if (!appMap.has(key)) {
+        appMap.set(key, {
+          namespace: issue.namespace,
+          cluster: issue.cluster || 'unknown',
+          deploymentCount: 0,
+          podIssues: 0,
+          deploymentIssues: 0,
+          status: 'healthy',
+          type: 'namespace'
+        })
+      }
+      const app = appMap.get(key)!
+      app.deploymentIssues++
+      if (app.deploymentIssues > 3) {
+        app.status = 'error'
+      } else if (app.status === 'healthy') {
+        app.status = 'warning'
+      }
+    })
+
+    return (Array.from(appMap.values()) as WorkloadItem[]).sort((a, b) => {
+      const aStats = a as AppSummary
+      const bStats = b as AppSummary
+      const statusOrder: Record<string, number> = { error: 0, critical: 0, warning: 1, healthy: 2 }
+      if (statusOrder[aStats.status] !== statusOrder[bStats.status]) {
+        return statusOrder[aStats.status] - statusOrder[bStats.status]
+      }
+      return bStats.deploymentCount - aStats.deploymentCount
+    })
+  }, [deployments, podIssues, deploymentIssues, globalSelectedClusters, isAllClustersSelected, customFilter])
+
+  const stats = useMemo(() => {
+    const namespaceApps = apps.filter(a => a.type === 'namespace') as AppSummary[]
+    return {
+      total: namespaceApps.length || apps.length,
+      healthy: namespaceApps.filter(a => a.status === 'healthy').length,
+      warning: namespaceApps.filter(a => a.status === 'warning').length,
+      critical: namespaceApps.filter(a => a.status === 'error').length,
+      totalDeployments: deployments.length,
+      totalPodIssues: podIssues.length,
+      totalDeploymentIssues: deploymentIssues.length
+    }
+  }, [apps, deployments, podIssues, deploymentIssues])
+
+  const getDashboardStatValue = (blockId: string): StatBlockValue => {
+    switch (blockId) {
+      case 'namespaces':
+        return { value: stats.total, sublabel: t('workloads.activeNamespaces'), onClick: () => drillToAllNamespaces(), isClickable: apps.length > 0 }
+      case 'critical':
+        return { value: stats.critical, sublabel: t('workloads.criticalIssues'), onClick: () => drillToAllNamespaces('critical'), isClickable: stats.critical > 0 }
+      case 'warning':
+        return { value: stats.warning, sublabel: t('workloads.warningIssues'), onClick: () => drillToAllNamespaces('warning'), isClickable: stats.warning > 0 }
+      case 'healthy':
+        return { value: stats.healthy, sublabel: t('workloads.healthyNamespaces'), onClick: () => drillToAllNamespaces('healthy'), isClickable: stats.healthy > 0 }
+      case 'deployments':
+        return { value: stats.totalDeployments, sublabel: t('workloads.totalDeployments'), onClick: () => drillToAllDeployments(), isClickable: stats.totalDeployments > 0 }
+      case 'pod_issues':
+        return { value: stats.totalPodIssues, sublabel: t('workloads.podIssues'), onClick: () => drillToAllPods('issues'), isClickable: stats.totalPodIssues > 0 }
+      case 'deployment_issues':
+        return { value: stats.totalDeploymentIssues, sublabel: t('workloads.deploymentIssues'), onClick: () => drillToAllDeployments('issues'), isClickable: stats.totalDeploymentIssues > 0 }
+      default:
+        return { value: '-', sublabel: '' }
+    }
+  }
+
+  return {
+    t,
+    apps,
+    stats,
+    clusters,
+    deployments,
+    podIssues,
+    deploymentIssues,
+    isLoading,
+    isRefreshing,
+    loadError,
+    lastUpdated,
+    showSkeletons,
+    forceSkeletonForOffline,
+    globalSelectedClusters,
+    isAllClustersSelected,
+    pendingDelete,
+    setPendingDelete,
+    showImportDialog,
+    setShowImportDialog,
+    handleImportWorkloads,
+    handleRefresh,
+    handleRestartDeployment,
+    handleDeleteDeployment,
+    confirmDeleteDeployment,
+    handleShowLogs,
+    getDashboardStatValue,
+    drillToDeployment,
+    drillToNamespace,
+  }
+}

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -157,10 +157,24 @@ configuredI18n.init({
 
 export default i18n
 
+// Recursively widen every leaf value of a translation resource object to
+// `string`. This keeps full type-safety for translation *keys* (used by
+// `t()` autocompletion and dot-path validation) while avoiding a TypeScript
+// compiler crash ("Debug Failure: No error for last overload signature")
+// that occurs when huge translation JSON files (our `common.json`/`cards.json`
+// are ~10k lines combined) are used as literal `typeof` types directly in
+// i18next's heavily-overloaded `t()` signature. Without this, the sheer
+// number of distinct string-literal leaf types combined with `t()`'s
+// overload set trips an internal TS assertion during `tsc -b`.
+// See: https://github.com/microsoft/TypeScript/issues/63195
+type FlattenLeafValues<T> = {
+  [K in keyof T]: T[K] extends object ? FlattenLeafValues<T[K]> : string
+}
+
 // Type-safe translation keys
 declare module 'i18next' {
   interface CustomTypeOptions {
     defaultNS: typeof defaultNS
-    resources: typeof resources['en']
+    resources: FlattenLeafValues<typeof resources['en']>
   }
 }

--- a/web/src/test/route-smoke.test.ts
+++ b/web/src/test/route-smoke.test.ts
@@ -105,7 +105,8 @@ function findModalFiles(): string[] {
         /\.(tsx?)$/.test(entry.name) &&
         /(Modal|Dialog)\.(tsx?)$/.test(entry.name) &&
         !entry.name.endsWith('.test.tsx') &&
-        !entry.name.endsWith('.test.ts')
+        !entry.name.endsWith('.test.ts') &&
+        !entry.name.startsWith('use') // hook files (e.g. useSyncDialog.ts) aren't components
       ) {
         results.push(full)
       }


### PR DESCRIPTION
Fixes #21777

## Summary

Splits three oversized workload/gitops components into `X.tsx` + `X.parts.tsx` + `useX.ts` following the established `RemediationConsole`/`DrillDownModal` pattern.

| File | Before | After (main) |
|------|--------|--------------|
| `Workloads.tsx` | 570 lines, 9 hooks | 126 lines |
| `GitOps.tsx` | 616 lines, 15 hooks | 85 lines |
| `SyncDialog.tsx` | 495 lines, 12 hooks | 124 lines |

### New files
- `web/src/components/workloads/useWorkloads.ts` — all data fetching, filtering, derived state
- `web/src/components/workloads/Workloads.parts.tsx` — `WorkloadsErrorBanner`, `WorkloadSkeletonList`, `WorkloadsEmptyState`, `WorkloadRow`, `ClustersOverview`
- `web/src/components/workloads/Workloads.types.ts` — `AppSummary`, `DeploymentSummary`, `WorkloadItem`
- `web/src/components/gitops/useGitOps.ts` — drift detection, sync state, stat helpers
- `web/src/components/gitops/GitOps.parts.tsx` — `GitOpsFilters`, `GitOpsAppRow`, `GitOpsAppsList`, `GitOpsFiltersAndList`, `GitOpsIntegrationInfo`
- `web/src/components/gitops/GitOps.types.ts` — `GitOpsApp`, `DriftResult`, etc.
- `web/src/components/gitops/useSyncDialog.ts` — phase state, detection/sync API calls
- `web/src/components/gitops/SyncDialog.parts.tsx` — `SyncPhaseIndicator`, `DetectionPhaseContent`, `PlanPhaseContent`, `ExecutionPhaseContent`

Note: `RemediationConsole.tsx` was already split in a prior commit on this branch.