### PR TITLE
[scanner] fix: resolve nightly/workflow test regressions

### DIFF
--- a/web/src/components/clusters/ClusterDetailModal.parts.tsx
+++ b/web/src/components/clusters/ClusterDetailModal.parts.tsx
@@ -71,7 +71,7 @@ export function ClusterDetailHeader({
           {aliasList.length > 0 && (
             <div
               className="text-xs text-muted-foreground mt-0.5"
-              title={t('clusterDetail.alsoKnownAs', { aliases: aliasList.join(', ') })}
+              title={t('clusterDetail.alsoKnownAs', { aliases: (aliasList || []).join(', ') })}
             >
               {t('clusterDetail.akaLabel')} {headerAliasSummary}
             </div>

--- a/web/src/components/drilldown/views/EventsDrillDown.parts.tsx
+++ b/web/src/components/drilldown/views/EventsDrillDown.parts.tsx
@@ -201,6 +201,7 @@ export function Pagination({ currentPage, totalPages, totalCount, onPageChange }
           start: (currentPage - 1) * PAGE_SIZE + 1,
           end: Math.min(currentPage * PAGE_SIZE, totalCount),
           total: totalCount,
+          defaultValue: `Showing ${(currentPage - 1) * PAGE_SIZE + 1}\u2013${Math.min(currentPage * PAGE_SIZE, totalCount)} of ${totalCount}`,
         })}
       </span>
       <div className="flex items-center gap-1">
@@ -221,6 +222,7 @@ export function Pagination({ currentPage, totalPages, totalCount, onPageChange }
           {t('pagination.pageOf', {
             page: currentPage,
             total: totalPages,
+            defaultValue: `Page ${currentPage} of ${totalPages}`,
           })}
         </span>
         <button

--- a/web/src/components/drilldown/views/__tests__/HelmReleaseDrillDown.test.tsx
+++ b/web/src/components/drilldown/views/__tests__/HelmReleaseDrillDown.test.tsx
@@ -276,6 +276,6 @@ metadata:
 
     // Overview must show the updated revision number from the live fetch, not the stale prop
     fireEvent.click(screen.getByRole('button', { name: 'drilldown.tabs.overview' }))
-    await waitFor(() => expect(screen.getByText('Revision: 3')).toBeInTheDocument())
+    await waitFor(() => expect(screen.getByText('drilldown.helm.revision: 3')).toBeInTheDocument())
   })
 })

--- a/web/src/lib/__tests__/safeLazy.test.ts
+++ b/web/src/lib/__tests__/safeLazy.test.ts
@@ -25,6 +25,26 @@ function getLoader(lazyComp: unknown): () => Promise<{ default: unknown }> {
   return (lazyComp as { _payload: { _result: () => Promise<{ default: unknown }> } })._payload._result
 }
 
