### PR TITLE
[scanner] refactor: split SecretDrillDown and ComplianceDrillDown (#21791)

### DIFF
--- a/web/src/components/drilldown/views/ComplianceDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.parts.tsx
@@ -1,0 +1,451 @@
+import { ChevronUp, ChevronDown, ChevronLeft, ChevronRight, ChevronsLeft, ChevronsRight, Search, X, Filter, Shield } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { StatusBadge } from '../../ui/StatusBadge'
+import { Input } from '../../ui/Input'
+import { Select } from '../../ui/Select'
+import { cn } from '../../../lib/cn'
+import { TOUCH_TARGET_HEIGHT_CLASS, TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
+import { PAGE_SIZE, severityColor, statusIcon, statusLabel } from './compliance-drilldown'
+import type { SortField, SortDir, ControlRow } from './compliance-drilldown'
+
+// ─── Summary Stats ────────────────────────────────────────────────────────────
+
+interface ComplianceSummaryStatsProps {
+  passCount: number
+  failCount: number
+  otherCount: number
+  totalCount: number
+  statusFilter: string
+  onClearFilter: () => void
+  onPassClick: () => void
+  onFailClick: () => void
+  onOtherClick: () => void
+}
+
+/** Four-cell stat grid: total / passing / failing / other with filter toggle on click. */
+export function ComplianceSummaryStats({
+  passCount,
+  failCount,
+  otherCount,
+  totalCount,
+  statusFilter,
+  onClearFilter,
+  onPassClick,
+  onFailClick,
+  onOtherClick,
+}: ComplianceSummaryStatsProps) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
+      <button
+        onClick={onClearFilter}
+        className={cn(
+          cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
+          !statusFilter ? 'border-teal-500/40 bg-teal-500/10' : 'border-border bg-card/50 hover:border-border/80'
+        )}
+      >
+        <div className="text-xl font-bold text-foreground">{totalCount}</div>
+        <div className="text-xs text-muted-foreground">Total Controls</div>
+      </button>
+      <button
+        onClick={onPassClick}
+        className={cn(
+          cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
+          statusFilter === 'pass' ? 'border-green-500/40 bg-green-500/10' : 'border-border bg-card/50 hover:border-border/80'
+        )}
+      >
+        <div className="text-xl font-bold text-green-400">{passCount}</div>
+        <div className="text-xs text-muted-foreground">Passing</div>
+      </button>
+      <button
+        onClick={onFailClick}
+        className={cn(
+          cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
+          statusFilter === 'fail' ? 'border-red-500/40 bg-red-500/10' : 'border-border bg-card/50 hover:border-border/80'
+        )}
+      >
+        <div className="text-xl font-bold text-red-400">{failCount}</div>
+        <div className="text-xs text-muted-foreground">Failing</div>
+      </button>
+      <button
+        onClick={onOtherClick}
+        className={cn(
+          cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
+          statusFilter === 'other' ? 'border-yellow-500/40 bg-yellow-500/10' : 'border-border bg-card/50 hover:border-border/80'
+        )}
+      >
+        <div className="text-xl font-bold text-yellow-400">{otherCount}</div>
+        <div className="text-xs text-muted-foreground">Other / N/A</div>
+      </button>
+    </div>
+  )
+}
+
+// ─── Search & Filters ─────────────────────────────────────────────────────────
+
+interface ComplianceSearchFiltersProps {
+  searchQuery: string
+  showFilters: boolean
+  activeFilters: number
+  statusFilter: string
+  severityFilter: string
+  clusterFilter: string
+  profileFilter: string
+  uniqueStatuses: string[]
+  uniqueClusters: string[]
+  uniqueProfiles: string[]
+  onSearchChange: (q: string) => void
+  onToggleFilters: () => void
+  onStatusChange: (v: string) => void
+  onSeverityChange: (v: string) => void
+  onClusterChange: (v: string) => void
+  onProfileChange: (v: string) => void
+  onClearAll: () => void
+}
+
+/** Search bar with filter-toggle button and collapsible dropdown panel. */
+export function ComplianceSearchFilters({
+  searchQuery,
+  showFilters,
+  activeFilters,
+  statusFilter,
+  severityFilter,
+  clusterFilter,
+  profileFilter,
+  uniqueStatuses,
+  uniqueClusters,
+  uniqueProfiles,
+  onSearchChange,
+  onToggleFilters,
+  onStatusChange,
+  onSeverityChange,
+  onClusterChange,
+  onProfileChange,
+  onClearAll,
+}: ComplianceSearchFiltersProps) {
+  const { t } = useTranslation()
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            type="text"
+            placeholder="Search by control ID, title, or description..."
+            value={searchQuery}
+            onChange={e => onSearchChange(e.target.value)}
+            leadingIcon={<Search className="w-4 h-4" />}
+            className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
+          />
+          {searchQuery && (
+            <button
+              onClick={() => onSearchChange('')}
+              className={cn('absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground z-10', TOUCH_TARGET_SIZE_CLASS)}
+            >
+              <X className="w-4 h-4" />
+            </button>
+          )}
+        </div>
+        <button
+          onClick={onToggleFilters}
+          className={cn(
+            'flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors',
+            TOUCH_TARGET_HEIGHT_CLASS,
+            showFilters || activeFilters > 0
+              ? 'border-teal-500/40 bg-teal-500/10 text-teal-400'
+              : 'border-border bg-card/50 text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <Filter className="w-4 h-4" />
+          Filters
+          {activeFilters > 0 && (
+            <span className="ml-1 px-1.5 py-0.5 rounded-full bg-teal-500/20 text-teal-400 text-xs font-medium">
+              {activeFilters}
+            </span>
+          )}
+        </button>
+      </div>
+      {showFilters && (
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-3">
+          <Select
+            value={statusFilter}
+            onChange={e => onStatusChange(e.target.value)}
+            className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
+          >
+            <option value="">{t('drilldown.compliance.allStatuses')}</option>
+            {uniqueStatuses.map(s => (
+              <option key={s} value={s}>{statusLabel(s)}</option>
+            ))}
+          </Select>
+          <Select
+            value={severityFilter}
+            onChange={e => onSeverityChange(e.target.value)}
+            className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
+          >
+            <option value="">{t('drilldown.compliance.allSeverities')}</option>
+            <option value="critical">{t('drilldown.compliance.critical')}</option>
+            <option value="high">{t('drilldown.compliance.high')}</option>
+            <option value="medium">{t('drilldown.compliance.medium')}</option>
+            <option value="low">{t('drilldown.compliance.low')}</option>
+          </Select>
+          <Select
+            value={clusterFilter}
+            onChange={e => onClusterChange(e.target.value)}
+            className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
+          >
+            <option value="">{t('drilldown.compliance.allClusters')}</option>
+            {uniqueClusters.map(c => (
+              <option key={c} value={c}>{c}</option>
+            ))}
+          </Select>
+          <Select
+            value={profileFilter}
+            onChange={e => onProfileChange(e.target.value)}
+            className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
+          >
+            <option value="">{t('drilldown.compliance.allProfiles')}</option>
+            {uniqueProfiles.map(p => (
+              <option key={p} value={p}>{p}</option>
+            ))}
+          </Select>
+          {activeFilters > 0 && (
+            <button
+              onClick={onClearAll}
+              className={cn('col-span-2 text-left text-xs text-muted-foreground transition-colors hover:text-foreground md:col-span-4', TOUCH_TARGET_HEIGHT_CLASS)}
+            >
+              Clear all filters
+            </button>
+          )}
+        </div>
+      )}
+    </>
+  )
+}
+
+// ─── Table ────────────────────────────────────────────────────────────────────
+
+interface ComplianceTableProps {
+  pagedRows: ControlRow[]
+  sortField: SortField
+  sortDir: SortDir
+  isAggregateSummaryOnly: boolean
+  onSort: (field: SortField) => void
+}
+
+function SortIndicator({ field, sortField, sortDir }: { field: SortField; sortField: SortField; sortDir: SortDir }) {
+  if (sortField !== field) return <ChevronUp className="w-3 h-3 opacity-20" />
+  return sortDir === 'asc'
+    ? <ChevronUp className="w-3 h-3" />
+    : <ChevronDown className="w-3 h-3" />
+}
+
+/** Scrollable table of compliance controls with sortable column headers. */
+export function ComplianceTable({
+  pagedRows,
+  sortField,
+  sortDir,
+  isAggregateSummaryOnly,
+  onSort,
+}: ComplianceTableProps) {
+  return (
+    <div className="flex-1 overflow-y-auto px-6">
+      {pagedRows.length === 0 ? (
+        <div className="text-center py-16 text-muted-foreground">
+          <Shield className="w-12 h-12 mx-auto mb-3 opacity-30" />
+          <p className="font-medium">
+            {isAggregateSummaryOnly ? 'Detailed controls are unavailable for this view' : 'No controls match filters'}
+          </p>
+          <p className="text-xs mt-1">
+            {isAggregateSummaryOnly
+              ? 'The summary totals above match the values from the selected stat block.'
+              : 'Try adjusting your search or filter criteria'}
+          </p>
+        </div>
+      ) : (
+        <div className="rounded-lg border border-border overflow-hidden">
+          {/* Table header */}
+          <div className="grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px bg-border text-xs font-medium text-muted-foreground">
+            <button onClick={() => onSort('controlId')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              Control <SortIndicator field="controlId" sortField={sortField} sortDir={sortDir} />
+            </button>
+            <div className="px-3 py-2 min-h-11 bg-card/80">Description</div>
+            <button onClick={() => onSort('status')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              Status <SortIndicator field="status" sortField={sortField} sortDir={sortDir} />
+            </button>
+            <button onClick={() => onSort('severity')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              Severity <SortIndicator field="severity" sortField={sortField} sortDir={sortDir} />
+            </button>
+            <button onClick={() => onSort('cluster')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              Cluster <SortIndicator field="cluster" sortField={sortField} sortDir={sortDir} />
+            </button>
+            <button onClick={() => onSort('profile')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
+              Profile <SortIndicator field="profile" sortField={sortField} sortDir={sortDir} />
+            </button>
+          </div>
+          {/* Table rows */}
+          {pagedRows.map((row, i) => (
+            <div
+              key={`${row.cluster}-${row.controlId}-${i}`}
+              className={cn(
+                'grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px text-sm',
+                row.status === 'fail' ? 'bg-red-500/5' : 'bg-transparent',
+                'hover:bg-card/40 transition-colors'
+              )}
+            >
+              <div className="px-3 py-2.5 font-mono text-xs font-medium text-foreground truncate">
+                {row.controlId}
+              </div>
+              <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.description || row.title}>
+                {row.title}
+              </div>
+              <div className="px-3 py-2.5 flex items-center gap-1.5">
+                {statusIcon(row.status)}
+                <span className="text-xs">{statusLabel(row.status)}</span>
+              </div>
+              <div className="px-3 py-2.5">
+                {row.severity && (
+                  <span className={cn('px-2 py-0.5 rounded text-xs font-medium border', severityColor(row.severity))}>
+                    {row.severity}
+                  </span>
+                )}
+              </div>
+              <div className="px-3 py-2.5">
+                <StatusBadge color="blue" size="xs">
+                  {row.cluster.split('/').pop() || row.cluster}
+                </StatusBadge>
+              </div>
+              <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.profile}>
+                {row.profile || '-'}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Pagination ───────────────────────────────────────────────────────────────
+
+interface CompliancePaginationProps {
+  page: number
+  totalPages: number
+  totalRows: number
+  onFirst: () => void
+  onPrev: () => void
+  onNext: () => void
+  onLast: () => void
+}
+
+/** Page-nav controls shown below the table. */
+export function CompliancePagination({
+  page,
+  totalPages,
+  totalRows,
+  onFirst,
+  onPrev,
+  onNext,
+  onLast,
+}: CompliancePaginationProps) {
+  return (
+    <div className="px-6 py-3 border-t border-border flex items-center justify-between text-sm text-muted-foreground">
+      <span>
+        Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, totalRows)} of {totalRows} controls
+      </span>
+      <div className="flex items-center gap-1">
+        <button
+          onClick={onFirst}
+          disabled={page === 0}
+          className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
+          title="First page"
+          aria-label="First page"
+        >
+          <ChevronsLeft className="w-4 h-4" />
+        </button>
+        <button
+          onClick={onPrev}
+          disabled={page === 0}
+          className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
+          title="Previous page"
+          aria-label="Previous page"
+        >
+          <ChevronLeft className="w-4 h-4" />
+        </button>
+        <span className="px-3 text-xs">
+          Page {page + 1} of {totalPages}
+        </span>
+        <button
+          onClick={onNext}
+          disabled={page >= totalPages - 1}
+          className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
+          title="Next page"
+          aria-label="Next page"
+        >
+          <ChevronRight className="w-4 h-4" />
+        </button>
+        <button
+          onClick={onLast}
+          disabled={page >= totalPages - 1}
+          className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
+          title="Last page"
+          aria-label="Last page"
+        >
+          <ChevronsRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Per-Cluster Breakdown ────────────────────────────────────────────────────
+
+interface ComplianceClusterBreakdownProps {
+  uniqueClusters: string[]
+  filteredRows: ControlRow[]
+  clusterFilter: string
+  onClusterClick: (cluster: string) => void
+}
+
+/** Mini per-cluster stat grid rendered below the pagination bar. */
+export function ComplianceClusterBreakdown({
+  uniqueClusters,
+  filteredRows,
+  clusterFilter,
+  onClusterClick,
+}: ComplianceClusterBreakdownProps) {
+  return (
+    <div className="px-6 py-3 border-t border-border">
+      <p className="text-xs text-muted-foreground mb-2">Per-cluster breakdown</p>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
+        {uniqueClusters.map(cluster => {
+          const clusterRows = filteredRows.filter(r => r.cluster === cluster)
+          const cPass = clusterRows.filter(r => r.status === 'pass').length
+          const cFail = clusterRows.filter(r => r.status === 'fail').length
+          const cTotal = clusterRows.length
+          const cScore = cTotal > 0 ? Math.round((cPass / cTotal) * 100) : 0
+          return (
+            <button
+              key={cluster}
+              onClick={() => onClusterClick(cluster)}
+              className={cn(
+                'rounded-lg border p-2 text-left transition-colors',
+                TOUCH_TARGET_HEIGHT_CLASS,
+                clusterFilter === cluster ? 'border-blue-500/40 bg-blue-500/10' : 'border-border bg-card/50 hover:border-border/80'
+              )}
+            >
+              <div className="text-xs font-medium text-foreground truncate">{cluster.split('/').pop() || cluster}</div>
+              <div className="flex items-center gap-2 mt-1">
+                <span className="text-xs text-green-400">{cPass} pass</span>
+                <span className="text-xs text-red-400">{cFail} fail</span>
+                <span className={cn(
+                  'text-xs font-bold ml-auto',
+                  cScore >= 80 ? 'text-green-400' : cScore >= 60 ? 'text-yellow-400' : 'text-red-400'
+                )}>
+                  {cScore}%
+                </span>
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -70,7 +70,7 @@ export function ComplianceDrillDown({ data }: Props) {
 
   // Unique values for filter dropdowns
   const uniqueClusters = [...new Set(allRows.map(r => r.cluster))].sort()
-  const uniqueProfiles = useMemo(() => [...new Set(allRows.map(r => r.profile).filter(Boolean))].sort(), [allRows])
+  const uniqueProfiles = useMemo(() => [...new Set(allRows.map(r => r.profile).filter((profile): profile is string => Boolean(profile)))].sort(), [allRows])
   const uniqueStatuses = [...new Set(allRows.map(r => r.status))].sort()
 
   // Filtered rows

--- a/web/src/components/drilldown/views/ComplianceDrillDown.tsx
+++ b/web/src/components/drilldown/views/ComplianceDrillDown.tsx
@@ -7,20 +7,11 @@
  */
 
 import { useState, useMemo } from 'react'
+import { Shield, ChevronLeft } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
-import {
-  Shield,
-  ChevronUp, ChevronDown, ChevronLeft, ChevronRight,
-  ChevronsLeft, ChevronsRight,
-  Search, X, Filter } from 'lucide-react'
 import { useTrestle } from '../../../hooks/useTrestle'
 import { useGlobalFilters } from '../../../hooks/useGlobalFilters'
 import { useDrillDown } from '../../../hooks/useDrillDown'
-import { StatusBadge } from '../../ui/StatusBadge'
-import { Input } from '../../ui/Input'
-import { Select } from '../../ui/Select'
-import { cn } from '../../../lib/cn'
-import { TOUCH_TARGET_HEIGHT_CLASS, TOUCH_TARGET_SIZE_CLASS } from '../../../lib/constants/ui'
 import {
   type Props,
   type SortField,
@@ -30,11 +21,15 @@ import {
   SEVERITY_ORDER,
   STATUS_ORDER,
   normalizeComplianceStatus,
-  severityColor,
-  statusIcon,
-  statusLabel,
   computeSummaryCounts,
 } from './compliance-drilldown'
+import {
+  ComplianceSummaryStats,
+  ComplianceSearchFilters,
+  ComplianceTable,
+  CompliancePagination,
+  ComplianceClusterBreakdown,
+} from './ComplianceDrillDown.parts'
 
 export function ComplianceDrillDown({ data }: Props) {
   const { t } = useTranslation()
@@ -102,35 +97,21 @@ export function ComplianceDrillDown({ data }: Props) {
     sorted.sort((a, b) => {
       let cmp = 0
       switch (sortField) {
-        case 'controlId':
-          cmp = a.controlId.localeCompare(b.controlId)
-          break
-        case 'severity':
-          cmp = (SEVERITY_ORDER[a.severity || 'medium'] ?? 2) - (SEVERITY_ORDER[b.severity || 'medium'] ?? 2)
-          break
-        case 'status':
-          cmp = (STATUS_ORDER[a.status] ?? 2) - (STATUS_ORDER[b.status] ?? 2)
-          break
-        case 'cluster':
-          cmp = a.cluster.localeCompare(b.cluster)
-          break
-        case 'profile':
-          cmp = (a.profile || '').localeCompare(b.profile || '')
-          break
+        case 'controlId': cmp = a.controlId.localeCompare(b.controlId); break
+        case 'severity': cmp = (SEVERITY_ORDER[a.severity || 'medium'] ?? 2) - (SEVERITY_ORDER[b.severity || 'medium'] ?? 2); break
+        case 'status': cmp = (STATUS_ORDER[a.status] ?? 2) - (STATUS_ORDER[b.status] ?? 2); break
+        case 'cluster': cmp = a.cluster.localeCompare(b.cluster); break
+        case 'profile': cmp = (a.profile || '').localeCompare(b.profile || ''); break
       }
       return sortDir === 'asc' ? cmp : -cmp
     })
     return sorted
   })()
 
-  // Paginated rows
   const totalPages = Math.ceil(sortedRows.length / PAGE_SIZE)
   const pagedRows = sortedRows.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE)
-
-  // Reset page when filters change
   const resetPage = () => setPage(0)
 
-  // Sort toggle
   const toggleSort = (field: SortField) => {
     if (sortField === field) {
       setSortDir(d => d === 'asc' ? 'desc' : 'asc')
@@ -141,15 +122,7 @@ export function ComplianceDrillDown({ data }: Props) {
     resetPage()
   }
 
-  const SortIndicator = ({ field }: { field: SortField }) => {
-    if (sortField !== field) return <ChevronUp className="w-3 h-3 opacity-20" />
-    return sortDir === 'asc'
-      ? <ChevronUp className="w-3 h-3" />
-      : <ChevronDown className="w-3 h-3" />
-  }
-
-  // Summary stats — prefer aggregate values passed by the stats overview so the
-  // drill-down matches the clicked stat block even when no OSCAL rows exist.
+  // Summary stats
   const rowPassCount = allRows.filter(r => r.status === 'pass').length
   const rowFailCount = allRows.filter(r => r.status === 'fail').length
   const rowOtherCount = allRows.filter(r => r.status === 'other' || r.status === 'not-applicable').length
@@ -192,321 +165,73 @@ export function ComplianceDrillDown({ data }: Props) {
           </div>
         </div>
 
-        {/* Summary stats */}
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-4">
-          <button
-            onClick={() => { setStatusFilter(''); resetPage() }}
-            className={cn(
-              cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
-              !statusFilter ? 'border-teal-500/40 bg-teal-500/10' : 'border-border bg-card/50 hover:border-border/80'
-            )}
-          >
-            <div className="text-xl font-bold text-foreground">{totalCount}</div>
-            <div className="text-xs text-muted-foreground">Total Controls</div>
-          </button>
-          <button
-            onClick={() => { setStatusFilter(statusFilter === 'pass' ? '' : 'pass'); resetPage() }}
-            className={cn(
-              cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
-              statusFilter === 'pass' ? 'border-green-500/40 bg-green-500/10' : 'border-border bg-card/50 hover:border-border/80'
-            )}
-          >
-            <div className="text-xl font-bold text-green-400">{passCount}</div>
-            <div className="text-xs text-muted-foreground">Passing</div>
-          </button>
-          <button
-            onClick={() => { setStatusFilter(statusFilter === 'fail' ? '' : 'fail'); resetPage() }}
-            className={cn(
-              cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
-              statusFilter === 'fail' ? 'border-red-500/40 bg-red-500/10' : 'border-border bg-card/50 hover:border-border/80'
-            )}
-          >
-            <div className="text-xl font-bold text-red-400">{failCount}</div>
-            <div className="text-xs text-muted-foreground">Failing</div>
-          </button>
-          <button
-            onClick={() => { setStatusFilter(statusFilter === 'other' ? '' : 'other'); resetPage() }}
-            className={cn(
-              cn('rounded-lg border p-3 text-left transition-colors', TOUCH_TARGET_HEIGHT_CLASS),
-              statusFilter === 'other' ? 'border-yellow-500/40 bg-yellow-500/10' : 'border-border bg-card/50 hover:border-border/80'
-            )}
-          >
-            <div className="text-xl font-bold text-yellow-400">{otherCount}</div>
-            <div className="text-xs text-muted-foreground">Other / N/A</div>
-          </button>
-        </div>
+        <ComplianceSummaryStats
+          passCount={passCount}
+          failCount={failCount}
+          otherCount={otherCount}
+          totalCount={totalCount}
+          statusFilter={statusFilter}
+          onClearFilter={() => { setStatusFilter(''); resetPage() }}
+          onPassClick={() => { setStatusFilter(statusFilter === 'pass' ? '' : 'pass'); resetPage() }}
+          onFailClick={() => { setStatusFilter(statusFilter === 'fail' ? '' : 'fail'); resetPage() }}
+          onOtherClick={() => { setStatusFilter(statusFilter === 'other' ? '' : 'other'); resetPage() }}
+        />
 
-        {/* Search + filter toggle */}
-        <div className="flex items-center gap-2">
-          <div className="relative flex-1">
-            <Input
-              type="text"
-              placeholder="Search by control ID, title, or description..."
-              value={searchQuery}
-              onChange={e => { setSearchQuery(e.target.value); resetPage() }}
-              leadingIcon={<Search className="w-4 h-4" />}
-              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
-            />
-            {searchQuery && (
-              <button
-                onClick={() => { setSearchQuery(''); resetPage() }}
-                className={cn('absolute right-2 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground z-10', TOUCH_TARGET_SIZE_CLASS)}
-              >
-                <X className="w-4 h-4" />
-              </button>
-            )}
-          </div>
-          <button
-            onClick={() => setShowFilters(!showFilters)}
-            className={cn(
-              'flex items-center gap-1.5 rounded-lg border px-3 py-2 text-sm transition-colors',
-              TOUCH_TARGET_HEIGHT_CLASS,
-              showFilters || activeFilters > 0
-                ? 'border-teal-500/40 bg-teal-500/10 text-teal-400'
-                : 'border-border bg-card/50 text-muted-foreground hover:text-foreground'
-            )}
-          >
-            <Filter className="w-4 h-4" />
-            Filters
-            {activeFilters > 0 && (
-              <span className="ml-1 px-1.5 py-0.5 rounded-full bg-teal-500/20 text-teal-400 text-xs font-medium">
-                {activeFilters}
-              </span>
-            )}
-          </button>
-        </div>
-
-        {/* Filter dropdowns */}
-        {showFilters && (
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-2 mt-3">
-            <Select
-              value={statusFilter}
-              onChange={e => { setStatusFilter(e.target.value); resetPage() }}
-              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
-            >
-              <option value="">{t('drilldown.compliance.allStatuses')}</option>
-              {uniqueStatuses.map(s => (
-                <option key={s} value={s}>{statusLabel(s)}</option>
-              ))}
-            </Select>
-            <Select
-              value={severityFilter}
-              onChange={e => { setSeverityFilter(e.target.value); resetPage() }}
-              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
-            >
-              <option value="">{t('drilldown.compliance.allSeverities')}</option>
-              <option value="critical">{t('drilldown.compliance.critical')}</option>
-              <option value="high">{t('drilldown.compliance.high')}</option>
-              <option value="medium">{t('drilldown.compliance.medium')}</option>
-              <option value="low">{t('drilldown.compliance.low')}</option>
-            </Select>
-            <Select
-              value={clusterFilter}
-              onChange={e => { setClusterFilter(e.target.value); resetPage() }}
-              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
-            >
-              <option value="">{t('drilldown.compliance.allClusters')}</option>
-              {uniqueClusters.map(c => (
-                <option key={c} value={c}>{c}</option>
-              ))}
-            </Select>
-            <Select
-              value={profileFilter}
-              onChange={e => { setProfileFilter(e.target.value); resetPage() }}
-              className={cn('bg-card/50', TOUCH_TARGET_HEIGHT_CLASS)}
-            >
-              <option value="">{t('drilldown.compliance.allProfiles')}</option>
-              {uniqueProfiles.map(p => (
-                <option key={p} value={p}>{p}</option>
-              ))}
-            </Select>
-
-            {activeFilters > 0 && (
-              <button
-                onClick={() => {
-                  setStatusFilter('')
-                  setSeverityFilter('')
-                  setClusterFilter('')
-                  setProfileFilter('')
-                  setSearchQuery('')
-                  resetPage()
-                }}
-                className={cn('col-span-2 text-left text-xs text-muted-foreground transition-colors hover:text-foreground md:col-span-4', TOUCH_TARGET_HEIGHT_CLASS)}
-              >
-                Clear all filters
-              </button>
-            )}
-          </div>
-        )}
+        <ComplianceSearchFilters
+          searchQuery={searchQuery}
+          showFilters={showFilters}
+          activeFilters={activeFilters}
+          statusFilter={statusFilter}
+          severityFilter={severityFilter}
+          clusterFilter={clusterFilter}
+          profileFilter={profileFilter}
+          uniqueStatuses={uniqueStatuses}
+          uniqueClusters={uniqueClusters}
+          uniqueProfiles={uniqueProfiles}
+          onSearchChange={q => { setSearchQuery(q); resetPage() }}
+          onToggleFilters={() => setShowFilters(!showFilters)}
+          onStatusChange={v => { setStatusFilter(v); resetPage() }}
+          onSeverityChange={v => { setSeverityFilter(v); resetPage() }}
+          onClusterChange={v => { setClusterFilter(v); resetPage() }}
+          onProfileChange={v => { setProfileFilter(v); resetPage() }}
+          onClearAll={() => {
+            setStatusFilter('')
+            setSeverityFilter('')
+            setClusterFilter('')
+            setProfileFilter('')
+            setSearchQuery('')
+            resetPage()
+          }}
+        />
       </div>
 
-      {/* Table */}
-      <div className="flex-1 overflow-y-auto px-6">
-        {pagedRows.length === 0 ? (
-          <div className="text-center py-16 text-muted-foreground">
-            <Shield className="w-12 h-12 mx-auto mb-3 opacity-30" />
-            <p className="font-medium">
-              {isAggregateSummaryOnly ? 'Detailed controls are unavailable for this view' : 'No controls match filters'}
-            </p>
-            <p className="text-xs mt-1">
-              {isAggregateSummaryOnly
-                ? 'The summary totals above match the values from the selected stat block.'
-                : 'Try adjusting your search or filter criteria'}
-            </p>
-          </div>
-        ) : (
-          <div className="rounded-lg border border-border overflow-hidden">
-            {/* Table header */}
-            <div className="grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px bg-border text-xs font-medium text-muted-foreground">
-              <button onClick={() => toggleSort('controlId')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
-                Control <SortIndicator field="controlId" />
-              </button>
-              <div className="px-3 py-2 min-h-11 bg-card/80">Description</div>
-              <button onClick={() => toggleSort('status')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
-                Status <SortIndicator field="status" />
-              </button>
-              <button onClick={() => toggleSort('severity')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
-                Severity <SortIndicator field="severity" />
-              </button>
-              <button onClick={() => toggleSort('cluster')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
-                Cluster <SortIndicator field="cluster" />
-              </button>
-              <button onClick={() => toggleSort('profile')} className="flex min-w-11 min-h-11 items-center gap-1 px-3 py-2 bg-card/80 hover:bg-card transition-colors">
-                Profile <SortIndicator field="profile" />
-              </button>
-            </div>
+      <ComplianceTable
+        pagedRows={pagedRows}
+        sortField={sortField}
+        sortDir={sortDir}
+        isAggregateSummaryOnly={isAggregateSummaryOnly}
+        onSort={toggleSort}
+      />
 
-            {/* Table rows */}
-            {pagedRows.map((row, i) => (
-              <div
-                key={`${row.cluster}-${row.controlId}-${i}`}
-                className={cn(
-                  'grid grid-cols-[1fr_2fr_100px_100px_120px_120px] gap-px text-sm',
-                  row.status === 'fail' ? 'bg-red-500/5' : 'bg-transparent',
-                  'hover:bg-card/40 transition-colors'
-                )}
-              >
-                <div className="px-3 py-2.5 font-mono text-xs font-medium text-foreground truncate">
-                  {row.controlId}
-                </div>
-                <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.description || row.title}>
-                  {row.title}
-                </div>
-                <div className="px-3 py-2.5 flex items-center gap-1.5">
-                  {statusIcon(row.status)}
-                  <span className="text-xs">{statusLabel(row.status)}</span>
-                </div>
-                <div className="px-3 py-2.5">
-                  {row.severity && (
-                    <span className={cn('px-2 py-0.5 rounded text-xs font-medium border', severityColor(row.severity))}>
-                      {row.severity}
-                    </span>
-                  )}
-                </div>
-                <div className="px-3 py-2.5">
-                  <StatusBadge color="blue" size="xs">
-                    {row.cluster.split('/').pop() || row.cluster}
-                  </StatusBadge>
-                </div>
-                <div className="px-3 py-2.5 text-xs text-muted-foreground truncate" title={row.profile}>
-                  {row.profile || '-'}
-                </div>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-
-      {/* Pagination */}
       {totalPages > 1 && (
-        <div className="px-6 py-3 border-t border-border flex items-center justify-between text-sm text-muted-foreground">
-          <span>
-            Showing {page * PAGE_SIZE + 1}--{Math.min((page + 1) * PAGE_SIZE, sortedRows.length)} of {sortedRows.length} controls
-          </span>
-          <div className="flex items-center gap-1">
-            {/* First/Last use the single-glyph ChevronsLeft/ChevronsRight (double-chevron)
-                instead of two overlapping single chevrons — reads as one control instead of
-                two arrows side-by-side. */}
-            <button
-              onClick={() => setPage(0)}
-              disabled={page === 0}
-              className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
-              title="First page"
-              aria-label="First page"
-            >
-              <ChevronsLeft className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => setPage(p => Math.max(0, p - 1))}
-              disabled={page === 0}
-              className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
-              title="Previous page"
-              aria-label="Previous page"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </button>
-            <span className="px-3 text-xs">
-              Page {page + 1} of {totalPages}
-            </span>
-            <button
-              onClick={() => setPage(p => Math.min(totalPages - 1, p + 1))}
-              disabled={page >= totalPages - 1}
-              className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
-              title="Next page"
-              aria-label="Next page"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </button>
-            <button
-              onClick={() => setPage(totalPages - 1)}
-              disabled={page >= totalPages - 1}
-              className="p-2 rounded hover:bg-card/50 disabled:opacity-30 disabled:cursor-not-allowed transition-colors min-h-11 min-w-11"
-              title="Last page"
-              aria-label="Last page"
-            >
-              <ChevronsRight className="w-4 h-4" />
-            </button>
-          </div>
-        </div>
+        <CompliancePagination
+          page={page}
+          totalPages={totalPages}
+          totalRows={sortedRows.length}
+          onFirst={() => setPage(0)}
+          onPrev={() => setPage(p => Math.max(0, p - 1))}
+          onNext={() => setPage(p => Math.min(totalPages - 1, p + 1))}
+          onLast={() => setPage(totalPages - 1)}
+        />
       )}
 
-      {/* Per-cluster breakdown */}
       {uniqueClusters.length > 1 && (
-        <div className="px-6 py-3 border-t border-border">
-          <p className="text-xs text-muted-foreground mb-2">Per-cluster breakdown</p>
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-2">
-            {uniqueClusters.map(cluster => {
-              const clusterRows = filteredRows.filter(r => r.cluster === cluster)
-              const cPass = clusterRows.filter(r => r.status === 'pass').length
-              const cFail = clusterRows.filter(r => r.status === 'fail').length
-              const cTotal = clusterRows.length
-              const cScore = cTotal > 0 ? Math.round((cPass / cTotal) * 100) : 0
-              return (
-                <button
-                  key={cluster}
-                  onClick={() => { setClusterFilter(clusterFilter === cluster ? '' : cluster); resetPage() }}
-                  className={cn(
-                    'rounded-lg border p-2 text-left transition-colors',
-                    TOUCH_TARGET_HEIGHT_CLASS,
-                    clusterFilter === cluster ? 'border-blue-500/40 bg-blue-500/10' : 'border-border bg-card/50 hover:border-border/80'
-                  )}
-                >
-                  <div className="text-xs font-medium text-foreground truncate">{cluster.split('/').pop() || cluster}</div>
-                  <div className="flex items-center gap-2 mt-1">
-                    <span className="text-xs text-green-400">{cPass} pass</span>
-                    <span className="text-xs text-red-400">{cFail} fail</span>
-                    <span className={cn(
-                      'text-xs font-bold ml-auto',
-                      cScore >= 80 ? 'text-green-400' : cScore >= 60 ? 'text-yellow-400' : 'text-red-400'
-                    )}>
-                      {cScore}%
-                    </span>
-                  </div>
-                </button>
-              )
-            })}
-          </div>
-        </div>
+        <ComplianceClusterBreakdown
+          uniqueClusters={uniqueClusters}
+          filteredRows={filteredRows}
+          clusterFilter={clusterFilter}
+          onClusterClick={cluster => { setClusterFilter(clusterFilter === cluster ? '' : cluster); resetPage() }}
+        />
       )}
     </div>
   )

--- a/web/src/components/drilldown/views/SecretDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.parts.tsx
@@ -1,0 +1,402 @@
+import { ChevronDown, ChevronUp, Loader2, Copy, Check, ChevronLeft, Layers, Server, Eye, EyeOff, Lock, Tag } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { ClusterBadge } from '../../ui/ClusterBadge'
+import { cn } from '../../../lib/cn'
+import { maskKubernetesYamlData } from '../../../lib/yamlMask'
+import type { SecretTab, TabType } from './useSecretDrillDown'
+
+// ─── Header ──────────────────────────────────────────────────────────────────
+
+interface SecretHeaderBreadcrumbsProps {
+  cluster: string
+  namespace: string
+  canGoBack: boolean
+  onBack: () => void
+  onNamespaceClick: () => void
+  onClusterClick: () => void
+}
+
+/** Navigation breadcrumbs: back button, namespace chip, cluster chip. */
+export function SecretHeaderBreadcrumbs({
+  cluster,
+  namespace,
+  canGoBack,
+  onBack,
+  onNamespaceClick,
+  onClusterClick,
+}: SecretHeaderBreadcrumbsProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="px-6 pt-6 pb-4">
+      <div className="flex items-center gap-6 text-sm">
+        {canGoBack && (
+          <button
+            type="button"
+            onClick={onBack}
+            className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
+            aria-label={t('drilldown.goBack')}
+            title={t('drilldown.goBack')}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            <span>{t('common.back')}</span>
+          </button>
+        )}
+        <button
+          type="button"
+          onClick={onNamespaceClick}
+          className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Layers className="w-4 h-4 text-purple-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
+          <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
+          <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+        <button
+          type="button"
+          onClick={onClusterClick}
+          className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
+        >
+          <Server className="w-4 h-4 text-blue-400" />
+          <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
+          <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
+          <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  )
+}
+
+// ─── Tab Bar ─────────────────────────────────────────────────────────────────
+
+interface SecretTabBarProps {
+  tabs: SecretTab[]
+  activeTab: TabType
+  onTabChange: (tab: TabType) => void
+}
+
+/** Horizontal tab bar for the Secret drill-down. */
+export function SecretTabBar({ tabs, activeTab, onTabChange }: SecretTabBarProps) {
+  return (
+    <div className="border-b border-border px-6">
+      <div className="flex gap-1">
+        {tabs.map((tab) => {
+          const Icon = tab.icon
+          return (
+            <button
+              key={tab.id}
+              onClick={() => onTabChange(tab.id)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium flex items-center gap-2 border-b-2 transition-colors',
+                activeTab === tab.id
+                  ? 'text-primary border-primary'
+                  : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
+              )}
+            >
+              <Icon className="w-4 h-4" />
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+// ─── Overview Tab ─────────────────────────────────────────────────────────────
+
+interface SecretOverviewTabProps {
+  secretName: string
+  secretType: string | null
+  dataLoading: boolean
+  dataError: string | null
+  dataEntries: [string, string][]
+  labels: Record<string, string> | null
+}
+
+/** Overview tab: basic info card, labels, secret key list. */
+export function SecretOverviewTab({
+  secretName,
+  secretType,
+  dataLoading,
+  dataError,
+  dataEntries,
+  labels,
+}: SecretOverviewTabProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-6">
+      {dataLoading && (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="w-5 h-5 animate-spin text-primary" />
+          <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
+        </div>
+      )}
+      {dataError && !dataLoading && (
+        <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
+          <p className="text-sm text-red-400">{dataError}</p>
+        </div>
+      )}
+      {/* Basic Info */}
+      <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20">
+        <div className="flex items-center gap-3">
+          <Lock className="w-8 h-8 text-red-400" />
+          <div>
+            <div className="text-lg font-semibold text-foreground">{secretName}</div>
+            <div className="text-sm text-muted-foreground">
+              Type: {secretType} • {dataEntries.length} key{dataEntries.length !== 1 ? 's' : ''}
+            </div>
+          </div>
+        </div>
+      </div>
+      {/* Labels */}
+      {labels && Object.keys(labels).length > 0 && (
+        <div>
+          <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
+            <Tag className="w-4 h-4 text-blue-400" />
+            Labels
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(labels).slice(0, 5).map(([key, value]) => (
+              <span key={key} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
+                {key}={value}
+              </span>
+            ))}
+            {Object.keys(labels).length > 5 && (
+              <span className="text-xs text-muted-foreground">+{Object.keys(labels).length - 5} more</span>
+            )}
+          </div>
+        </div>
+      )}
+      {/* Data Keys */}
+      <div>
+        <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
+          <Lock className="w-4 h-4 text-red-400" />
+          Secret Keys
+        </h3>
+        {dataEntries.length > 0 ? (
+          <div className="flex flex-wrap gap-2">
+            {dataEntries.map(([key]) => (
+              <span key={key} className="text-xs px-2 py-1 rounded bg-red-500/10 text-red-400 font-mono">
+                {key}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">No data in this Secret</p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─── Data Tab ─────────────────────────────────────────────────────────────────
+
+interface SecretDataTabProps {
+  dataEntries: [string, string][]
+  displayedData: [string, string][]
+  revealedKeys: Set<string>
+  copiedField: string | null
+  showAllData: boolean
+  onToggleReveal: (key: string) => void
+  onCopy: (field: string, value: string) => void
+  onToggleShowAll: () => void
+}
+
+/** Data tab: key/value rows with per-key reveal and copy controls. */
+export function SecretDataTab({
+  dataEntries,
+  displayedData,
+  revealedKeys,
+  copiedField,
+  showAllData,
+  onToggleReveal,
+  onCopy,
+  onToggleShowAll,
+}: SecretDataTabProps) {
+  return (
+    <div className="space-y-4">
+      <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
+        <Lock className="w-4 h-4" />
+        Secret values are hidden by default. Click the eye icon to reveal.
+      </div>
+      {dataEntries.length > 0 ? (
+        <>
+          {displayedData.map(([key, value]) => (
+            <div key={key} className="rounded-lg bg-card/50 border border-border overflow-hidden">
+              <div className="flex items-center justify-between px-3 py-2 bg-red-500/10 border-b border-border">
+                <span className="font-mono text-sm text-red-400">{key}</span>
+                <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => onToggleReveal(key)}
+                    className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                  >
+                    {revealedKeys.has(key) ? (
+                      <EyeOff className="w-4 h-4" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                  </button>
+                  <button
+                    onClick={() => onCopy(`data-${key}`, value)}
+                    className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
+                  >
+                    {copiedField === `data-${key}` ? (
+                      <Check className="w-4 h-4 text-green-400" />
+                    ) : (
+                      <Copy className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+              <pre className="p-3 text-xs font-mono text-foreground whitespace-pre-wrap max-h-48 overflow-auto">
+                {revealedKeys.has(key) ? value : '••••••••••••••••'}
+              </pre>
+            </div>
+          ))}
+          {dataEntries.length > 5 && (
+            <button
+              onClick={onToggleShowAll}
+              className="text-xs text-primary hover:text-primary/80 flex items-center gap-1"
+            >
+              {showAllData ? (
+                <>Show less <ChevronUp className="w-3 h-3" /></>
+              ) : (
+                <>Show all {dataEntries.length} keys <ChevronDown className="w-3 h-3" /></>
+              )}
+            </button>
+          )}
+        </>
+      ) : (
+        <div className="p-4 rounded-lg bg-card/50 border border-border text-center text-muted-foreground">
+          No data in this Secret
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── Describe Tab ─────────────────────────────────────────────────────────────
+
+interface SecretDescribeTabProps {
+  describeLoading: boolean
+  describeOutput: string | null
+  copiedField: string | null
+  onCopy: (field: string, value: string) => void
+}
+
+/** Describe tab: raw kubectl describe output with copy button. */
+export function SecretDescribeTab({
+  describeLoading,
+  describeOutput,
+  copiedField,
+  onCopy,
+}: SecretDescribeTabProps) {
+  const { t } = useTranslation()
+  return (
+    <div>
+      {describeLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          <span className="ml-2 text-muted-foreground">{t('drilldown.status.runningDescribe')}</span>
+        </div>
+      ) : describeOutput ? (
+        <div className="relative">
+          <button
+            onClick={() => onCopy('describe', describeOutput)}
+            className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+          >
+            {copiedField === 'describe' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
+          </button>
+          <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+            {describeOutput}
+          </pre>
+        </div>
+      ) : (
+        <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── YAML Tab ─────────────────────────────────────────────────────────────────
+
+interface SecretYamlTabProps {
+  yamlLoading: boolean
+  yamlOutput: string | null
+  yamlRevealed: boolean
+  copiedField: string | null
+  onToggleReveal: () => void
+  onCopy: (field: string, value: string) => void
+}
+
+/** YAML tab: masked-by-default YAML output with reveal toggle and copy. */
+export function SecretYamlTab({
+  yamlLoading,
+  yamlOutput,
+  yamlRevealed,
+  copiedField,
+  onToggleReveal,
+  onCopy,
+}: SecretYamlTabProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="space-y-3">
+      {/* #6209: same warning the Data tab uses, so the YAML tab is no
+          longer the easy bypass for the per-key reveal model. */}
+      <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
+        <Lock className="w-4 h-4" />
+        {yamlRevealed
+          ? 'Secret values are visible. Click the eye icon to mask.'
+          : 'Secret values are hidden by default. Click the eye icon to reveal.'}
+      </div>
+      {yamlLoading ? (
+        <div className="flex items-center justify-center py-12">
+          <Loader2 className="w-6 h-6 animate-spin text-primary" />
+          <span className="ml-2 text-muted-foreground">{t('drilldown.status.fetchingYaml')}</span>
+        </div>
+      ) : yamlOutput ? (
+        <div className="relative">
+          {(() => {
+            // Compute once per render so the Copy button puts the
+            // SAME bytes onto the clipboard that the user is looking
+            // at — masked when masked, raw when revealed (#6209).
+            const displayedYaml = yamlRevealed ? yamlOutput : maskKubernetesYamlData(yamlOutput)
+            return (
+              <>
+                <div className="absolute top-2 right-2 flex items-center gap-1">
+                  <button
+                    onClick={onToggleReveal}
+                    className="p-1 rounded bg-secondary/50 text-muted-foreground hover:text-foreground"
+                    aria-label={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
+                    title={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
+                  >
+                    {yamlRevealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                  <button
+                    onClick={() => onCopy('yaml', displayedYaml)}
+                    className="px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
+                  >
+                    {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
+                  </button>
+                </div>
+                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
+                  {displayedYaml}
+                </pre>
+              </>
+            )
+          })()}
+        </div>
+      ) : (
+        <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
+          <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/web/src/components/drilldown/views/SecretDrillDown.tsx
+++ b/web/src/components/drilldown/views/SecretDrillDown.tsx
@@ -1,20 +1,3 @@
-import { useState, useEffect, useRef } from 'react'
-import { useLocalAgent } from '../../../hooks/useLocalAgent'
-import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
-import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
-import { ClusterBadge } from '../../ui/ClusterBadge'
-import { FileText, Code, Info, Tag, ChevronDown, ChevronUp, Loader2, Copy, Check, ChevronLeft, Layers, Server, Eye, EyeOff, Lock } from 'lucide-react'
-import { cn } from '../../../lib/cn'
-import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
-import { useTranslation } from 'react-i18next'
-import { copyToClipboard } from '../../../lib/clipboard'
-
-interface Props {
-  data: Record<string, unknown>
-}
-
-type TabType = 'overview' | 'data' | 'describe' | 'yaml'
-
 // #6231: the regex-based maskSecretYaml that used to live here had two
 // real bugs (block-scalar handling, false bundle-bloat claim about
 // js-yaml). Replaced by a shared js-yaml-based helper in lib/yamlMask.
@@ -25,431 +8,103 @@ import { maskKubernetesYamlData } from '../../../lib/yamlMask'
 /** @deprecated use `maskKubernetesYamlData` from `lib/yamlMask` */
 export const maskSecretYaml = maskKubernetesYamlData
 
-/** Property names that must never be used as object keys (prototype pollution prevention). */
-const UNSAFE_PROP_NAMES = new Set(['__proto__', 'constructor', 'prototype'])
+import { useSecretDrillDown } from './useSecretDrillDown'
+import {
+  SecretHeaderBreadcrumbs,
+  SecretTabBar,
+  SecretOverviewTab,
+  SecretDataTab,
+  SecretDescribeTab,
+  SecretYamlTab,
+} from './SecretDrillDown.parts'
+
+interface Props {
+  data: Record<string, unknown>
+}
 
 export function SecretDrillDown({ data }: Props) {
-  const { t } = useTranslation()
-  const cluster = data.cluster as string
-  const namespace = data.namespace as string
-  const secretName = data.secret as string
-  const { isConnected: agentConnected } = useLocalAgent()
-  const { drillToNamespace, drillToCluster } = useDrillDownActions()
-  const { state, pop } = useDrillDown()
-  const { runKubectl } = useDrillDownWebSocket(cluster)
-
-  const [activeTab, setActiveTab] = useState<TabType>('overview')
-  const [secretData, setSecretData] = useState<Record<string, string> | null>(null)
-  const [secretType, setSecretType] = useState<string | null>(null)
-  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
-  const [describeLoading, setDescribeLoading] = useState(false)
-  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
-  const [yamlLoading, setYamlLoading] = useState(false)
-  const [dataLoading, setDataLoading] = useState(false)
-  const [dataError, setDataError] = useState<string | null>(null)
-  const [labels, setLabels] = useState<Record<string, string> | null>(null)
-  const [copiedField, setCopiedField] = useState<string | null>(null)
-  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const [showAllData, setShowAllData] = useState(false)
-  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
-  // YAML tab reveal state — defaults to MASKED so the `data:` block doesn't
-  // leak base64-encoded secrets the moment a user clicks the YAML tab
-  // (#6209). Mirrors the per-key reveal pattern on the Data tab — explicit
-  // user action required to see secrets.
-  const [yamlRevealed, setYamlRevealed] = useState(false)
-
-
-  // Fetch Secret data
-  const fetchData = async () => {
-    if (!agentConnected) return
-    setDataLoading(true)
-    setDataError(null)
-    try {
-      const output = await runKubectl(['get', 'secret', secretName, '-n', namespace, '-o', 'json'])
-      if (output) {
-        const secret = JSON.parse(output)
-        // Decode base64 data (use null-prototype object to prevent prototype pollution)
-        const decodedData: Record<string, string> = Object.create(null) as Record<string, string>
-        if (secret.data) {
-          for (const [key, value] of Object.entries(secret.data)) {
-            if (UNSAFE_PROP_NAMES.has(key)) continue
-            try {
-              decodedData[key] = atob(value as string)
-            } catch {
-              decodedData[key] = value as string
-            }
-          }
-        }
-        setSecretData(decodedData)
-        setSecretType(secret.type || 'Opaque')
-        setLabels(secret.metadata?.labels || {})
-      }
-    } catch (err) {
-      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load Secret data'))
-    } finally {
-      setDataLoading(false)
-    }
-  }
-
-  const fetchDescribe = async () => {
-    if (!agentConnected || describeOutput) return
-    setDescribeLoading(true)
-    const output = await runKubectl(['describe', 'secret', secretName, '-n', namespace])
-    setDescribeOutput(output)
-    setDescribeLoading(false)
-  }
-
-  const fetchYaml = async () => {
-    if (!agentConnected || yamlOutput) return
-    setYamlLoading(true)
-    const output = await runKubectl(['get', 'secret', secretName, '-n', namespace, '-o', 'yaml'])
-    setYamlOutput(output)
-    setYamlLoading(false)
-  }
-
-  // Track if we've already loaded data to prevent refetching
-  const hasLoadedRef = useRef(false)
-
-  // Pre-fetch tab data when agent connects
-  // Batched to limit concurrent WebSocket connections (max 2 at a time)
-  useEffect(() => {
-    if (!agentConnected || hasLoadedRef.current) return
-    hasLoadedRef.current = true
-
-    const loadData = async () => {
-      // Batch 1: Overview data (2 concurrent)
-      await Promise.all([
-        fetchData(),
-        fetchDescribe(),
-      ])
-
-      // Batch 2: YAML (lower priority)
-      await fetchYaml()
-    }
-
-    loadData()
-  }, [agentConnected, fetchData, fetchDescribe, fetchYaml])
-
-  useEffect(() => {
-    return () => {
-      if (copiedFieldTimeoutRef.current) {
-        clearTimeout(copiedFieldTimeoutRef.current)
-      }
-    }
-  }, [])
-
-  const handleCopy = (field: string, value: string) => {
-    copyToClipboard(value)
-    setCopiedField(field)
-    if (copiedFieldTimeoutRef.current) {
-      clearTimeout(copiedFieldTimeoutRef.current)
-    }
-    copiedFieldTimeoutRef.current = setTimeout(() => {
-      setCopiedField(null)
-      copiedFieldTimeoutRef.current = null
-    }, UI_FEEDBACK_TIMEOUT_MS)
-  }
-
-  const toggleReveal = (key: string) => {
-    setRevealedKeys(prev => {
-      const next = new Set(prev)
-      if (next.has(key)) {
-        next.delete(key)
-      } else {
-        next.add(key)
-      }
-      return next
-    })
-  }
-
-  const TABS: { id: TabType; label: string; icon: typeof Info }[] = [
-    { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
-    { id: 'data', label: t('drilldown.tabs.data', 'Data'), icon: Lock },
-    { id: 'describe', label: t('drilldown.tabs.describe', 'Describe'), icon: FileText },
-    { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
-  ]
-
-  const dataEntries = Object.entries(secretData || {})
-  const displayedData = showAllData ? dataEntries : dataEntries.slice(0, 5)
+  const {
+    cluster,
+    namespace,
+    secretName,
+    drillToNamespace,
+    drillToCluster,
+    stackLength,
+    pop,
+    activeTab,
+    setActiveTab,
+    tabs,
+    secretType,
+    dataLoading,
+    dataError,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    yamlRevealed,
+    toggleYamlRevealed,
+    copiedField,
+    handleCopy,
+    showAllData,
+    setShowAllData,
+    revealedKeys,
+    toggleReveal,
+    dataEntries,
+    displayedData,
+    labels,
+  } = useSecretDrillDown(data)
 
   return (
     <div className="flex flex-col h-full -m-6">
-      {/* Header */}
-      <div className="px-6 pt-6 pb-4">
-        <div className="flex items-center gap-6 text-sm">
-          {state.stack.length > 1 && (
-            <button
-              type="button"
-              onClick={pop}
-              className="flex items-center gap-2 hover:bg-secondary/50 border border-transparent hover:border-border px-3 py-1.5 rounded-lg transition-all text-muted-foreground hover:text-foreground"
-              aria-label={t('drilldown.goBack')}
-              title={t('drilldown.goBack')}
-            >
-              <ChevronLeft className="w-4 h-4" />
-              <span>{t('common.back')}</span>
-            </button>
-          )}
-          <button
-            type="button"
-            onClick={() => drillToNamespace(cluster, namespace)}
-            className="flex items-center gap-2 hover:bg-purple-500/10 border border-transparent hover:border-purple-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-          >
-            <Layers className="w-4 h-4 text-purple-400" />
-            <span className="text-muted-foreground">{t('drilldown.fields.namespace')}</span>
-            <span className="font-mono text-purple-400 group-hover:text-purple-300 transition-colors">{namespace}</span>
-            <svg className="w-3 h-3 text-purple-400/70 group-hover:text-purple-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-          <button
-            type="button"
-            onClick={() => drillToCluster(cluster)}
-            className="flex items-center gap-2 hover:bg-blue-500/10 border border-transparent hover:border-blue-500/30 px-3 py-1.5 rounded-lg transition-all group cursor-pointer"
-          >
-            <Server className="w-4 h-4 text-blue-400" />
-            <span className="text-muted-foreground">{t('drilldown.fields.cluster')}</span>
-            <ClusterBadge cluster={cluster.split('/').pop() || cluster} size="sm" />
-            <svg className="w-3 h-3 text-blue-400/70 group-hover:text-blue-400 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-            </svg>
-          </button>
-        </div>
-      </div>
-
-      {/* Tabs */}
-      <div className="border-b border-border px-6">
-        <div className="flex gap-1">
-          {TABS.map((tab) => {
-            const Icon = tab.icon
-            return (
-              <button
-                key={tab.id}
-                onClick={() => setActiveTab(tab.id)}
-                className={cn(
-                  'px-4 py-2 text-sm font-medium flex items-center gap-2 border-b-2 transition-colors',
-                  activeTab === tab.id
-                    ? 'text-primary border-primary'
-                    : 'text-muted-foreground border-transparent hover:text-foreground hover:border-border'
-                )}
-              >
-                <Icon className="w-4 h-4" />
-                {tab.label}
-              </button>
-            )
-          })}
-        </div>
-      </div>
-
-      {/* Tab Content */}
+      <SecretHeaderBreadcrumbs
+        cluster={cluster}
+        namespace={namespace}
+        canGoBack={stackLength > 1}
+        onBack={pop}
+        onNamespaceClick={() => drillToNamespace(cluster, namespace)}
+        onClusterClick={() => drillToCluster(cluster)}
+      />
+      <SecretTabBar tabs={tabs} activeTab={activeTab} onTabChange={setActiveTab} />
       <div className="flex-1 overflow-y-auto p-6 space-y-6">
         {activeTab === 'overview' && (
-          <div className="space-y-6">
-            {dataLoading && (
-              <div className="flex items-center justify-center py-6">
-                <Loader2 className="w-5 h-5 animate-spin text-primary" />
-                <span className="ml-2 text-sm text-muted-foreground">{t('common.loading', 'Loading...')}</span>
-              </div>
-            )}
-            {dataError && !dataLoading && (
-              <div className="p-3 rounded-lg bg-red-500/10 border border-red-500/20">
-                <p className="text-sm text-red-400">{dataError}</p>
-              </div>
-            )}
-            {/* Basic Info */}
-            <div className="p-4 rounded-lg bg-red-500/10 border border-red-500/20">
-              <div className="flex items-center gap-3">
-                <Lock className="w-8 h-8 text-red-400" />
-                <div>
-                  <div className="text-lg font-semibold text-foreground">{secretName}</div>
-                  <div className="text-sm text-muted-foreground">
-                    Type: {secretType} • {dataEntries.length} key{dataEntries.length !== 1 ? 's' : ''}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            {/* Labels */}
-            {labels && Object.keys(labels).length > 0 && (
-              <div>
-                <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
-                  <Tag className="w-4 h-4 text-blue-400" />
-                  Labels
-                </h3>
-                <div className="flex flex-wrap gap-2">
-                  {Object.entries(labels).slice(0, 5).map(([key, value]) => (
-                    <span key={key} className="text-xs px-2 py-1 rounded bg-blue-500/10 text-blue-400 font-mono">
-                      {key}={value}
-                    </span>
-                  ))}
-                  {Object.keys(labels).length > 5 && (
-                    <span className="text-xs text-muted-foreground">+{Object.keys(labels).length - 5} more</span>
-                  )}
-                </div>
-              </div>
-            )}
-
-            {/* Data Keys */}
-            <div>
-              <h3 className="text-sm font-semibold text-foreground mb-2 flex items-center gap-2">
-                <Lock className="w-4 h-4 text-red-400" />
-                Secret Keys
-              </h3>
-              {dataEntries.length > 0 ? (
-                <div className="flex flex-wrap gap-2">
-                  {dataEntries.map(([key]) => (
-                    <span key={key} className="text-xs px-2 py-1 rounded bg-red-500/10 text-red-400 font-mono">
-                      {key}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <p className="text-sm text-muted-foreground">No data in this Secret</p>
-              )}
-            </div>
-          </div>
+          <SecretOverviewTab
+            secretName={secretName}
+            secretType={secretType}
+            dataLoading={dataLoading}
+            dataError={dataError}
+            dataEntries={dataEntries}
+            labels={labels}
+          />
         )}
-
         {activeTab === 'data' && (
-          <div className="space-y-4">
-            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
-              <Lock className="w-4 h-4" />
-              Secret values are hidden by default. Click the eye icon to reveal.
-            </div>
-            {dataEntries.length > 0 ? (
-              <>
-                {displayedData.map(([key, value]) => (
-                  <div key={key} className="rounded-lg bg-card/50 border border-border overflow-hidden">
-                    <div className="flex items-center justify-between px-3 py-2 bg-red-500/10 border-b border-border">
-                      <span className="font-mono text-sm text-red-400">{key}</span>
-                      <div className="flex items-center gap-1">
-                        <button
-                          onClick={() => toggleReveal(key)}
-                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
-                        >
-                          {revealedKeys.has(key) ? (
-                            <EyeOff className="w-4 h-4" />
-                          ) : (
-                            <Eye className="w-4 h-4" />
-                          )}
-                        </button>
-                        <button
-                          onClick={() => handleCopy(`data-${key}`, value)}
-                          className="p-1 rounded hover:bg-secondary/50 text-muted-foreground hover:text-foreground"
-                        >
-                          {copiedField === `data-${key}` ? (
-                            <Check className="w-4 h-4 text-green-400" />
-                          ) : (
-                            <Copy className="w-4 h-4" />
-                          )}
-                        </button>
-                      </div>
-                    </div>
-                    <pre className="p-3 text-xs font-mono text-foreground whitespace-pre-wrap max-h-48 overflow-auto">
-                      {revealedKeys.has(key) ? value : '••••••••••••••••'}
-                    </pre>
-                  </div>
-                ))}
-                {dataEntries.length > 5 && (
-                  <button
-                    onClick={() => setShowAllData(!showAllData)}
-                    className="text-xs text-primary hover:text-primary/80 flex items-center gap-1"
-                  >
-                    {showAllData ? (
-                      <>Show less <ChevronUp className="w-3 h-3" /></>
-                    ) : (
-                      <>Show all {dataEntries.length} keys <ChevronDown className="w-3 h-3" /></>
-                    )}
-                  </button>
-                )}
-              </>
-            ) : (
-              <div className="p-4 rounded-lg bg-card/50 border border-border text-center text-muted-foreground">
-                No data in this Secret
-              </div>
-            )}
-          </div>
+          <SecretDataTab
+            dataEntries={dataEntries}
+            displayedData={displayedData}
+            revealedKeys={revealedKeys}
+            copiedField={copiedField}
+            showAllData={showAllData}
+            onToggleReveal={toggleReveal}
+            onCopy={handleCopy}
+            onToggleShowAll={() => setShowAllData(!showAllData)}
+          />
         )}
-
         {activeTab === 'describe' && (
-          <div>
-            {describeLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.runningDescribe')}</span>
-              </div>
-            ) : describeOutput ? (
-              <div className="relative">
-                <button
-                  onClick={() => handleCopy('describe', describeOutput)}
-                  className="absolute top-2 right-2 px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                >
-                  {copiedField === 'describe' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                </button>
-                <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                  {describeOutput}
-                </pre>
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
-          </div>
+          <SecretDescribeTab
+            describeLoading={describeLoading}
+            describeOutput={describeOutput}
+            copiedField={copiedField}
+            onCopy={handleCopy}
+          />
         )}
-
         {activeTab === 'yaml' && (
-          <div className="space-y-3">
-            {/* #6209: same warning the Data tab uses, so the YAML tab is no
-                longer the easy bypass for the per-key reveal model. */}
-            <div className="p-3 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-sm text-yellow-400 flex items-center gap-2">
-              <Lock className="w-4 h-4" />
-              {yamlRevealed
-                ? 'Secret values are visible. Click the eye icon to mask.'
-                : 'Secret values are hidden by default. Click the eye icon to reveal.'}
-            </div>
-            {yamlLoading ? (
-              <div className="flex items-center justify-center py-12">
-                <Loader2 className="w-6 h-6 animate-spin text-primary" />
-                <span className="ml-2 text-muted-foreground">{t('drilldown.status.fetchingYaml')}</span>
-              </div>
-            ) : yamlOutput ? (
-              <div className="relative">
-                {(() => {
-                  // Compute once per render so the Copy button puts the
-                  // SAME bytes onto the clipboard that the user is looking
-                  // at — masked when masked, raw when revealed (#6209).
-                  const displayedYaml = yamlRevealed ? yamlOutput : maskSecretYaml(yamlOutput)
-                  return (
-                    <>
-                      <div className="absolute top-2 right-2 flex items-center gap-1">
-                        <button
-                          onClick={() => setYamlRevealed(v => !v)}
-                          className="p-1 rounded bg-secondary/50 text-muted-foreground hover:text-foreground"
-                          aria-label={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
-                          title={yamlRevealed ? 'Mask secret values' : 'Reveal secret values'}
-                        >
-                          {yamlRevealed ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
-                        </button>
-                        <button
-                          onClick={() => handleCopy('yaml', displayedYaml)}
-                          className="px-2 py-1 rounded bg-secondary/50 text-xs text-muted-foreground hover:text-foreground flex items-center gap-1"
-                        >
-                          {copiedField === 'yaml' ? <><Check className="w-3 h-3 text-green-400" /> Copied</> : <><Copy className="w-3 h-3" /> Copy</>}
-                        </button>
-                      </div>
-                      <pre className="p-4 rounded-lg bg-black/50 border border-border overflow-auto max-h-[60vh] text-xs text-foreground font-mono whitespace-pre-wrap">
-                        {displayedYaml}
-                      </pre>
-                    </>
-                  )
-                })()}
-              </div>
-            ) : (
-              <div className="p-4 rounded-lg bg-yellow-500/10 border border-yellow-500/20 text-center">
-                <p className="text-yellow-400">{t('drilldown.empty.localAgentNotConnected')}</p>
-              </div>
-            )}
-          </div>
+          <SecretYamlTab
+            yamlLoading={yamlLoading}
+            yamlOutput={yamlOutput}
+            yamlRevealed={yamlRevealed}
+            copiedField={copiedField}
+            onToggleReveal={toggleYamlRevealed}
+            onCopy={handleCopy}
+          />
         )}
       </div>
     </div>

--- a/web/src/components/drilldown/views/useSecretDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useSecretDrillDown.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+const mockUseLocalAgent = vi.fn()
+const mockRunKubectl = vi.fn()
+const mockCopyToClipboard = vi.fn()
+const mockPop = vi.fn()
+const mockDrillToNamespace = vi.fn()
+const mockDrillToCluster = vi.fn()
+
+vi.mock('../../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => mockUseLocalAgent(),
+}))
+
+vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
+  useDrillDownWebSocket: () => ({ runKubectl: mockRunKubectl }),
+}))
+
+vi.mock('../../../hooks/useDrillDown', () => ({
+  useDrillDown: () => ({ state: { stack: ['root'] }, pop: mockPop }),
+  useDrillDownActions: () => ({
+    drillToNamespace: mockDrillToNamespace,
+    drillToCluster: mockDrillToCluster,
+  }),
+}))
+
+vi.mock('../../../lib/clipboard', () => ({
+  copyToClipboard: (text: string) => mockCopyToClipboard(text),
+}))
+
+import { useSecretDrillDown } from './useSecretDrillDown'
+
+const baseData = { cluster: 'c1', namespace: 'ns1', secret: 'secret1' }
+
+describe('useSecretDrillDown', () => {
+  beforeEach(() => {
+    mockUseLocalAgent.mockReset()
+    mockRunKubectl.mockReset()
+    mockCopyToClipboard.mockReset()
+    mockPop.mockReset()
+    mockDrillToNamespace.mockReset()
+    mockDrillToCluster.mockReset()
+  })
+
+  it('returns idle initial state and does not fetch when agent is disconnected', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+    expect(result.current.cluster).toBe('c1')
+    expect(result.current.namespace).toBe('ns1')
+    expect(result.current.secretName).toBe('secret1')
+    expect(result.current.secretData).toBeNull()
+    expect(result.current.activeTab).toBe('overview')
+    expect(result.current.tabs.map(tb => tb.id)).toEqual(['overview', 'data', 'describe', 'yaml'])
+    expect(mockRunKubectl).not.toHaveBeenCalled()
+  })
+
+  it('success path: decodes base64 secret data and populates type/labels/describe/yaml', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const secret = {
+      type: 'kubernetes.io/tls',
+      data: { 'tls.crt': btoa('cert-value'), 'tls.key': btoa('key-value') },
+      metadata: { labels: { app: 'demo' } },
+    }
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[0] === 'get' && args[args.length - 1] === 'json') return Promise.resolve(JSON.stringify(secret))
+      if (args[0] === 'describe') return Promise.resolve('describe output')
+      return Promise.resolve('yaml output')
+    })
+
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+
+    await waitFor(() => expect(result.current.secretData).not.toBeNull())
+    expect(result.current.secretData).toEqual({ 'tls.crt': 'cert-value', 'tls.key': 'key-value' })
+    expect(result.current.secretType).toBe('kubernetes.io/tls')
+    expect(result.current.labels).toEqual({ app: 'demo' })
+    await waitFor(() => expect(result.current.describeOutput).toBe('describe output'))
+    await waitFor(() => expect(result.current.yamlOutput).toBe('yaml output'))
+  })
+
+  it('skips unsafe prototype-pollution key names when decoding secret data', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const secret = {
+      type: 'Opaque',
+      data: { safe: btoa('ok'), __proto__: btoa('bad'), constructor: btoa('bad2') },
+      metadata: {},
+    }
+    mockRunKubectl.mockResolvedValue(JSON.stringify(secret))
+
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+    await waitFor(() => expect(result.current.secretData).not.toBeNull())
+    expect(result.current.secretData).toEqual({ safe: 'ok' })
+  })
+
+  it('error path: sets dataError when fetch throws', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    mockRunKubectl.mockImplementation((args: string[]) => {
+      if (args[0] === 'get' && args[args.length - 1] === 'json') return Promise.reject(new Error('kubectl blew up'))
+      return Promise.resolve('output')
+    })
+
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+    await waitFor(() => expect(result.current.dataError).toBe('kubectl blew up'))
+    expect(result.current.dataLoading).toBe(false)
+  })
+
+  it('displayedData truncates to 5 entries until showAllData is set', async () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: true })
+    const data: Record<string, string> = {}
+    for (let i = 0; i < 8; i++) data[`key${i}`] = btoa(`val${i}`)
+    mockRunKubectl.mockResolvedValue(JSON.stringify({ type: 'Opaque', data, metadata: {} }))
+
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+    await waitFor(() => expect(result.current.dataEntries.length).toBe(8))
+    expect(result.current.displayedData.length).toBe(5)
+
+    act(() => result.current.setShowAllData(true))
+    expect(result.current.displayedData.length).toBe(8)
+  })
+
+  it('toggleReveal and toggleYamlRevealed toggle their respective flags', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+
+    expect(result.current.revealedKeys.has('k1')).toBe(false)
+    act(() => result.current.toggleReveal('k1'))
+    expect(result.current.revealedKeys.has('k1')).toBe(true)
+
+    expect(result.current.yamlRevealed).toBe(false)
+    act(() => result.current.toggleYamlRevealed())
+    expect(result.current.yamlRevealed).toBe(true)
+  })
+
+  it('handleCopy copies value and sets copiedField', () => {
+    mockUseLocalAgent.mockReturnValue({ isConnected: false })
+    const { result } = renderHook(() => useSecretDrillDown(baseData))
+
+    act(() => result.current.handleCopy('field1', 'value1'))
+    expect(mockCopyToClipboard).toHaveBeenCalledWith('value1')
+    expect(result.current.copiedField).toBe('field1')
+  })
+})

--- a/web/src/components/drilldown/views/useSecretDrillDown.ts
+++ b/web/src/components/drilldown/views/useSecretDrillDown.ts
@@ -1,0 +1,223 @@
+import { useState, useEffect, useRef } from 'react'
+import { Info, FileText, Code, Lock } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { useLocalAgent } from '../../../hooks/useLocalAgent'
+import { useDrillDownWebSocket } from '../../../hooks/useDrillDownWebSocket'
+import { useDrillDownActions, useDrillDown } from '../../../hooks/useDrillDown'
+import { UI_FEEDBACK_TIMEOUT_MS } from '../../../lib/constants/network'
+import { copyToClipboard } from '../../../lib/clipboard'
+
+/** Property names that must never be used as object keys (prototype pollution prevention). */
+const UNSAFE_PROP_NAMES = new Set(['__proto__', 'constructor', 'prototype'])
+
+export type TabType = 'overview' | 'data' | 'describe' | 'yaml'
+
+export interface SecretTab {
+  id: TabType
+  label: string
+  icon: typeof Info
+}
+
+export interface UseSecretDrillDownResult {
+  cluster: string
+  namespace: string
+  secretName: string
+  drillToNamespace: (cluster: string, namespace: string) => void
+  drillToCluster: (cluster: string) => void
+  stackLength: number
+  pop: () => void
+  activeTab: TabType
+  setActiveTab: (tab: TabType) => void
+  secretData: Record<string, string> | null
+  secretType: string | null
+  describeOutput: string | null
+  describeLoading: boolean
+  yamlOutput: string | null
+  yamlLoading: boolean
+  dataLoading: boolean
+  dataError: string | null
+  labels: Record<string, string> | null
+  copiedField: string | null
+  showAllData: boolean
+  setShowAllData: (v: boolean) => void
+  revealedKeys: Set<string>
+  yamlRevealed: boolean
+  toggleYamlRevealed: () => void
+  handleCopy: (field: string, value: string) => void
+  toggleReveal: (key: string) => void
+  tabs: SecretTab[]
+  dataEntries: [string, string][]
+  displayedData: [string, string][]
+}
+
+/**
+ * Owns all state and data fetching for the Secret drill-down view
+ * so the view component stays presentational.
+ */
+export function useSecretDrillDown(data: Record<string, unknown>): UseSecretDrillDownResult {
+  const { t } = useTranslation()
+  const cluster = data.cluster as string
+  const namespace = data.namespace as string
+  const secretName = data.secret as string
+  const { isConnected: agentConnected } = useLocalAgent()
+  const { drillToNamespace, drillToCluster } = useDrillDownActions()
+  const { state, pop } = useDrillDown()
+  const { runKubectl } = useDrillDownWebSocket(cluster)
+
+  const [activeTab, setActiveTab] = useState<TabType>('overview')
+  const [secretData, setSecretData] = useState<Record<string, string> | null>(null)
+  const [secretType, setSecretType] = useState<string | null>(null)
+  const [describeOutput, setDescribeOutput] = useState<string | null>(null)
+  const [describeLoading, setDescribeLoading] = useState(false)
+  const [yamlOutput, setYamlOutput] = useState<string | null>(null)
+  const [yamlLoading, setYamlLoading] = useState(false)
+  const [dataLoading, setDataLoading] = useState(false)
+  const [dataError, setDataError] = useState<string | null>(null)
+  const [labels, setLabels] = useState<Record<string, string> | null>(null)
+  const [copiedField, setCopiedField] = useState<string | null>(null)
+  const copiedFieldTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const [showAllData, setShowAllData] = useState(false)
+  const [revealedKeys, setRevealedKeys] = useState<Set<string>>(new Set())
+  const [yamlRevealed, setYamlRevealed] = useState(false)
+
+  const fetchData = async () => {
+    if (!agentConnected) return
+    setDataLoading(true)
+    setDataError(null)
+    try {
+      const output = await runKubectl(['get', 'secret', secretName, '-n', namespace, '-o', 'json'])
+      if (output) {
+        const secret = JSON.parse(output)
+        // Decode base64 data (use null-prototype object to prevent prototype pollution)
+        const decodedData: Record<string, string> = Object.create(null) as Record<string, string>
+        if (secret.data) {
+          for (const [key, value] of Object.entries(secret.data)) {
+            if (UNSAFE_PROP_NAMES.has(key)) continue
+            try {
+              decodedData[key] = atob(value as string)
+            } catch {
+              decodedData[key] = value as string
+            }
+          }
+        }
+        setSecretData(decodedData)
+        setSecretType(secret.type || 'Opaque')
+        setLabels(secret.metadata?.labels || {})
+      }
+    } catch (err) {
+      setDataError(err instanceof Error ? err.message : t('common.fetchFailed', 'Failed to load Secret data'))
+    } finally {
+      setDataLoading(false)
+    }
+  }
+
+  const fetchDescribe = async () => {
+    if (!agentConnected || describeOutput) return
+    setDescribeLoading(true)
+    const output = await runKubectl(['describe', 'secret', secretName, '-n', namespace])
+    setDescribeOutput(output)
+    setDescribeLoading(false)
+  }
+
+  const fetchYaml = async () => {
+    if (!agentConnected || yamlOutput) return
+    setYamlLoading(true)
+    const output = await runKubectl(['get', 'secret', secretName, '-n', namespace, '-o', 'yaml'])
+    setYamlOutput(output)
+    setYamlLoading(false)
+  }
+
+  // Track if we've already loaded data to prevent refetching
+  const hasLoadedRef = useRef(false)
+
+  // Pre-fetch tab data when agent connects
+  // Batched to limit concurrent WebSocket connections (max 2 at a time)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {
+    if (!agentConnected || hasLoadedRef.current) return
+    hasLoadedRef.current = true
+    const loadData = async () => {
+      // Batch 1: Overview data (2 concurrent)
+      await Promise.all([fetchData(), fetchDescribe()])
+      // Batch 2: YAML (lower priority)
+      await fetchYaml()
+    }
+    loadData()
+  }, [agentConnected])
+
+  useEffect(() => {
+    return () => {
+      if (copiedFieldTimeoutRef.current) {
+        clearTimeout(copiedFieldTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = (field: string, value: string) => {
+    copyToClipboard(value)
+    setCopiedField(field)
+    if (copiedFieldTimeoutRef.current) {
+      clearTimeout(copiedFieldTimeoutRef.current)
+    }
+    copiedFieldTimeoutRef.current = setTimeout(() => {
+      setCopiedField(null)
+      copiedFieldTimeoutRef.current = null
+    }, UI_FEEDBACK_TIMEOUT_MS)
+  }
+
+  const toggleReveal = (key: string) => {
+    setRevealedKeys(prev => {
+      const next = new Set(prev)
+      if (next.has(key)) {
+        next.delete(key)
+      } else {
+        next.add(key)
+      }
+      return next
+    })
+  }
+
+  const toggleYamlRevealed = () => setYamlRevealed(v => !v)
+
+  const tabs: SecretTab[] = [
+    { id: 'overview', label: t('drilldown.tabs.overview', 'Overview'), icon: Info },
+    { id: 'data', label: t('drilldown.tabs.data', 'Data'), icon: Lock },
+    { id: 'describe', label: t('drilldown.tabs.describe', 'Describe'), icon: FileText },
+    { id: 'yaml', label: t('drilldown.tabs.yaml', 'YAML'), icon: Code },
+  ]
+
+  const dataEntries = Object.entries(secretData || {})
+  const displayedData = showAllData ? dataEntries : dataEntries.slice(0, 5)
+
+  return {
+    cluster,
+    namespace,
+    secretName,
+    drillToNamespace,
+    drillToCluster,
+    stackLength: state.stack.length,
+    pop,
+    activeTab,
+    setActiveTab,
+    secretData,
+    secretType,
+    describeOutput,
+    describeLoading,
+    yamlOutput,
+    yamlLoading,
+    dataLoading,
+    dataError,
+    labels,
+    copiedField,
+    showAllData,
+    setShowAllData,
+    revealedKeys,
+    yamlRevealed,
+    toggleYamlRevealed,
+    handleCopy,
+    toggleReveal,
+    tabs,
+    dataEntries,
+    displayedData,
+  }
+}


### PR DESCRIPTION
Fixes #21791

## Summary

Splits two oversized drilldown components into `X.tsx` + `X.parts.tsx` + `useX.ts` following the established pattern.

| File | Before | After |
|------|--------|-------|
| `SecretDrillDown.tsx` | 457 lines | 112 lines |
| `useSecretDrillDown.ts` | — | 223 lines (new) |
| `SecretDrillDown.parts.tsx` | — | 402 lines (new) |
| `ComplianceDrillDown.tsx` | 515 lines | 240 lines |
| `ComplianceDrillDown.parts.tsx` | — | 451 lines (new) |

`DrillDownModal.tsx` was already reduced to 154 lines in a prior commit on this branch.

## What was split

**SecretDrillDown** — 13 hooks extracted to `useSecretDrillDown.ts`; UI parts (header breadcrumbs, tab bar, overview/data/describe/yaml tabs) extracted to `SecretDrillDown.parts.tsx`.

**ComplianceDrillDown** — UI chunks (summary stats, search+filter panel, table, pagination, per-cluster breakdown) extracted to `ComplianceDrillDown.parts.tsx`; all state and data logic remains in the main component.

No behaviour change; all exports (including `maskSecretYaml` deprecated re-export) preserved.