### PR TITLE
[scanner] test: add drilldown renderHook coverage

### DIFF
--- a/web/src/components/gitops/useGitOps.test.ts
+++ b/web/src/components/gitops/useGitOps.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+import '../../test/utils/setupMocks'
+
+// #7993 Phase 4: drift detection now fetches kc-agent's detect-drift
+// endpoint directly (not `api.post`). Match by suffix to stay agnostic of
+// LOCAL_AGENT_HTTP_URL's host.
+const DETECT_DRIFT_PATH_SUFFIX = '/gitops/detect-drift'
+const HEALTH_CHECK_PATH = '/api/health'
+const ASYNC_WAIT_TIMEOUT_MS = 2000
+
+let mockClusters: Array<{ name: string; context?: string }> = []
+
+const stableRefetch = vi.fn()
+vi.mock('../../hooks/useMCP', () => ({
+  useClusters: () => ({
+    clusters: mockClusters, deduplicatedClusters: mockClusters, isRefreshing: false, refetch: stableRefetch,
+  }),
+  useHelmReleases: () => ({ releases: [] }),
+  useOperatorSubscriptions: () => ({ subscriptions: [] }),
+}))
+
+const drillToAllHelmSpy = vi.fn()
+const drillToAllOperatorsSpy = vi.fn()
+vi.mock('../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToAllHelm: drillToAllHelmSpy, drillToAllOperators: drillToAllOperatorsSpy,
+  }),
+}))
+
+const showToastSpy = vi.fn()
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: showToastSpy }),
+}))
+
+let demoModeFlag = false
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string) => key, i18n: { language: 'en' } }),
+}))
+
+import { useGitOps } from './useGitOps'
+import * as useDemoModeModule from '../../hooks/useDemoMode'
+
+type DriftFetchResponse = { ok: boolean; body: unknown }
+let driftFetchHandler: () => DriftFetchResponse | Promise<DriftFetchResponse>
+
+describe('useGitOps', () => {
+  beforeEach(() => {
+    demoModeFlag = false
+    mockClusters = []
+    stableRefetch.mockClear()
+    drillToAllHelmSpy.mockClear()
+    drillToAllOperatorsSpy.mockClear()
+    showToastSpy.mockClear()
+    driftFetchHandler = () => ({ ok: true, body: { drifted: false, resources: [] } })
+    vi.spyOn(useDemoModeModule, 'getDemoMode').mockImplementation(() => demoModeFlag)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString()
+        if (url.includes(DETECT_DRIFT_PATH_SUFFIX)) {
+          const { ok, body } = await driftFetchHandler()
+          return { ok, json: () => Promise.resolve(body) } as unknown as Response
+        }
+        if (url.includes(HEALTH_CHECK_PATH)) {
+          return { ok: true, json: () => Promise.resolve({}) } as unknown as Response
+        }
+        return { ok: true, json: () => Promise.resolve({}) } as unknown as Response
+      })
+    )
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('returns initial state with configured apps and empty stats while checking', () => {
+    driftFetchHandler = () => new Promise(() => {})
+    const { result } = renderHook(() => useGitOps())
+    expect(result.current.apps.length).toBeGreaterThan(0)
+    expect(result.current.stats.total).toBe(result.current.apps.length)
+  })
+
+  it('success path: marks apps synced when no drift is detected', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    driftFetchHandler = () => ({ ok: true, body: { drifted: false, resources: [] } })
+    const { result } = renderHook(() => useGitOps())
+
+    await waitFor(
+      () => expect(result.current.apps.every(a => a.syncStatus === 'synced')).toBe(true),
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    expect(result.current.stats.drifted).toBe(0)
+  })
+
+  it('error path: surfaces drift-check failure without marking apps synced', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    driftFetchHandler = () => {
+      throw new Error('backend exploded')
+    }
+    const { result } = renderHook(() => useGitOps())
+
+    await waitFor(
+      () => expect(result.current.apps.some(a => a.syncStatus === 'error')).toBe(true),
+      { timeout: ASYNC_WAIT_TIMEOUT_MS }
+    )
+    const errored = result.current.apps.find(a => a.syncStatus === 'error')
+    expect(errored?.driftDetails).toEqual(['backend exploded'])
+  })
+
+  it('does not detect drift in demo mode', async () => {
+    demoModeFlag = true
+    const { result } = renderHook(() => useGitOps())
+    await waitFor(() => expect(result.current.apps.every(a => a.syncStatus !== 'checking')).toBe(true), {
+      timeout: ASYNC_WAIT_TIMEOUT_MS,
+    })
+  })
+
+  it('handleRefresh triggers refetch of clusters and re-runs drift detection', async () => {
+    mockClusters = [{ name: 'only', context: 'only' }]
+    const { result } = renderHook(() => useGitOps())
+    await waitFor(() => expect(result.current.apps.every(a => a.syncStatus !== 'checking')).toBe(true), {
+      timeout: ASYNC_WAIT_TIMEOUT_MS,
+    })
+
+    act(() => {
+      result.current.handleRefresh()
+    })
+    expect(stableRefetch).toHaveBeenCalled()
+  })
+
+  it('handleSync opens the sync dialog for the given app and handleSyncComplete marks it synced', () => {
+    const { result } = renderHook(() => useGitOps())
+    const app = result.current.apps[0]
+
+    act(() => {
+      result.current.handleSync(app)
+    })
+    expect(result.current.syncDialogApp).toEqual(app)
+
+    act(() => {
+      result.current.handleSyncComplete()
+    })
+    expect(showToastSpy).toHaveBeenCalledWith(expect.stringContaining(app.name), 'success')
+  })
+})

