### PR TITLE
🐛 fix: restore missing prelude in useMissions.cluster-targeting.test.tsx

### DIFF
--- a/web/src/hooks/useMissions.cluster-targeting.test.tsx
+++ b/web/src/hooks/useMissions.cluster-targeting.test.tsx
@@ -1,3 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import React from 'react'
+import { MissionProvider, useMissions } from './useMissions'
+import { getDemoMode } from './useDemoMode'
+import { fetchMissionContent, missionCache } from '../lib/missions/missionCache'
+
+// ── External module mocks ─────────────────────────────────────────────────────
+
+vi.mock('./mcp/shared', () => ({
+  agentFetch: (...args: unknown[]) => globalThis.fetch(...(args as [RequestInfo, RequestInit?])),
+  clusterCacheRef: { clusters: [] },
+  REFRESH_INTERVAL_MS: 120_000,
+  CLUSTER_POLL_INTERVAL_MS: 60_000,
+}))
+
+vi.mock('./useDemoMode', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./useDemoMode')>()),
+  useDemoMode: () => ({ isDemoMode: false, toggleDemoMode: vi.fn(), setDemoMode: vi.fn() }),
+  getDemoMode: vi.fn(() => false),
+}))
+vi.mock('./useLocalAgent', () => ({
+  useLocalAgent: vi.fn(() => ({ isConnected: false })),
+  isAgentUnavailable: vi.fn(() => false),
+  isAgentConnected: vi.fn(() => false),
+  reportAgentActivity: vi.fn(),
+  reportAgentDataSuccess: vi.fn(),
+  reportAgentDataError: vi.fn(),
+}))
+
+vi.mock('../lib/utils/wsAuth', () => ({
+  getWsAuthParams: vi.fn((url: string) => Promise.resolve({ url, protocols: [] })),
+}))
+
+vi.mock('./useTokenUsage', () => ({
+  addCategoryTokens: vi.fn(),
+  setActiveTokenCategory: vi.fn(),
+  clearActiveTokenCategory: vi.fn(),
+  getActiveTokenCategories: vi.fn(() => []),
+}))
+
+vi.mock('./useResolutions', () => ({
+  detectIssueSignature: vi.fn(() => ({ type: 'Unknown' })),
+  findSimilarResolutionsStandalone: vi.fn(() => []),
+  generateResolutionPromptContext: vi.fn(() => ''),
+}))
+
+vi.mock('../lib/missions/missionCache', () => ({
+  missionCache: {
+    installers: [],
+  },
+  fetchMissionContent: vi.fn(async mission => ({
+    mission,
+    raw: JSON.stringify(mission),
+  })),
+}))
+
+vi.mock('../lib/constants', async (importOriginal) => {
+  const actual = await importOriginal() as Record<string, unknown>
+  return { ...actual,
+  LOCAL_AGENT_WS_URL: 'ws://localhost:8585/ws',
+  LOCAL_AGENT_HTTP_URL: 'http://localhost:8585',
+} })
+
+vi.mock('../lib/analytics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../lib/analytics')>()),
+  emitMissionStarted: vi.fn(),
+  emitMissionCompleted: vi.fn(),
+  emitMissionError: vi.fn(),
+  emitMissionRated: vi.fn(),
+  emitAgentTokenFailure: vi.fn(),
+  emitWsAuthMissing: vi.fn(),
+  emitSseAuthFailure: vi.fn(),
+  emitSessionRefreshFailure: vi.fn(),
+}
+))
+
+vi.mock('../lib/missions/preflightCheck', () => ({
+  runPreflightCheck: vi.fn().mockResolvedValue({ ok: true }),
+  classifyKubectlError: vi.fn().mockReturnValue({ code: 'UNKNOWN_EXECUTION_FAILURE', message: 'mock' }),
+  getRemediationActions: vi.fn().mockReturnValue([]),
+  resolveRequiredTools: vi.fn(() => []),
+  runToolPreflightCheck: vi.fn().mockResolvedValue({ ok: true, tools: [] }),
+  runClusterReadinessCheck: vi.fn().mockResolvedValue({ ok: true }),
+}))
+
+vi.mock('../lib/missions/scanner/malicious', () => ({
+  scanForMaliciousContent: vi.fn().mockReturnValue([]),
+}))
+
+vi.mock('../lib/kubectlProxy', () => ({
+  kubectlProxy: { exec: vi.fn() },
+}))
+
+// ── Mock WebSocket ─────────────────────────────────────────────────────────────
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  /** Reference to the most recently created instance. Reset in beforeEach. */
+  static lastInstance: MockWebSocket | null = null
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((e: Event) => void) | null = null
+  onmessage: ((e: MessageEvent) => void) | null = null
+  onclose: ((e: CloseEvent) => void) | null = null
+  onerror: ((e: Event) => void) | null = null
+  send = vi.fn()
+  close = vi.fn()
+
+  constructor(public url: string) {
+    MockWebSocket.lastInstance = this
+  }
+
+  simulateOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent('message', { data: JSON.stringify(data) }))
+  }
+
+  simulateClose() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onclose?.(new CloseEvent('close'))
+  }
+
+  simulateError() {
+    this.onerror?.(new Event('error'))
+  }
+}
+
+vi.stubGlobal('WebSocket', MockWebSocket)
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <MissionProvider>{children}</MissionProvider>
+)
+
+const defaultParams = {
+  title: 'Test Mission',
+  description: 'Pod crash investigation',
+  type: 'troubleshoot' as const,
+  initialPrompt: 'Fix the pod crash',
+  skipReview: true,
+}
+
+/** Start a mission and simulate the WebSocket opening so the mission moves to 'running'. */
+async function startMissionWithConnection(
+  result: { current: ReturnType<typeof useMissions> },
+): Promise<{ missionId: string; requestId: string }> {
+  let missionId = ''
+  act(() => {
+    missionId = result.current.startMission(defaultParams)
+  })
+  // Flush the preflight promise chain before simulating the socket opening.
+  await flushMissionPreflightChain()
+  await act(async () => {
+    MockWebSocket.lastInstance?.simulateOpen()
+  })
+  // Find the chat send call (list_agents fires first, then chat)
+  const chatCall = MockWebSocket.lastInstance?.send.mock.calls.find(
+    (call: string[]) => JSON.parse(call[0]).type === 'chat',
+  )
+  const requestId = chatCall ? JSON.parse(chatCall[0]).id : ''
+  return { missionId, requestId }
+}
+
+async function flushMissionPreflightChain() {
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+  await act(async () => { await Promise.resolve() })
+}
+
+// ── Pre-seed a mission in localStorage without going through the WS flow ──────
+beforeEach(() => {
+  localStorage.clear()
+  MockWebSocket.lastInstance = null
+  missionCache.installers = []
+  vi.clearAllMocks()
+  vi.mocked(getDemoMode).mockReturnValue(false)
+  // Suppress auto-reconnect noise: after onclose, ensureConnection is retried
+  // after 3 s. Tests complete before that fires, but mocking fetch avoids
+  // unhandled-rejection warnings from the HTTP fallback path.
+  globalThis.fetch = vi.fn().mockResolvedValue({ ok: true })
+})
+
+// ── saveMission ───────────────────────────────────────────────────────────────
+
 describe('startMission cluster targeting', () => {
   it('injects single cluster context into the prompt', async () => {
     const { result } = renderHook(() => useMissions(), { wrapper })


### PR DESCRIPTION
Round 2 of the #22043 split-truncation cleanup. Main's post-#22197 Coverage Suite run (@41411b97) failed with 41 tests red in `useMissions.cluster-targeting.test.tsx` — `ReferenceError: renderHook is not defined`. Same truncation class, different missing piece: this file lost its **imports and mocks** while keeping test bodies, and escaped round 1's seedMission-keyed audit because it never uses that helper.

This time the audit was structural across **all 22** useMissions test files (first line must be an import; every renderHook/mock use must resolve): cluster-targeting was the only remaining gap. Prelude restored verbatim from the pre-split parent; unused imports + unused seedMission helper trimmed. ESLint 0/0, esbuild parse clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)