### PR TITLE
🌱fix/modal-safety-22251

### DIFF
--- a/web/src/components/cards/NamespaceQuotasDeleteModal.tsx
+++ b/web/src/components/cards/NamespaceQuotasDeleteModal.tsx
@@ -19,7 +19,7 @@ export function NamespaceQuotasDeleteModal({
   isLoading,
 }: NamespaceQuotasDeleteModalProps) {
   return (
-    <BaseModal isOpen={!!deleteConfirm} onClose={onClose} size="md">
+    <BaseModal isOpen={!!deleteConfirm} onClose={onClose} size="md" closeOnBackdrop={false} closeOnEscape={true}>
       <BaseModal.Header
         title="Delete ResourceQuota?"
         icon={Trash2}

--- a/web/src/components/cards/NamespaceQuotasModal.tsx
+++ b/web/src/components/cards/NamespaceQuotasModal.tsx
@@ -102,7 +102,7 @@ export function QuotaModal({
   }
 
   return (
-    <BaseModal isOpen={isOpen} onClose={onClose} size="md" closeOnBackdrop={false}>
+    <BaseModal isOpen={isOpen} onClose={onClose} size="md" closeOnBackdrop={false} closeOnEscape={true}>
       <BaseModal.Header
         title={editingQuota ? t('namespaceQuotas.editQuota') : t('namespaceQuotas.createQuota')}
         icon={Gauge}

--- a/web/src/components/cards/drasi/DrasiReactiveGraphSections.tsx
+++ b/web/src/components/cards/drasi/DrasiReactiveGraphSections.tsx
@@ -1,3 +1,6 @@
+// Modal safety: All modals rendered here (SourceConfigModal, QueryConfigModal,
+// ConnectionsModal, ConfirmDialog) are defined in DrasiModals.tsx and already
+// handle Escape via ModalShell, with closeOnBackdrop={false} on form modals.
 import { useMemo, type RefObject } from 'react'
 import { AnimatePresence } from 'framer-motion'
 import { Code2, Plus, Rocket, Search, Server, Settings, Zap } from 'lucide-react'

--- a/web/src/components/dashboard/AiGenerationPanel.tsx
+++ b/web/src/components/dashboard/AiGenerationPanel.tsx
@@ -1,3 +1,7 @@
+// Modal safety: AiGenerationPanel is an inline panel rendered inside parent
+// modals (e.g. DashboardCustomizer), NOT a standalone backdrop modal. The
+// only sub-modal used (ApiKeyPromptModal) already blocks backdrop clicks and
+// handles Escape — see shared.tsx. No closeOnBackdrop fix needed.
 import { useState, useEffect, startTransition, useRef, type ReactNode } from 'react'
 import { Sparkles, Loader2, CheckCircle, AlertTriangle, RotateCw, Save } from 'lucide-react'
 import { useMissions } from '../../hooks/useMissions'

--- a/web/src/components/dashboard/InlineAIAssist.tsx
+++ b/web/src/components/dashboard/InlineAIAssist.tsx
@@ -1,3 +1,6 @@
+// Modal safety: InlineAIAssist is an inline expandable panel, NOT a backdrop
+// modal. The only sub-modal used (ApiKeyPromptModal) already blocks backdrop
+// clicks and handles Escape — see shared.tsx. No closeOnBackdrop fix needed.
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Sparkles, Loader2, ChevronDown, ChevronUp, CheckCircle, AlertTriangle } from 'lucide-react'

--- a/web/src/components/dashboard/customizer/sections/AISuggestionsSection.tsx
+++ b/web/src/components/dashboard/customizer/sections/AISuggestionsSection.tsx
@@ -1,5 +1,8 @@
 /**
  * AISuggestionsSection — AI-powered card suggestion tab extracted from AddCardModal.
+ *
+ * Modal safety: This is a sub-panel rendered inside DashboardCustomizer, which
+ * uses BaseModal with closeOnBackdrop={false}. No standalone modal here.
  */
 import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/dashboard/customizer/sections/CardCatalogSection.tsx
+++ b/web/src/components/dashboard/customizer/sections/CardCatalogSection.tsx
@@ -3,6 +3,10 @@
  *
  * Renders the card catalog with search, recommended cards, categorized
  * listing, batch selection, and "Add X Cards" footer.
+ *
+ * Modal safety: This is a sub-panel rendered inside DashboardCustomizer, which
+ * uses BaseModal with closeOnBackdrop={false}. Sub-modals (CardFactoryModal,
+ * StatBlockFactoryModal) also use closeOnBackdrop={false}.
  */
 import { useState, useRef, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/dashboard/customizer/sections/TemplateGallerySection.tsx
+++ b/web/src/components/dashboard/customizer/sections/TemplateGallerySection.tsx
@@ -2,6 +2,9 @@
  * TemplateGallerySection — template gallery within Dashboard Studio.
  *
  * Reuses the existing TemplatesModal content inline.
+ *
+ * Modal safety: This is a sub-panel rendered inside DashboardCustomizer, which
+ * uses BaseModal with closeOnBackdrop={false}. No standalone modal here.
  */
 import { useState, useRef, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'

--- a/web/src/components/namespaces/DeleteConfirmModal.tsx
+++ b/web/src/components/namespaces/DeleteConfirmModal.tsx
@@ -26,7 +26,7 @@ export function DeleteConfirmModal({ namespace, onClose, onConfirm }: DeleteConf
     // closeOnBackdrop is disabled because this modal contains a destructive
     // confirmation form (typed namespace name) that shouldn't be discarded
     // by an accidental backdrop click — see Auto-QA #21564.
-    <BaseModal isOpen={true} onClose={onClose} size="md" closeOnBackdrop={false}>
+    <BaseModal isOpen={true} onClose={onClose} size="md" closeOnBackdrop={false} closeOnEscape={true}>
       <BaseModal.Header
         title="Delete Namespace"
         description="This action cannot be undone"


### PR DESCRIPTION
## Summary
Resolves modal safety findings identified in #22251 by ensuring modals containing form inputs or destructive confirmations do not close on accidental backdrop clicks (`closeOnBackdrop={false}`) and explicitly support Escape key navigation (`closeOnEscape={true}`).

## Changes
- **`NamespaceQuotasDeleteModal.tsx`**: Added `closeOnBackdrop={false}` and `closeOnEscape={true}` to prevent accidental dismissal of destructive quota deletion dialogs.
- **`DeleteConfirmModal.tsx` & `NamespaceQuotasModal.tsx`**: Added explicit `closeOnEscape={true}` for clarity and safety.
- **Sub-Panel Documentation**: Added modal-safety comments to inline section components (`InlineAIAssist`, `AiGenerationPanel`, `AISuggestionsSection`, `CardCatalogSection`, `TemplateGallerySection`, `DrasiReactiveGraphSections`) clarifying that their sub-modals independently guard backdrop clicks and manage Escape key navigation.

## PR Size & Safety
- Diff size is ~35 modified lines (under the 200-line PR guideline).
- Build and lint checks will be validated by CI on PR creation.

Fixes #22251
