### PR TITLE
🐛 fix: final three defects from the useMissions test split

### DIFF
--- a/web/src/hooks/useMissions.persistence-agents.test.tsx
+++ b/web/src/hooks/useMissions.persistence-agents.test.tsx
@@ -404,5 +404,3 @@ describe('agent selection logic', () => {
 
 // ── sendMessage edge cases ──────────────────────────────────────────────────
 
-describe('sendMessage edge cases', () => {
-})

--- a/web/src/hooks/useMissions.preflight-stream.test.tsx
+++ b/web/src/hooks/useMissions.preflight-stream.test.tsx
@@ -522,5 +522,3 @@ describe('preflight check', () => {
 
 // ── Malicious content scanning ───────────────────────────────────────────────
 
-describe('runSavedMission malicious content scan', () => {
-})

--- a/web/src/hooks/useMissions.save-rename-run.test.tsx
+++ b/web/src/hooks/useMissions.save-rename-run.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from '@testing-library/react'
 import React from 'react'
 import { MissionProvider, useMissions } from './useMissions'
 import { getDemoMode } from './useDemoMode'
+import { missionCache } from '../lib/missions/missionCache'
 
 // ── External module mocks ─────────────────────────────────────────────────────
 


### PR DESCRIPTION
Round 3 of the #22043 split-truncation cleanup — and the last, because this time the whole 22-file useMissions suite was **run locally: 345 tests, 0 failures**.

1. `save-rename-run`: split dropped the `missionCache` import; `beforeEach` still references it → the ReferenceError behind main's red after round 2.
2. `preflight-stream`: empty `describe('runSavedMission malicious content scan')` — its tests were moved into dedup-timeout by the split; vitest fails a testless suite.
3. `persistence-agents`: same, empty `describe('sendMessage edge cases')`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)