--- a/web/src/components/gitops/useSyncDialog.test.ts
+++ b/web/src/components/gitops/useSyncDialog.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+
+import '../../test/utils/setupMocks'
+
+// Expected endpoint hit by the hook. #7993 Phase 4 moved drift detection to
+// kc-agent, so the hook fetches ${LOCAL_AGENT_HTTP_URL}/gitops/detect-drift
+// and ${LOCAL_AGENT_HTTP_URL}/gitops/sync. We match on the path suffix to
+// stay agnostic of the exact agent host.
+const DETECT_DRIFT_PATH_SUFFIX = '/gitops/detect-drift'
+const SYNC_PATH_SUFFIX = '/gitops/sync'
+const ASYNC_WAIT_TIMEOUT_MS = 2000
+
+vi.mock('../../hooks/mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
+import { useSyncDialog } from './useSyncDialog'
+
+type FetchMock = ReturnType<typeof vi.fn>
+
+function makeFetchMock(impl: (url: string) => Promise<Response>): FetchMock {
+  return vi.fn((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    return impl(url)
+  }) as FetchMock
+}
+
+function mockResponse(body: unknown, ok = true): Response {
+  return {
+    ok,
+    json: () => Promise.resolve(body),
+  } as unknown as Response
+}
+
+describe('useSyncDialog', () => {
+  const defaultProps = {
+    isOpen: true,
+    appName: 'test-app',
+    namespace: 'default',
+    cluster: 'test-cluster',
+    repoUrl: 'https://github.com/test/repo',
+    path: 'deploy/',
+    onSyncComplete: vi.fn(),
+    onClose: vi.fn(),
+  }
+
+  let fetchMock: FetchMock
+
+  beforeEach(() => {
+    fetchMock = makeFetchMock(() => Promise.resolve(mockResponse({ drifted: false, resources: [] })))
+    vi.stubGlobal('fetch', fetchMock)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.clearAllMocks()
+  })
+
+  it('returns initial detection-phase state when closed', () => {
+    const { result } = renderHook(() => useSyncDialog({ ...defaultProps, isOpen: false }))
+    expect(result.current.phase).toBe('detection')
+    expect(result.current.driftedResources).toEqual([])
+    expect(result.current.syncLogs).toEqual([])
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('success path: runs detection on open and transitions to plan phase with no drift', async () => {
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+
+    await waitFor(() => expect(result.current.phase).toBe('plan'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+    expect(result.current.driftedResources).toEqual([])
+    expect(result.current.error).toBeNull()
+
+    const calledUrl = fetchMock.mock.calls[0][0] as string
+    expect(calledUrl).toContain(DETECT_DRIFT_PATH_SUFFIX)
+  })
+
+  it('success path: populates driftedResources and sync plan when drift is found', async () => {
+    fetchMock = makeFetchMock(() =>
+      Promise.resolve(
+        mockResponse({
+          drifted: true,
+          resources: [
+            { kind: 'Deployment', name: 'frontend', namespace: 'default', field: 'replicas', gitValue: '3', clusterValue: '5' },
+          ],
+        })
+      )
+    )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+
+    await waitFor(() => expect(result.current.phase).toBe('plan'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+    expect(result.current.driftedResources).toHaveLength(1)
+    expect(result.current.syncPlan).toEqual([
+      { action: 'update', resource: 'Deployment/frontend', details: 'replicas: 5 → 3' },
+    ])
+  })
+
+  it('error path: sets error and logs failure when detection fails', async () => {
+    fetchMock = makeFetchMock(() => Promise.resolve(mockResponse({ error: 'boom: backend down' }, false)))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+
+    await waitFor(() => expect(result.current.error).toBe('boom: backend down'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+    expect(result.current.phase).toBe('detection')
+    expect(result.current.syncLogs.some(l => l.status === 'error')).toBe(true)
+  })
+
+  it('runSync success path: applies resources and transitions to complete phase', async () => {
+    fetchMock = makeFetchMock((url) => {
+      if (url.includes(SYNC_PATH_SUFFIX)) {
+        return Promise.resolve(mockResponse({ success: true, applied: ['Deployment/frontend'], errors: [] }))
+      }
+      return Promise.resolve(mockResponse({ drifted: false, resources: [] }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+    await waitFor(() => expect(result.current.phase).toBe('plan'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+
+    await act(async () => {
+      await result.current.runSync()
+    })
+
+    expect(result.current.phase).toBe('complete')
+    expect(result.current.syncLogs.some(l => l.message.includes('Deployment/frontend'))).toBe(true)
+  })
+
+  it('runSync error path: surfaces sync failure message', async () => {
+    fetchMock = makeFetchMock((url) => {
+      if (url.includes(SYNC_PATH_SUFFIX)) {
+        return Promise.resolve(mockResponse({ error: 'sync boom' }, false))
+      }
+      return Promise.resolve(mockResponse({ drifted: false, resources: [] }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+    await waitFor(() => expect(result.current.phase).toBe('plan'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+
+    await act(async () => {
+      await result.current.runSync()
+    })
+
+    expect(result.current.error).toBe('sync boom')
+  })
+
+  it('handleClose calls onSyncComplete only when phase is complete', async () => {
+    fetchMock = makeFetchMock((url) => {
+      if (url.includes(SYNC_PATH_SUFFIX)) {
+        return Promise.resolve(mockResponse({ success: true, applied: [], errors: [] }))
+      }
+      return Promise.resolve(mockResponse({ drifted: false, resources: [] }))
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { result } = renderHook(() => useSyncDialog(defaultProps))
+    await waitFor(() => expect(result.current.phase).toBe('plan'), { timeout: ASYNC_WAIT_TIMEOUT_MS })
+
+    act(() => {
+      result.current.handleClose()
+    })
+    expect(defaultProps.onSyncComplete).not.toHaveBeenCalled()
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.runSync()
+    })
+    expect(result.current.phase).toBe('complete')
+
+    act(() => {
+      result.current.handleClose()
+    })
+    expect(defaultProps.onSyncComplete).toHaveBeenCalledTimes(1)
+    expect(defaultProps.onClose).toHaveBeenCalledTimes(2)
+  })
+})

--- a/web/src/components/workloads/useWorkloads.test.ts
+++ b/web/src/components/workloads/useWorkloads.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+
+import '../../test/utils/setupMocks'
+
+interface MockPodIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason: string
+}
+
+interface MockDeploymentIssue {
+  name: string
+  namespace: string
+  cluster: string
+  reason: string
+}
+
+interface MockDeployment {
+  name: string
+  namespace: string
+  cluster: string
+  status: string
+  replicas: number
+  readyReplicas: number
+}
+
+interface MockCluster {
+  name: string
+  [key: string]: unknown
+}
+
+let mockPodIssues: MockPodIssue[] = []
+let mockDeploymentIssues: MockDeploymentIssue[] = []
+let mockDeployments: MockDeployment[] = []
+let mockClusters: MockCluster[] = []
+let mockIsLoading = false
+let mockHookError: string | null = null
+let mockAgentStatus: 'connected' | 'disconnected' = 'connected'
+
+const {
+  refetchPodIssuesSpy,
+  refetchDeploymentIssuesSpy,
+  refetchDeploymentsSpy,
+  refetchClustersSpy,
+  showToastSpy,
+  drillToNamespaceSpy,
+  drillToAllNamespacesSpy,
+  drillToAllDeploymentsSpy,
+  drillToAllPodsSpy,
+  drillToDeploymentSpy,
+  kubectlExecSpy,
+} = vi.hoisted(() => ({
+  refetchPodIssuesSpy: vi.fn(),
+  refetchDeploymentIssuesSpy: vi.fn(),
+  refetchDeploymentsSpy: vi.fn(),
+  refetchClustersSpy: vi.fn(),
+  showToastSpy: vi.fn(),
+  drillToNamespaceSpy: vi.fn(),
+  drillToAllNamespacesSpy: vi.fn(),
+  drillToAllDeploymentsSpy: vi.fn(),
+  drillToAllPodsSpy: vi.fn(),
+  drillToDeploymentSpy: vi.fn(),
+  kubectlExecSpy: vi.fn().mockResolvedValue({ output: 'success', exitCode: 0 }),
+}))
+
+vi.mock('../../hooks/useMCP', () => ({
+  usePodIssues: () => ({ issues: mockPodIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: refetchPodIssuesSpy }),
+  useDeploymentIssues: () => ({ issues: mockDeploymentIssues, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: refetchDeploymentIssuesSpy }),
+  useDeployments: () => ({ deployments: mockDeployments, isLoading: mockIsLoading, isRefreshing: false, error: mockHookError, lastUpdated: null, refetch: refetchDeploymentsSpy }),
+  useClusters: () => ({ clusters: mockClusters, deduplicatedClusters: mockClusters, isLoading: mockIsLoading, error: mockHookError, lastUpdated: null, refetch: refetchClustersSpy }),
+}))
+
+vi.mock('../../hooks/useGlobalFilters', () => ({
+  useGlobalFilters: () => ({
+    selectedClusters: [],
+    isAllClustersSelected: true,
+    customFilter: '',
+    filterByCluster: <T,>(items: T[]) => items,
+  }),
+}))
+
+vi.mock('../../hooks/useLocalAgent', () => ({
+  useLocalAgent: () => ({ status: mockAgentStatus }),
+  wasAgentEverConnected: () => false,
+}))
+
+vi.mock('../../hooks/useBackendHealth', () => ({
+  isInClusterMode: () => false,
+}))
+
+vi.mock('../../lib/unified/demo', () => ({
+  useIsModeSwitching: () => false,
+}))
+
+vi.mock('../ui/Toast', () => ({
+  useToast: () => ({ showToast: showToastSpy }),
+}))
+
+vi.mock('../../hooks/useDrillDown', () => ({
+  useDrillDownActions: () => ({
+    drillToNamespace: drillToNamespaceSpy,
+    drillToAllNamespaces: drillToAllNamespacesSpy,
+    drillToAllDeployments: drillToAllDeploymentsSpy,
+    drillToAllPods: drillToAllPodsSpy,
+    drillToDeployment: drillToDeploymentSpy,
+  }),
+}))
+
+vi.mock('../../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: kubectlExecSpy },
+}))
+
+vi.mock('react-i18next', () => ({
+  initReactI18next: { type: '3rdParty', init: () => {} },
+  useTranslation: () => ({ t: (key: string, fallback?: string) => fallback || key, i18n: { language: 'en' } }),
+}))
+
+import { useWorkloads } from './useWorkloads'
+
+describe('useWorkloads', () => {
+  beforeEach(() => {
+    mockPodIssues = []
+    mockDeploymentIssues = []
+    mockDeployments = []
+    mockClusters = []
+    mockIsLoading = false
+    mockHookError = null
+    mockAgentStatus = 'connected'
+    refetchPodIssuesSpy.mockClear()
+    refetchDeploymentIssuesSpy.mockClear()
+    refetchDeploymentsSpy.mockClear()
+    refetchClustersSpy.mockClear()
+    showToastSpy.mockClear()
+    kubectlExecSpy.mockClear()
+  })
+
+  it('returns loading state and empty collections initially', () => {
+    mockIsLoading = true
+    const { result } = renderHook(() => useWorkloads())
+    expect(result.current.isLoading).toBe(true)
+    expect(result.current.apps).toEqual([])
+    expect(result.current.deployments).toEqual([])
+    expect(result.current.podIssues).toEqual([])
+    expect(result.current.deploymentIssues).toEqual([])
+  })
+
+  it('success path: aggregates deployments and issues into namespace apps', () => {
+    mockDeployments = [
+      { name: 'dep-1', namespace: 'ns1', cluster: 'c1', status: 'running', replicas: 2, readyReplicas: 2 },
+    ]
+    mockPodIssues = [
+      { name: 'pod-1', namespace: 'ns1', cluster: 'c1', reason: 'CrashLoopBackOff' },
+    ]
+    mockDeploymentIssues = []
+
+    const { result } = renderHook(() => useWorkloads())
+
+    expect(result.current.isLoading).toBe(false)
+    expect(result.current.apps).toHaveLength(1)
+    expect(result.current.apps[0]).toMatchObject({
+      namespace: 'ns1',
+      cluster: 'c1',
+      deploymentCount: 1,
+      podIssues: 1,
+      status: 'warning',
+    })
+    expect(result.current.stats.totalDeployments).toBe(1)
+    expect(result.current.stats.totalPodIssues).toBe(1)
+  })
+
+  it('error path: surfaces loadError from underlying hooks', () => {
+    mockHookError = 'failed to fetch deployments'
+    const { result } = renderHook(() => useWorkloads())
+    expect(result.current.loadError).toBe('failed to fetch deployments')
+  })
+
+  it('handleRefresh refetches all underlying data sources', () => {
+    const { result } = renderHook(() => useWorkloads())
+    act(() => {
+      result.current.handleRefresh()
+    })
+    expect(refetchPodIssuesSpy).toHaveBeenCalled()
+    expect(refetchDeploymentIssuesSpy).toHaveBeenCalled()
+    expect(refetchDeploymentsSpy).toHaveBeenCalled()
+    expect(refetchClustersSpy).toHaveBeenCalled()
+  })
+
+  it('handleImportWorkloads appends imported workloads and shows a toast', () => {
+    const { result } = renderHook(() => useWorkloads())
+    act(() => {
+      result.current.handleImportWorkloads([
+        {
+          name: 'imported-1',
+          namespace: 'ns2',
+          targetClusters: ['c2'],
+          replicas: 1,
+          readyReplicas: 1,
+          image: 'nginx',
+        } as never,
+      ])
+    })
+    expect(showToastSpy).toHaveBeenCalled()
+    expect(result.current.deployments.some(d => d.name === 'imported-1')).toBe(true)
+  })
+
+  it('handleDeleteDeployment sets pendingDelete and confirmDeleteDeployment clears it after exec', async () => {
+    const { result } = renderHook(() => useWorkloads())
+    const fakeEvent = { stopPropagation: vi.fn() } as unknown as React.MouseEvent
+
+    act(() => {
+      result.current.handleDeleteDeployment(fakeEvent, 'c1', 'ns1', 'dep-1')
+    })
+    expect(result.current.pendingDelete).toEqual({ cluster: 'c1', namespace: 'ns1', name: 'dep-1' })
+
+    await act(async () => {
+      await result.current.confirmDeleteDeployment()
+    })
+    expect(kubectlExecSpy).toHaveBeenCalledWith(
+      ['delete', 'deployment', 'dep-1', '-n', 'ns1'],
+      { context: 'c1' }
+    )
+    expect(result.current.pendingDelete).toBeNull()
+  })
+
+  it('handleShowLogs drills into the deployment pods tab', () => {
+    const { result } = renderHook(() => useWorkloads())
+    const fakeEvent = { stopPropagation: vi.fn() } as unknown as React.MouseEvent
+    act(() => {
+      result.current.handleShowLogs(fakeEvent, 'c1', 'ns1', 'dep-1')
+    })
+    expect(drillToDeploymentSpy).toHaveBeenCalledWith('c1', 'ns1', 'dep-1', { tab: 'pods' })
+  })
+
+  it('shows skeletons while loading with no data yet', () => {
+    mockIsLoading = true
+    const { result } = renderHook(() => useWorkloads())
+    expect(result.current.showSkeletons).toBe(true)
+  })
+})


### PR DESCRIPTION
Fixes #21968, Fixes #22012

## What
Adds `renderHook` unit tests (`@testing-library/react`) for the drilldown-split hooks that still shipped without coverage after the second wave of `X.tsx` + `X.parts.tsx` + `useX.ts` refactors:

- `web/src/components/workloads/useWorkloads.test.ts`
- `web/src/components/gitops/useGitOps.test.ts`
- `web/src/components/gitops/useSyncDialog.test.ts`

`useRBACDrillDown`, `useConfigMapDrillDown`, and `useSecretDrillDown` already had dedicated hook tests on `main` (verified before starting this work), so this PR closes the remaining gap called out in #21968 / #22012: `useWorkloads` (components/workloads), `useGitOps`, and `useSyncDialog`.

## Coverage added
Each hook's test file follows the pattern established by the existing `use*DrillDown.test.ts` files:
- Initial state (loading flags / empty collections, or closed/detection phase)
- Success path with mocked fetch/query response — asserts derived/filtered state
- Error path — asserts error surfaced on the hook's return value
- Refresh/refetch/handler behavior (`handleRefresh`, `handleImportWorkloads`, `confirmDeleteDeployment`, `handleSync`/`handleSyncComplete`, `runSync`, `handleClose`, etc.)

## Verification
Ran the full suite for the touched directories plus the pre-existing RBAC/ConfigMap/Secret drilldown hook tests locally:

```
Test Files  11 passed (11)
     Tests  97 passed (97)
```

No production code was changed — this is test-only coverage. Build/lint are validated by CI on the PR.
