### PR TITLE
🐛 fix: restore test preludes lost in the useMissions test-file split

### DIFF
--- a/web/src/hooks/useMissions.cancellation.test.tsx
+++ b/web/src/hooks/useMissions.cancellation.test.tsx
@@ -1,3 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { MissionProvider, useMissions } from './useMissions'
+import { getDemoMode } from './useDemoMode'
+import { missionCache } from '../lib/missions/missionCache'
+
+// ── External module mocks ─────────────────────────────────────────────────────
+
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
+  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
+}))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentActivity: vi.fn(),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn((url: string) => Promise.resolve({ url, protocols: [] })),
+}))
+
+vi.mock('./useTokenUsage', () => ({
+  addCategoryTokens: vi.fn(),
+  setActiveTokenCategory: vi.fn(),
+  clearActiveTokenCategory: vi.fn(),
+  getActiveTokenCategories: vi.fn(() => []),
+}))
+
+vi.mock('./useResolutions', () => ({
+  detectIssueSignature: vi.fn(() => ({ type: 'Unknown' })),
+  findSimilarResolutionsStandalone: vi.fn(() => []),
+  generateResolutionPromptContext: vi.fn(() => ''),
+}))
+
+vi.mock('../lib/missions/missionCache', () => ({
+  missionCache: {
+    installers: [],
+  },
+  fetchMissionContent: vi.fn(async mission => ({
+    mission,
+    raw: JSON.stringify(mission),
+  })),
+}))
+
+vi.mock('../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual,
+  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+} })
+
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
+  emitMissionStarted: vi.fn(),
+  emitMissionCompleted: vi.fn(),
+  emitMissionError: vi.fn(),
+  emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
+}
+))
+
+vi.mock('../lib/missions/preflightCheck', () => ({
+  runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
+  classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
+  getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
+  runClusterReadinessCheck: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../lib/missions/scanner/malicious', () => ({
+  scanForMaliciousContent: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn() },
+}))
+
+// ── Mock WebSocket ─────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  /** Reference to the most recently created instance. Reset in beforeEach. */
+  static lastInstance: MockWebSocket | null = null
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onclose: ((e: CloseEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(public url: string) {
+    MockWebSocket.lastInstance = this
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MissionProvider>{children}</MissionProvider>
+)
+
+const defaultParams = {
+  title: 'Test Mission',
+  description: 'Pod crash investigation',
+  type: 'troubleshoot' as const,
+  initialPrompt: 'Fix the pod crash',
+  skipReview: true,
+}
+
+/** Start a mission and simulate the WebSocket opening so the mission moves to 'running'. */
+async function startMissionWithConnection(
+  result: { current: ReturnType<typeof useMissions> },
+): Promise<{ missionId: string; requestId: string }> {
+  let missionId = ''
+  act(() => {
+    missionId = result.current.startMission(defaultParams)
+  })
+  // Flush the preflight promise chain before simulating the socket opening.
+  await flushMissionPreflightChain()
+  await act(async () => {
+    MockWebSocket.lastInstance?.simulateOpen()
+  })
+  // Find the chat send call (list_agents fires first, then chat)
+  const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
+    (call: string[]) => JSON.parse(call[0]).type === 'chat',
+  )
+  const requestId = chatCall ? JSON.parse(chatCall[0]).id : ''
+  return { missionId, requestId }
+}
+
+async function flushMissionPreflightChain() {
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+}
+
+// ── Pre-seed a mission in localStorage without going through the WS flow ──────
+function seedMission(overrides: Partial<{
+  id: string
+  status: string
+  title: string
+  type: string
+}> = {}) {
+  const mission = {
+    id: overrides.id ?? 'seeded-mission-1',
+    title: overrides.title ?? 'Seeded Mission',
+    description: 'Pre-seeded',
+    type: overrides.type ?? 'troubleshoot',
+    status: overrides.status ?? 'pending',
+    messages: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  localStorage.setItem('kc_missions', JSON.stringify([mission]))
+  return mission.id
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  MockWebSocket.lastInstance = null
+  missionCache.installers = []
+  vi.clearAllMocks()
+  vi.mocked(getDemoMode).mockReturnValue(false)
+  // Suppress auto-reconnect noise: after onclose, ensureConnection is retried
+  // after 3 s. Tests complete before that fires, but mocking fetch avoids
+  // unhandled-rejection warnings from the HTTP fallback path.
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+})
+
+// ── saveMission ───────────────────────────────────────────────────────────────
+
 describe('setActiveMission', () => {
   it('opens the sidebar when setting an active mission', () => {
     const missionId = seedMission()

--- a/web/src/hooks/useMissions.dedup-timeout.test.tsx
+++ b/web/src/hooks/useMissions.dedup-timeout.test.tsx
@@ -1,3 +1,217 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import React from 'react'
+import { MissionProvider, useMissions, type StartMissionParams } from './useMissions'
+import {
+  MISSION_CONTROL_TRIGGER_TIMEOUT_MS,
+  MISSION_TIMEOUT_CHECK_INTERVAL_MS,
+  MISSION_TIMEOUT_MS,
+} from './useMissions.constants'
+import { getDemoMode } from './useDemoMode'
+import { emitMissionError } from '../lib/analytics'
+
+// ── External module mocks ─────────────────────────────────────────────────────
+
+vi.mock('./mcp/agentFetch', () => ({
+  agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
+}))
+
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
+  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
+  isDemoModeForced: false,
+  default: vi.fn(() => false),
+}))
+vi.mock('./useLocalAgent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./useLocalAgent')>()
+  return {
+    ...actual,
+    useLocalAgent: vi.fn(() => ({ isConnected: false })),
+    isAgentUnavailable: vi.fn(() => false),
+    isAgentConnected: vi.fn(() => false),
+    reportAgentActivity: vi.fn(),
+    reportAgentDataSuccess: vi.fn(),
+    reportAgentDataError: vi.fn(),
+  }
+})
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn((url: string) => Promise.resolve({ url, protocols: [] })),
+}))
+
+vi.mock('./useTokenUsage', () => ({
+  addCategoryTokens: vi.fn(),
+  setActiveTokenCategory: vi.fn(),
+  clearActiveTokenCategory: vi.fn(),
+  getActiveTokenCategories: vi.fn(() => []),
+}))
+
+vi.mock('./useResolutions', () => ({
+  detectIssueSignature: vi.fn(() => ({ type: 'Unknown' })),
+  findSimilarResolutionsStandalone: vi.fn(() => []),
+  generateResolutionPromptContext: vi.fn(() => ''),
+}))
+
+vi.mock('../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual,
+  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+} })
+
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
+  emitError: vi.fn(),
+  emitMissionStarted: vi.fn(),
+  emitMissionCompleted: vi.fn(),
+  emitMissionError: vi.fn(),
+  emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
+}
+))
+
+vi.mock('../lib/missions/preflightCheck', () => ({
+  runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
+  classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
+  getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
+  runClusterReadinessCheck: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../lib/missions/scanner/malicious', () => ({
+  scanForMaliciousContent: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn() },
+}))
+
+// ── Mock WebSocket ─────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  /** Reference to the most recently created instance. Reset in beforeEach. */
+  static lastInstance: MockWebSocket | null = null
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onclose: ((e: CloseEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(public url: string) {
+    MockWebSocket.lastInstance = this
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MissionProvider>{children}</MissionProvider>
+)
+
+const defaultParams = {
+  title: 'Test Mission',
+  description: 'Pod crash investigation',
+  type: 'troubleshoot' as const,
+  initialPrompt: 'Fix the pod crash',
+  skipReview: true,
+}
+
+/** Start a mission and simulate the WebSocket opening so the mission moves to 'running'. */
+async function startMissionWithConnection(
+  result: { current: ReturnType<typeof useMissions> },
+  params: StartMissionParams = defaultParams,
+): Promise<{ missionId: string; requestId: string }> {
+  let missionId = ''
+  act(() => {
+    missionId = result.current.startMission(params)
+  })
+  // Flush the preflight promise chain before simulating the socket opening.
+  await flushMissionPreflightChain()
+  await act(async () => {
+    MockWebSocket.lastInstance?.simulateOpen()
+  })
+  // Find the chat send call (list_agents fires first, then chat)
+  const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
+    (call: string[]) => JSON.parse(call[0]).type === 'chat',
+  )
+  const requestId = chatCall ? JSON.parse(chatCall[0]).id : ''
+  return { missionId, requestId }
+}
+
+async function flushMissionPreflightChain() {
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+}
+
+// ── Pre-seed a mission in localStorage without going through the WS flow ──────
+function seedMission(overrides: Partial<{
+  id: string
+  status: string
+  title: string
+  type: string
+}> = {}) {
+  const mission = {
+    id: overrides.id ?? 'seeded-mission-1',
+    title: overrides.title ?? 'Seeded Mission',
+    description: 'Pre-seeded',
+    type: overrides.type ?? 'troubleshoot',
+    status: overrides.status ?? 'pending',
+    messages: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  localStorage.setItem('kc_missions', JSON.stringify([mission]))
+  return mission.id
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  MockWebSocket.lastInstance = null
+  vi.clearAllMocks()
+  vi.mocked(getDemoMode).mockReturnValue(false)
+  // Suppress auto-reconnect noise: after onclose, ensureConnection is retried
+  // after 3 s. Tests complete before that fires, but mocking fetch avoids
+  // unhandled-rejection warnings from the HTTP fallback path.
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+})
+
+// ── Persistence edge cases ──────────────────────────────────────────────────
+
   it('blocks execution when imported mission contains malicious content', async () => {
     const { scanForMaliciousContent } = await import('../lib/missions/scanner/malicious')
     vi.mocked(scanForMaliciousContent).mockReturnValueOnce([

--- a/web/src/hooks/useMissions.preflight-stream.test.tsx
+++ b/web/src/hooks/useMissions.preflight-stream.test.tsx
@@ -1,3 +1,212 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MissionProvider, useMissions, type StartMissionParams } from './useMissions'
+import { getDemoMode } from './useDemoMode'
+import { emitMissionError } from '../lib/analytics'
+
+// ── External module mocks ─────────────────────────────────────────────────────
+
+vi.mock('./mcp/agentFetch', () => ({
+  agentFetch: vi.fn((...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?]))),
+}))
+
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
+  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
+  isDemoModeForced: false,
+  default: vi.fn(() => false),
+}))
+vi.mock('./useLocalAgent', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./useLocalAgent')>()
+  return {
+    ...actual,
+    useLocalAgent: vi.fn(() => ({ isConnected: false })),
+    isAgentUnavailable: vi.fn(() => false),
+    isAgentConnected: vi.fn(() => false),
+    reportAgentActivity: vi.fn(),
+    reportAgentDataSuccess: vi.fn(),
+    reportAgentDataError: vi.fn(),
+  }
+})
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn((url: string) => Promise.resolve({ url, protocols: [] })),
+}))
+
+vi.mock('./useTokenUsage', () => ({
+  addCategoryTokens: vi.fn(),
+  setActiveTokenCategory: vi.fn(),
+  clearActiveTokenCategory: vi.fn(),
+  getActiveTokenCategories: vi.fn(() => []),
+}))
+
+vi.mock('./useResolutions', () => ({
+  detectIssueSignature: vi.fn(() => ({ type: 'Unknown' })),
+  findSimilarResolutionsStandalone: vi.fn(() => []),
+  generateResolutionPromptContext: vi.fn(() => ''),
+}))
+
+vi.mock('../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual,
+  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+} })
+
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
+  emitError: vi.fn(),
+  emitMissionStarted: vi.fn(),
+  emitMissionCompleted: vi.fn(),
+  emitMissionError: vi.fn(),
+  emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
+}
+))
+
+vi.mock('../lib/missions/preflightCheck', () => ({
+  runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
+  classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
+  getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
+  runClusterReadinessCheck: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../lib/missions/scanner/malicious', () => ({
+  scanForMaliciousContent: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn() },
+}))
+
+// ── Mock WebSocket ─────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  /** Reference to the most recently created instance. Reset in beforeEach. */
+  static lastInstance: MockWebSocket | null = null
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onclose: ((e: CloseEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(public url: string) {
+    MockWebSocket.lastInstance = this
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MissionProvider>{children}</MissionProvider>
+)
+
+const defaultParams = {
+  title: 'Test Mission',
+  description: 'Pod crash investigation',
+  type: 'troubleshoot' as const,
+  initialPrompt: 'Fix the pod crash',
+  skipReview: true,
+}
+
+/** Start a mission and simulate the WebSocket opening so the mission moves to 'running'. */
+async function startMissionWithConnection(
+  result: { current: ReturnType<typeof useMissions> },
+  params: StartMissionParams = defaultParams,
+): Promise<{ missionId: string; requestId: string }> {
+  let missionId = ''
+  act(() => {
+    missionId = result.current.startMission(params)
+  })
+  // Flush the preflight promise chain before simulating the socket opening.
+  await flushMissionPreflightChain()
+  await act(async () => {
+    MockWebSocket.lastInstance?.simulateOpen()
+  })
+  // Find the chat send call (list_agents fires first, then chat)
+  const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
+    (call: string[]) => JSON.parse(call[0]).type === 'chat',
+  )
+  const requestId = chatCall ? JSON.parse(chatCall[0]).id : ''
+  return { missionId, requestId }
+}
+
+async function flushMissionPreflightChain() {
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+}
+
+// ── Pre-seed a mission in localStorage without going through the WS flow ──────
+function seedMission(overrides: Partial<{
+  id: string
+  status: string
+  title: string
+  type: string
+}> = {}) {
+  const mission = {
+    id: overrides.id ?? 'seeded-mission-1',
+    title: overrides.title ?? 'Seeded Mission',
+    description: 'Pre-seeded',
+    type: overrides.type ?? 'troubleshoot',
+    status: overrides.status ?? 'pending',
+    messages: [],
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  }
+  localStorage.setItem('kc_missions', JSON.stringify([mission]))
+  return mission.id
+}
+
+beforeEach(() => {
+  localStorage.clear()
+  MockWebSocket.lastInstance = null
+  vi.clearAllMocks()
+  vi.mocked(getDemoMode).mockReturnValue(false)
+  // Suppress auto-reconnect noise: after onclose, ensureConnection is retried
+  // after 3 s. Tests complete before that fires, but mocking fetch avoids
+  // unhandled-rejection warnings from the HTTP fallback path.
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+})
+
+// ── Persistence edge cases ──────────────────────────────────────────────────
+
   it('sends conversation history in the payload', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })
     const { missionId, requestId } = await startMissionWithConnection(result)


### PR DESCRIPTION
## The main-breaking root cause

The #22043 test-file split truncated the top of three new files — `useMissions.cancellation.test.tsx`, `useMissions.dedup-timeout.test.tsx`, `useMissions.preflight-stream.test.tsx` shipped with **no imports, mocks, MockWebSocket, wrapper, or helpers**. They parse (vitest globals), then every test dies at runtime: `ReferenceError: seedMission is not defined`.

That is the Coverage Suite failure keeping main red since 7/31, which trips the scanner-merge-guardrails circuit breaker and freezes the entire console PR queue. It merged under the old `--admin` bypass, which is exactly the failure mode the no-admin policy now prevents.

## Fix

- Preludes restored **verbatim from each file's pre-split parent** (save-run → cancellation; preflight-agents → dedup-timeout, preflight-stream)
- Unused imports those preludes carry for these subsets trimmed (same hygiene #22043 applied to the split files it got right)
- `persistence-agents` needed nothing — its lone `seedMission` grep hit was a false positive
- ESLint: 0 errors 0 warnings on all three; esbuild parse clean

Fixes #22004

🤖 Generated with [Claude Code](https://claude.com/claude-code)