### PR TITLE
♿ Improve keyboard nav, ARIA labels, and color contrast

### DIFF
--- a/web/src/components/compliance/RiskMatrixDashboard.tsx
+++ b/web/src/components/compliance/RiskMatrixDashboard.tsx
@@ -138,14 +138,14 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
   if (loading) return (
     <div className="flex items-center justify-center h-64">
       <Loader2 className="w-8 h-8 animate-spin text-blue-400" />
-      <span className="ml-3 text-gray-300">Loading risk matrix…</span>
+      <span className="ml-3 text-muted-foreground">Loading risk matrix…</span>
     </div>
   )
 
   if (error) return (
     <div className="p-6 bg-red-500/10 border border-red-500/30 rounded-lg space-y-3">
       <p className="text-red-400 font-medium">Unable to load risk matrix data</p>
-      <p className="text-sm text-gray-300">{error}</p>
+      <p className="text-sm text-muted-foreground">{error}</p>
       <button
         onClick={fetchData}
         className="px-4 py-2 bg-red-500/20 hover:bg-red-500/30 border border-red-500/40 rounded text-sm text-red-300 transition-colors"
@@ -173,38 +173,38 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
       {summary && (
         <div className="grid grid-cols-2 md:grid-cols-6 gap-4">
           <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-300">Total Risks</p>
+            <p className="text-sm text-muted-foreground">Total Risks</p>
             <p className="text-2xl font-bold text-white">{summary.total_risks}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-red-900/30">
-            <p className="text-sm text-gray-300">Critical</p>
+            <p className="text-sm text-muted-foreground">Critical</p>
             <p className="text-2xl font-bold text-red-400">{summary.critical}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-red-700/30">
-            <p className="text-sm text-gray-300">High</p>
+            <p className="text-sm text-muted-foreground">High</p>
             <p className="text-2xl font-bold text-red-300">{summary.high}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-orange-700/30">
-            <p className="text-sm text-gray-300">Medium</p>
+            <p className="text-sm text-muted-foreground">Medium</p>
             <p className="text-2xl font-bold text-orange-400">{summary.medium}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-green-700/30">
-            <p className="text-sm text-gray-300">Low</p>
+            <p className="text-sm text-muted-foreground">Low</p>
             <p className="text-2xl font-bold text-green-400">{summary.low}</p>
           </div>
           <div className="bg-gray-800/50 rounded-lg p-4 border border-gray-700">
-            <p className="text-sm text-gray-300">Trend</p>
+            <p className="text-sm text-muted-foreground">Trend</p>
             <div className="flex items-center gap-1">
               {summary.trend_direction === 'down' ? (
                 <TrendingDown className="w-5 h-5 text-green-400" />
               ) : summary.trend_direction === 'up' ? (
                 <TrendingUp className="w-5 h-5 text-red-400" />
               ) : (
-                <ArrowRight className="w-5 h-5 text-gray-300" />
+                <ArrowRight className="w-5 h-5 text-muted-foreground" />
               )}
               <span className={`text-lg font-bold ${
                 summary.trend_direction === 'down' ? 'text-green-400' :
-                summary.trend_direction === 'up' ? 'text-red-400' : 'text-gray-300'
+                summary.trend_direction === 'up' ? 'text-red-400' : 'text-muted-foreground'
               }`}>{summary.trend_percentage}%</span>
             </div>
           </div>
@@ -215,11 +215,11 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
         {/* Heat Map */}
         <div className="bg-gray-800/50 rounded-lg border border-gray-700 p-6">
           <h2 className="text-lg font-semibold text-white mb-4">Risk Heat Map</h2>
-          <p className="text-xs text-gray-300 mb-3">Click a cell to view risks in that zone</p>
+          <p className="text-xs text-muted-foreground mb-3">Click a cell to view risks in that zone</p>
           <div className="flex">
             {/* Y-axis label */}
             <div className="flex flex-col justify-center mr-2">
-              <span className="text-xs text-gray-300 -rotate-90 whitespace-nowrap">← Likelihood →</span>
+              <span className="text-xs text-muted-foreground -rotate-90 whitespace-nowrap">← Likelihood →</span>
             </div>
             <div className="flex-1">
               {/* Grid rows — highest likelihood at top */}
@@ -227,7 +227,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 const likelihood = MATRIX_SIZE - rowIdx
                 return (
                   <div key={likelihood} className="flex items-center gap-1 mb-1">
-                    <span className="text-xs text-gray-300 w-20 text-right pr-2 truncate">{AXIS_LABELS[likelihood - 1]}</span>
+                    <span className="text-xs text-muted-foreground w-20 text-right pr-2 truncate">{AXIS_LABELS[likelihood - 1]}</span>
                     {Array.from({ length: MATRIX_SIZE }, (_, colIdx) => {
                       const impact = colIdx + 1
                       const cell = heatmapLookup.get(`${likelihood}-${impact}`)
@@ -252,10 +252,10 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
               {/* X-axis labels */}
               <div className="flex gap-1 mt-1 ml-20">
                 {IMPACT_LABELS.map(label => (
-                  <span key={label} className="flex-1 text-center text-xs text-gray-300 truncate">{label}</span>
+                  <span key={label} className="flex-1 text-center text-xs text-muted-foreground truncate">{label}</span>
                 ))}
               </div>
-              <p className="text-xs text-gray-300 text-center mt-1">← Impact →</p>
+              <p className="text-xs text-muted-foreground text-center mt-1">← Impact →</p>
             </div>
           </div>
         </div>
@@ -270,7 +270,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 </h2>
                 <button
                   onClick={() => setSelectedCell(null)}
-                  className="text-xs text-gray-300 hover:text-white"
+                  className="text-xs text-muted-foreground hover:text-white"
                 >{i18next.t('common:clearSelection', 'Clear selection')}</button>
               </div>
               {selectedRisks.length === 0 ? (
@@ -283,7 +283,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                         <span className="text-sm font-medium text-white">{risk.name}</span>
                         {severityBadge(risk.score)}
                       </div>
-                      <div className="flex gap-4 text-xs text-gray-300">
+                      <div className="flex gap-4 text-xs text-muted-foreground">
                         <span>{risk.category}</span>
                         <span>Owner: {risk.owner}</span>
                         <span className={risk.status === 'Open' ? 'text-yellow-400' : 'text-green-400'}>{risk.status}</span>
@@ -302,7 +302,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                     <span className="text-xs text-gray-500 w-6">{idx + 1}.</span>
                     <div className="flex-1 min-w-0">
                       <p className="text-sm text-white truncate">{risk.name}</p>
-                      <p className="text-xs text-gray-300">{risk.category} · {risk.owner}</p>
+                      <p className="text-xs text-muted-foreground">{risk.category} · {risk.owner}</p>
                     </div>
                     <div className="text-right">
                       <span className="text-lg font-bold text-white">{risk.score}</span>
@@ -327,7 +327,7 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
                 className="w-full rounded-t bg-gradient-to-t from-orange-600 to-orange-400 transition-all"
                 style={{ height: `${(val / 50) * 100}%` }}
               />
-              <span className="text-xs text-gray-300">M{idx + 1}</span>
+              <span className="text-xs text-muted-foreground">M{idx + 1}</span>
             </div>
           ))}
         </div>
@@ -340,13 +340,13 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
       {/* All risks table */}
       <div className="bg-gray-800/50 rounded-lg border border-gray-700 overflow-hidden">
         <div className="p-4 border-b border-gray-700 flex items-center gap-2">
-          <ChevronDown className="w-4 h-4 text-gray-300" />
+          <ChevronDown className="w-4 h-4 text-muted-foreground" />
           <h2 className="text-lg font-semibold text-white">All Risks</h2>
           <span className="text-xs text-gray-500 ml-2">({risks.length} total)</span>
         </div>
         <table className="w-full text-sm">
           <thead>
-            <tr className="text-gray-300 border-b border-gray-700">
+            <tr className="text-muted-foreground border-b border-gray-700">
               <th className="text-left p-3">ID</th>
               <th className="text-left p-3">Name</th>
               <th className="text-left p-3">Category</th>
@@ -362,16 +362,16 @@ export const RiskMatrixDashboardContent = memo(function RiskMatrixDashboardConte
               <tr key={r.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
                 <td className="p-3 font-mono text-blue-300">{r.id}</td>
                 <td className="p-3 text-white">{r.name}</td>
-                <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-gray-300 text-xs">{r.category}</span></td>
-                <td className="p-3 text-center text-gray-300">{r.likelihood}</td>
-                <td className="p-3 text-center text-gray-300">{r.impact}</td>
+                <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-muted-foreground text-xs">{r.category}</span></td>
+                <td className="p-3 text-center text-muted-foreground">{r.likelihood}</td>
+                <td className="p-3 text-center text-muted-foreground">{r.impact}</td>
                 <td className="p-3 text-center font-bold text-white">{r.score}</td>
                 <td className="p-3">{severityBadge(r.score)}</td>
                 <td className="p-3">
                   <span className={`text-xs font-medium ${
                     r.status === 'Open' ? 'text-yellow-400' :
                     r.status === 'Mitigating' ? 'text-blue-400' :
-                    r.status === 'Accepted' ? 'text-gray-300' : 'text-green-400'
+                    r.status === 'Accepted' ? 'text-muted-foreground' : 'text-green-400'
                   }`}>{r.status}</span>
                 </td>
               </tr>

--- a/web/src/components/compliance/ThreatIntelDashboard.tsx
+++ b/web/src/components/compliance/ThreatIntelDashboard.tsx
@@ -285,7 +285,7 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
                 <tr key={feed.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
                   <td className="p-3 text-white font-medium">{feed.name}</td>
                   <td className="p-3 text-gray-400">{feed.provider}</td>
-                  <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-gray-200 text-xs">{feed.category}</span></td>
+                  <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-foreground text-xs">{feed.category}</span></td>
                   <td className="p-3">
                     <span className={`flex items-center gap-1.5 ${FEED_STATUS_COLORS[feed.status]}`}>
                       {feed.status === 'active' ? <CheckCircle2 className="w-4 h-4" /> :
@@ -322,7 +322,7 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
             <tbody>
               {iocs.map(ioc => (
                 <tr key={ioc.id} className="border-b border-gray-700/50 hover:bg-gray-700/30">
-                  <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-gray-200 text-xs uppercase">{ioc.ioc_type}</span></td>
+                  <td className="p-3"><span className="px-2 py-0.5 rounded bg-gray-700 text-foreground text-xs uppercase">{ioc.ioc_type}</span></td>
                   <td className="p-3 font-mono text-blue-300 text-xs">{ioc.indicator}</td>
                   <td className="p-3 text-gray-400">{ioc.feed_name}</td>
                   <td className="p-3">
@@ -333,12 +333,12 @@ const ThreatIntelDashboard = memo(function ThreatIntelDashboard() {
                   <td className="p-3">
                     <span className="flex items-center gap-1.5">
                       {IOC_STATUS_ICON[ioc.status]}
-                      <span className="text-gray-200 capitalize">{(ioc.status ?? '').replace('_', ' ')}</span>
+                      <span className="text-foreground capitalize">{(ioc.status ?? '').replace('_', ' ')}</span>
                     </span>
                   </td>
                   <td className="p-3 text-white">{ioc.matched_resource}</td>
-                  <td className="p-3 text-gray-200">{ioc.cluster}</td>
-                  <td className="p-3 text-gray-200 text-xs">{new Date(ioc.detected_at).toLocaleString()}</td>
+                  <td className="p-3 text-foreground">{ioc.cluster}</td>
+                  <td className="p-3 text-foreground text-xs">{new Date(ioc.detected_at).toLocaleString()}</td>
                 </tr>
               ))}
             </tbody>

--- a/web/src/lib/cards/CardAIActions.tsx
+++ b/web/src/lib/cards/CardAIActions.tsx
@@ -127,6 +127,7 @@ For each issue, please:
         onKeyDown={(event) => handleActionKeyDown(event, handleDiagnose)}
         className="p-1 rounded text-muted-foreground hover:text-purple-400 hover:bg-purple-500/10 transition-colors"
         title={`Diagnose ${name}`}
+        aria-label={`Diagnose ${name}`}
       >
         <Stethoscope className="w-3.5 h-3.5" />
       </div>
@@ -139,6 +140,7 @@ For each issue, please:
           onKeyDown={(event) => handleActionKeyDown(event, handleRepair)}
           className="p-1 rounded text-muted-foreground hover:text-orange-400 hover:bg-orange-500/10 transition-colors"
           title={`${repairLabel} ${name}`}
+          aria-label={`${repairLabel} ${name}`}
         >
           <Wrench className="w-3.5 h-3.5" />
         </div>

--- a/web/src/lib/cards/CardFilterChips.tsx
+++ b/web/src/lib/cards/CardFilterChips.tsx
@@ -26,6 +26,8 @@ export function CardFilterChips({ chips, activeChip, onChipClick }: CardFilterCh
           <button
             key={chip.id}
             onClick={() => onChipClick(chip.id)}
+            aria-pressed={isActive}
+            aria-label={`Filter by ${chip.label}${chip.count !== undefined ? ` (${chip.count})` : ''}`}
             className={`flex items-center gap-1 px-2 py-1 text-xs rounded-md border transition-colors ${isActive
               ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
               : 'bg-secondary/50 border-border text-muted-foreground hover:text-foreground hover:bg-secondary'

--- a/web/src/lib/cards/CardRuntime.tsx
+++ b/web/src/lib/cards/CardRuntime.tsx
@@ -36,7 +36,7 @@
  * ```
  */
 
-import { ReactNode, useState } from 'react'
+import { ReactNode, useState, type KeyboardEvent } from 'react'
 import { getIcon } from '../icons'
 import { CardDefinition, CardColumnDefinition } from './types'
 import { useCardData, SortDirection } from './cardHooks'
@@ -370,6 +370,16 @@ export function CardRuntime({ definition, config: _config, title }: CardRuntimeP
                     key={idx}
                     className={`border-b border-border/50 ${drillDown ? 'cursor-pointer hover:bg-secondary/50' : ''}`}
                     onClick={() => drillDown && handleItemClick(item)}
+                    {...(drillDown ? {
+                      role: 'button' as const,
+                      tabIndex: 0,
+                      onKeyDown: (event: KeyboardEvent<HTMLTableRowElement>) => {
+                        if (event.key === 'Enter' || event.key === ' ') {
+                          event.preventDefault()
+                          handleItemClick(item)
+                        }
+                      },
+                    } : {})}
                   >
                     {columns?.map(col => (
                       <td

--- a/web/src/lib/stats/StatsRuntime.tsx
+++ b/web/src/lib/stats/StatsRuntime.tsx
@@ -32,7 +32,7 @@
  * ```
  */
 
-import { useState, useMemo } from 'react'
+import { useState, useMemo, type KeyboardEvent } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getIcon } from '../icons'
 import { ChevronDown, ChevronRight, Activity, Settings } from 'lucide-react'
@@ -109,10 +109,25 @@ function StatBlock({ block, value, hasData }: StatBlockProps) {
 
   const displayValue = hasData ? value.value : '-'
 
+  const handleActivate = () => {
+    if (isClickable) value.onClick?.()
+  }
+
   return (
     <div
       className={`glass p-4 rounded-lg ${isClickable ? 'cursor-pointer hover:bg-secondary/50' : ''} transition-colors`}
-      onClick={() => isClickable && value.onClick?.()}
+      onClick={handleActivate}
+      {...(isClickable ? {
+        role: 'button' as const,
+        tabIndex: 0,
+        'aria-label': block.tooltip || value.tooltip || block.label,
+        onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => {
+          if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            handleActivate()
+          }
+        },
+      } : {})}
       title={block.tooltip || value.tooltip}
     >
       <div className="flex items-center gap-2 mb-2">


### PR DESCRIPTION
Fixes #22006
Fixes #22007
Fixes #22008

## Summary

Auto-QA (Accessibility focus day) flagged keyboard-navigation gaps, ARIA-label gaps on interactive elements, and color-contrast risks. This PR addresses the real findings from those scans (several flagged lines turned out to already be accessible `<button>` elements with existing `onKeyDown`/`aria-label` handling, e.g. `PodDrillDown.tsx`, and were left untouched).

### Keyboard navigation / ARIA labels (#22006, #22008)
- **`src/lib/stats/StatsRuntime.tsx`**: clickable `StatBlock` container was a plain `div` with only `onClick`. Added `role="button"`, `tabIndex={0}`, `onKeyDown` (Enter/Space activation), and an `aria-label` derived from the tooltip/label so screen reader users get an accessible name.
- **`src/lib/cards/CardRuntime.tsx`**: table rows (`<tr>`) in the `table` visualization become clickable when `drillDown` is set, but had no keyboard equivalent. Added `role="button"`, `tabIndex={0}`, and `onKeyDown` (Enter/Space) matching the existing pattern used in `CardListItem.tsx`.
- **`src/lib/cards/CardAIActions.tsx`**: icon-only Diagnose/Repair controls (already keyboard-operable via `role="button"`/`onKeyDown`) had only a `title` attribute; added `aria-label` so assistive tech announces their purpose.
- **`src/lib/cards/CardFilterChips.tsx`**: filter chip buttons now expose `aria-pressed` (reflecting active state) and a descriptive `aria-label` including the chip's count.

### Color contrast (#22007)
- **`src/components/compliance/RiskMatrixDashboard.tsx`** / **`src/components/compliance/ThreatIntelDashboard.tsx`**: replaced raw `text-gray-200` / `text-gray-300` Tailwind utility classes with the design system's `text-foreground` / `text-muted-foreground` semantic tokens, so contrast is centrally controlled and verified rather than hardcoded per-component.

## Notes
- Per repo convention, build/lint are validated by CI on this PR (not run locally).
- Changes are scoped to the flagged accessibility issues; no unrelated refactors.
