### PR TITLE
[scanner] fix: use common namespace key for Helm more-items link

### DIFF
--- a/web/src/components/drilldown/views/helm-release-drilldown/HelmOverviewPanel.tsx
+++ b/web/src/components/drilldown/views/helm-release-drilldown/HelmOverviewPanel.tsx
@@ -118,7 +118,7 @@ export function HelmOverviewPanel({
                 onClick={onShowMoreResources}
                 className="text-xs text-primary hover:underline"
               >
-                {t('common.moreItems', { count: parsedResources.length - 10 })}
+                {t('common:moreItems', { count: parsedResources.length - 10 })}
               </button>
             )}
           </div>


### PR DESCRIPTION
Fixes #21967

## Summary
- Use the correct namespace key syntax for the Helm overview "more items" link.
- This resolves the TypeScript build error on main without changing behavior.