+/**
+ * Attaches a no-op rejection handler immediately, then returns the same
+ * promise so callers can still assert on it later (e.g. via
+ * `expect(promise).rejects.toThrow(...)`).
+ *
+ * Needed because these tests advance vi's fake timers through several retry/
+ * timeout ticks *before* the real assertion attaches its `.catch`/`.rejects`
+ * handler. Node's unhandled-rejection tracking checks at each tick boundary,
+ * so a promise that rejects early but isn't "observed" until several
+ * `advanceTimersByTimeAsync` calls later gets flagged as an unhandled
+ * rejection (a false positive — the real assertion below always awaits it).
+ * Attaching this handler synchronously at creation time marks the promise as
+ * handled without affecting the later assertion (multiple `.catch`/`.then`
+ * handlers may be attached to the same promise). See #22004.
+ */
+function expectEventualRejection<T>(promise: Promise<T>): Promise<T> {
+  promise.catch(() => { /* observed above; real assertion happens later */ })
+  return promise
+}
+
 describe('safeLazy', () => {
   beforeEach(() => {
     vi.useFakeTimers()
@@ -61,7 +81,7 @@ describe('safeLazy', () => {
       'Foo',
     )
 
-    const resultPromise = getLoader(LazyComp)()
+    const resultPromise = expectEventualRejection(getLoader(LazyComp)())
     // Advance past retry delays (500ms + 1000ms) since safeLazy retries all errors
     await vi.advanceTimersByTimeAsync(500)
     await vi.advanceTimersByTimeAsync(1000)
@@ -75,7 +95,7 @@ describe('safeLazy', () => {
       'MissingExport',
     )
 
-    const resultPromise = getLoader(LazyComp)()
+    const resultPromise = expectEventualRejection(getLoader(LazyComp)())
     await vi.advanceTimersByTimeAsync(500)
     await vi.advanceTimersByTimeAsync(1000)
 
@@ -91,7 +111,7 @@ describe('safeLazy', () => {
       'BadExport',
     )
 
-    const resultPromise = getLoader(LazyComp)()
+    const resultPromise = expectEventualRejection(getLoader(LazyComp)())
     await vi.advanceTimersByTimeAsync(500)
     await vi.advanceTimersByTimeAsync(1000)
 
@@ -126,7 +146,7 @@ describe('safeLazy', () => {
     const importFn = vi.fn().mockRejectedValue(new Error('Network failure'))
 
     const LazyComp = safeLazy(importFn, 'Component')
-    const resultPromise = getLoader(LazyComp)()
+    const resultPromise = expectEventualRejection(getLoader(LazyComp)())
 
     // Advance past retry delays (500ms + 1000ms)
     await vi.advanceTimersByTimeAsync(500)
@@ -145,7 +165,7 @@ describe('safeLazy', () => {
     )
 
     const LazyComp = safeLazy(importFn, 'HungComponent')
-    const resultPromise = getLoader(LazyComp)()
+    const resultPromise = expectEventualRejection(getLoader(LazyComp)())
 
     // Advance past timeout (5s) + retry delays for each attempt
     // Attempt 1: 5s timeout → reject → 500ms delay


### PR DESCRIPTION
## Summary

Investigates and fixes the following:

- Fixes #22002 — Startup Smoke Tests were failing at commit `db863354` because `npm run build` (`tsc -b`) crashed with the upstream TypeScript compiler bug described in #22014. That fix is already merged to `main`; I verified `npm run build` now completes end-to-end (tsc + vite build + postbuild safety checks) with no source changes needed for this issue specifically.
- Fixes #22003 — `scripts/consistency-test.sh` Phase 3 (Join Guards) had 1 violation: `ClusterDetailModal.parts.tsx` called `aliasList.join(', ')` unguarded. Guarded it with `(aliasList || [])` per the existing repo-wide convention (dozens of examples already use this pattern).
- Fixes #22004 — `safeLazy.test.ts` intermittently logged 5 "unhandled rejection" errors in nightly unit-test runs (matching the reported "5 errors" with all tests passing). Root cause: tests advance `vi`'s fake timers through several retry/timeout ticks *before* attaching the real `.rejects.toThrow()`/`.catch()` handler, so Node's unhandled-rejection tracking flags the already-settled promise. Fixed by attaching a no-op `.catch()` immediately when each of the 5 rejecting `resultPromise`s is created (verified 5 consecutive clean runs locally after the fix, vs. reproducing the error consistently before).
- Fixes #22018 — 6 Coverage Suite test failures, all pre-existing bugs unmasked once #22014 fixed the `tsc -b` crash (Coverage Suite couldn't previously run to completion):
  - `EventsDrillDown.parts.tsx`: PR #22014 renamed `pagination.showing`/`pagination.pageOf` t() calls but dropped their `defaultValue` fallback strings, breaking 5 EventsDrillDown pagination tests that rely on the local `useTranslation` mock's `defaultValue` handling. Restored the `defaultValue` strings (matching the original pre-#22014 behavior/format, including the en-dash in "Showing 1–20 of 25").
  - `HelmReleaseDrillDown.test.tsx`: one assertion expected the fully-translated string `"Revision: 3"`, but this test file uses the shared global `react-i18next` mock (`src/test/setup.ts`) which renders raw untranslated keys for calls without a `defaultValue` — exactly like every other assertion in this same file (e.g. `screen.getByText('drilldown.helm.manifestResources')`). Fixed the assertion to match the mock's actual (and consistent) output.

#21545 (nightly release failing) was already closed as completed — no action taken there.

## Verification

- `npx tsc -b` and full `npm run build` succeed cleanly on `main` + this branch.
- `npx vitest run` on the 4 touched/related test files: 34/34 tests pass, 5 consecutive clean runs of `safeLazy.test.ts` with zero unhandled rejections (previously reproduced consistently).
- Manually replicated `scripts/consistency-test.sh`'s Phase 3 rg pattern + exclude globs in Python against `src/hooks/` and `src/components/`: 1 violation before this change, 0 after (couldn't run the script directly in this sandbox — no root access to install `ripgrep` — so verified the exact regex/exclude logic instead).

Fixes #22002, Fixes #22003, Fixes #22004, Fixes #22018
