### PR TITLE
ci: don't cancel in-progress build-gate runs

### DIFF
--- a/.github/workflows/pre-merge-gate.yml
+++ b/.github/workflows/pre-merge-gate.yml
@@ -7,9 +7,19 @@ on:
 
 permissions: read-all  # default read; writes scoped to job below
 
+# NOTE: cancel-in-progress is deliberately false. build-gate is a REQUIRED
+# status check in branch protection. When a run is cancelled, GitHub records
+# the check as `cancelled` (not `success`), which branch protection treats as
+# unsatisfied — and cancelling the run for the current head SHA leaves that SHA
+# with no passing build-gate at all. With admin-merge disabled, such a PR can
+# never merge until a fresh run completes. Rapid re-pushes (e.g. a fix-up commit
+# pushed onto a PR) previously cancelled the in-flight run and stranded the PR.
+# Letting each run finish guarantees every head SHA ends with a real
+# success/failure conclusion. The only cost is some extra CI minutes on
+# superseded commits, which is far cheaper than a permanently unmergeable queue.
 concurrency:
   group: pre-merge-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   build-gate:


### PR DESCRIPTION
## Problem

`build-gate` is a **required** status check in `main` branch protection. The workflow's `concurrency` block set `cancel-in-progress: true`. When a run is cancelled, GitHub records the check as `cancelled` (not `success`), which branch protection treats as **unsatisfied** — and cancelling the run for the current head SHA leaves that SHA with **no passing build-gate**.

With admin-merge disabled, such a PR can **never merge** until a fresh run completes. Pushing a fix-up commit onto a PR (routine) reliably triggered this: the new push cancelled the in-flight run, and if superseded again the head was stranded with only a `cancelled` gate.

## Fix

Set `cancel-in-progress: false` so each run finishes and every head SHA ends with a real success/failure conclusion. Cost: some extra CI minutes on superseded commits — far cheaper than a permanently stalled merge queue.