### PR TITLE
[scanner] fix: a11y auto-qa follow-ups

### DIFF
--- a/web/src/components/drilldown/views/buildpack-drilldown/ImageDetailsPanel.tsx
+++ b/web/src/components/drilldown/views/buildpack-drilldown/ImageDetailsPanel.tsx
@@ -1,4 +1,5 @@
 import { AlertCircle, Check, Clock, Copy, GitBranch, Loader2, Package, RefreshCw } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
 import type { BuildpackStatus, KpackBuild, KpackCondition, KpackImageStatus } from './types'
 
 interface ImageDetailsPanelProps {
@@ -22,6 +23,7 @@ export function ImageDetailsPanel({
   copiedField,
   onCopy,
 }: ImageDetailsPanelProps) {
+  const { t } = useTranslation()
   const latestImage = imageInfo?.status?.latestImage || 'N/A'
   const conditions = imageInfo?.status?.conditions || []
   const readyCondition = conditions.find((c: KpackCondition) => c.type === 'Ready')
@@ -84,7 +86,12 @@ export function ImageDetailsPanel({
             <div className="p-4 rounded-lg border border-border bg-card/50">
               <div className="flex items-center justify-between mb-2">
                 <h4 className="text-sm font-medium text-foreground">Latest Image</h4>
-                <button onClick={() => onCopy('image', latestImage)} className="p-1 hover:bg-secondary rounded">
+                <button
+                  type="button"
+                  onClick={() => onCopy('image', latestImage)}
+                  aria-label={t('actions.copy')}
+                  className="p-1 min-h-11 min-w-11 flex items-center justify-center hover:bg-secondary rounded"
+                >
                   {copiedField === 'image' ? (
                     <Check className="w-3 h-3 text-green-400" />
                   ) : (

--- a/web/src/lib/cards/CardClusterFilter.tsx
+++ b/web/src/lib/cards/CardClusterFilter.tsx
@@ -81,6 +81,7 @@ export function CardClusterFilter({
         }}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
+        aria-label="Filter by cluster"
         className={`flex items-center gap-1 px-2 py-1 text-xs rounded-lg border transition-colors ${selectedClusters.length > 0
           ? 'bg-purple-500/20 border-purple-500/30 text-purple-400'
           : 'bg-secondary border-border text-muted-foreground hover:text-foreground'


### PR DESCRIPTION
Fixes #22005
Fixes #22006
Fixes #22007
Fixes #22008
Fixes #22009

## Summary

Investigated all five Auto-QA accessibility/resilience findings. Three of them (#22006 keyboard navigation, #22007 color contrast, #22008 loading/error states) were already resolved on `main` prior to this PR — verified by inspecting the current source for every file referenced in each issue (e.g. `PodDrillDown.tsx` buttons already have `type="button"`, `onKeyDown`, and focus-visible styles; `RiskMatrixDashboard.tsx`/`ThreatIntelDashboard.tsx` no longer use low-contrast gray text; the listed components already have loading/error handling). Those issues were also already closed as completed.

The remaining two open issues had genuine, narrowly-scoped bugs, fixed here:

- **#22005 (missing ARIA labels):** `CardClusterFilter.tsx`'s icon-only cluster filter trigger button (`Filter`/`ChevronDown` icons, no visible text) had no `aria-label`, so screen reader users had no accessible name for it. Added `aria-label="Filter by cluster"`, matching the existing `title` text.
- **#22009 (touch targets too small):** `ImageDetailsPanel.tsx`'s icon-only "copy image reference" button used `p-1` with a 12px icon (~24px hit area, well under the 44px WCAG 2.5.5 minimum) and also had no `aria-label`. Added the project's standard `min-h-11 min-w-11` sizing plus `aria-label={t('actions.copy')}` (reusing the existing `common:actions.copy` translation key) and `type="button"`.

## Changes
- `web/src/lib/cards/CardClusterFilter.tsx`: add `aria-label` to icon-only filter button.
- `web/src/components/drilldown/views/buildpack-drilldown/ImageDetailsPanel.tsx`: add `aria-label`, `type="button"`, and 44px touch target sizing to the copy button.

Small, surgical diff (10 lines) per the Auto-QA PR guidance.
