### PR TITLE
[scanner] fix: resolve coverage-suite drilldown test failures

### DIFF
--- a/web/src/components/drilldown/views/useCRDDrillDown.ts
+++ b/web/src/components/drilldown/views/useCRDDrillDown.ts
@@ -63,6 +63,7 @@ export function useCRDDrillDown(cluster: string, crdName: string): UseCRDDrillDo
           setVersions([])
           setConditions([])
           setVersionsError('Failed to parse CRD data')
+          setVersionsLoading(false)
           return
         }
         // Get versions
@@ -118,6 +119,7 @@ export function useCRDDrillDown(cluster: string, crdName: string): UseCRDDrillDo
         } catch {
           setInstances([])
           setInstancesError('Failed to parse instances data')
+          setInstancesLoading(false)
           return
         }
         const items = data.items || []

--- a/web/src/components/drilldown/views/useDriftDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useDriftDrillDown.test.ts
@@ -19,7 +19,7 @@ vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
   useDrillDownWebSocket: () => ({ runKubectl: mockRunKubectl }),
 }))
 
-import { useDriftDrillDown } from '../useDriftDrillDown'
+import { useDriftDrillDown } from './useDriftDrillDown'
 
 const KUSTOMIZATION = 'kustomization'
 const ARGO_APPS = ['applications', 'argoproj.io'].join('.')

--- a/web/src/components/drilldown/views/useDriftDrillDown.ts
+++ b/web/src/components/drilldown/views/useDriftDrillDown.ts
@@ -42,6 +42,7 @@ export function useDriftDrillDown(
           } catch {
             setChanges([])
             setChangesError('Failed to parse drift data')
+            setChangesLoading(false)
             return
           }
           const items = ksList.items || []
@@ -79,6 +80,7 @@ export function useDriftDrillDown(
         } catch {
           setChanges([])
           setChangesError('Failed to parse ArgoCD data')
+          setChangesLoading(false)
           return
         }
         const apps = appList.items || []

--- a/web/src/components/drilldown/views/useEventsDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useEventsDrillDown.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { renderHook, waitFor, act } from '@testing-library/react'
 
 const mockGetDemoMode = vi.fn()
@@ -28,14 +28,9 @@ function failResponse(): Response {
 
 describe('useEventsDrillDown', () => {
   beforeEach(() => {
-    vi.useFakeTimers()
     mockGetDemoMode.mockReset()
     mockAgentFetch.mockReset()
     mockCopyToClipboard.mockReset()
-  })
-
-  afterEach(() => {
-    vi.useRealTimers()
   })
 
   it('short-circuits in demo mode without hitting the agent', async () => {

--- a/web/src/components/drilldown/views/useOperatorDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useOperatorDrillDown.test.ts
@@ -17,7 +17,7 @@ vi.mock('../../../hooks/useDrillDownWebSocket', () => ({
   useDrillDownWebSocket: () => ({ runKubectl: mockRunKubectl }),
 }))
 
-import { useOperatorDrillDown } from '../useOperatorDrillDown'
+import { useOperatorDrillDown } from './useOperatorDrillDown'
 
 const CSV_NAME = 'cert-manager.v1.14.0'
 const OPERATOR_NAME = 'cert-manager'

--- a/web/src/components/drilldown/views/useOperatorDrillDown.ts
+++ b/web/src/components/drilldown/views/useOperatorDrillDown.ts
@@ -44,6 +44,7 @@ export function useOperatorDrillDown(
         } catch {
           console.warn('[OperatorDrillDown] Failed to parse CSV JSON output')
           setCsvInfo({ name: currentCSV || operatorName, displayName: operatorName, version: 'Unknown', phase: operatorPhase })
+          setCsvLoading(false)
           return
         }
         const csvName2 = csv.metadata?.name || csvName
@@ -79,6 +80,7 @@ export function useOperatorDrillDown(
         } catch {
           console.warn('[OperatorDrillDown] Failed to parse CRD JSON output')
           setOperatorCRDs([])
+          setCrdsLoading(false)
           return
         }
         const crds = csv.spec?.customresourcedefinitions?.owned || []

--- a/web/src/components/drilldown/views/useReplicaSetDrillDown.test.ts
+++ b/web/src/components/drilldown/views/useReplicaSetDrillDown.test.ts
@@ -70,11 +70,14 @@ describe('useReplicaSetDrillDown', () => {
       ],
     }
 
-    // fetchData → rs JSON, then pods JSON. fetchEvents/Describe/Yaml return strings.
+    // fetchData and fetchEvents run concurrently in Promise.all (Batch 1), so calls resolve
+    // in this order: rs JSON (fetchData's first await), events output (fetchEvents, which has
+    // no earlier await), then pods JSON (fetchData's second await, once rs has resolved).
+    // Batch 2 (describe + yaml) only starts once Batch 1 fully settles.
     mockRunKubectl
       .mockResolvedValueOnce(JSON.stringify(rs))
-      .mockResolvedValueOnce(JSON.stringify(pods))
       .mockResolvedValueOnce('events output')
+      .mockResolvedValueOnce(JSON.stringify(pods))
       .mockResolvedValueOnce('describe output')
       .mockResolvedValueOnce('yaml output')
 
@@ -93,7 +96,7 @@ describe('useReplicaSetDrillDown', () => {
       { name: 'web-2', status: 'Pending', restarts: 0 },
     ])
 
-    const podsCall = mockRunKubectl.mock.calls[1][0] as string[]
+    const podsCall = mockRunKubectl.mock.calls[2][0] as string[]
     expect(podsCall.slice(0, 5)).toEqual(['get', 'pods', '-n', 'ns1', '-l'])
     // Selector should include both matchLabels entries joined by comma.
     const selector = podsCall[5]


### PR DESCRIPTION
Fixes #22025

## Root causes

1. **`useCRDDrillDown.ts` / `useDriftDrillDown.ts` / `useOperatorDrillDown.ts`** — the JSON-parse-failure `catch` blocks `return`ed early, skipping the trailing `set*Loading(false)` call. This left `versionsLoading` / `instancesLoading` / `changesLoading` stuck at `true` forever whenever the agent returned invalid JSON.
2. **`useDriftDrillDown.test.ts` / `useOperatorDrillDown.test.ts`** — leftover relative import bug from the oversized-test-file split (#22023): `import ... from '../useDriftDrillDown'` / `'../useOperatorDrillDown'` pointed one directory too high. Both hooks live alongside their test files, so the import should be `'./useDriftDrillDown'` / `'./useOperatorDrillDown'`.
3. **`useEventsDrillDown.test.ts`** — `vi.useFakeTimers()` was enabled in `beforeEach` but never advanced, so `waitFor()`'s internal polling (which relies on real timers) never re-checked the assertion, causing every test in the file to time out.
4. **`useReplicaSetDrillDown.test.ts`** — the mock response queue assumed `fetchData`'s rs+pods calls resolved back-to-back, but `fetchData` and `fetchEvents` run concurrently via `Promise.all`, so the actual call order is rs → events → pods. Reordered the mocked responses (and updated the call-index assertion) to match.

## Verification

Ran the full drilldown test suite locally after the fix:

```
Test Files  66 passed (66)
     Tests  464 passed (464)
```

All 13 previously failing tests (in `useCRDDrillDown.test.ts`, `useDriftDrillDown.test.ts`, `useEventsDrillDown.test.ts`, `useOperatorDrillDown.test.ts`, `useReplicaSetDrillDown.test.ts`) now pass.