### PR TITLE
🐛 Fix: fail coverage merge job on incomplete shard artifact set

### DIFF
--- a/.github/workflows/coverage-hourly.yml
+++ b/.github/workflows/coverage-hourly.yml
@@ -167,6 +167,23 @@ jobs:
           pattern: coverage-shard-*
           path: /tmp/shards
 
+      - name: Verify shard artifact completeness
+        run: |
+          # Each shard uploads coverage under `web/coverage/coverage-final.json` with
+          # `if-no-files-found: ignore`, so a crashed/timed-out/OOM-killed shard simply
+          # produces no artifact instead of failing the download step. Because
+          # `test.coverage.all` is false in web/vite.config.ts, each shard only reports
+          # coverage for files its own tests import — the merge step unions whatever
+          # artifacts are present, so silently merging fewer than TOTAL_SHARDS artifacts
+          # produces an artificial coverage drop instead of a build failure (#22273).
+          # Fail loudly here instead of letting that reach the merge/badge step.
+          FOUND=$(find /tmp/shards -maxdepth 1 -type d -name 'coverage-shard-*' | wc -l | tr -d ' ')
+          echo "Found ${FOUND}/${TOTAL_SHARDS} shard coverage artifacts"
+          if [ "$FOUND" -lt "$TOTAL_SHARDS" ]; then
+            echo "::error::Only ${FOUND}/${TOTAL_SHARDS} coverage shard artifacts were downloaded. One or more shards likely failed, timed out, or was OOM-killed before uploading coverage. Refusing to merge an incomplete coverage set — check the test-shard job runs above for the missing shard(s)."
+            exit 1
+          fi
+
       - name: Download failed test artifacts
         if: always()
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1


### PR DESCRIPTION
Fixes #22283

---

### 📝 Summary of Changes

- `coverage-hourly.yml` merge job now fails explicitly if fewer than the expected 12 shard coverage artifacts were downloaded, instead of silently merging whatever subset is present.
- Addresses the root cause described in #22283 (and observed in #22273): because `web/vite.config.ts` sets `test.coverage.all = false`, each shard only reports coverage for files its own tests import, so a flaky/timed-out/OOM-killed shard previously produced an artificial coverage drop rather than a CI failure.

---

### Changes Made

- [x] Added a "Verify shard artifact completeness" step in the `merge-coverage` job, placed after "Download all shard coverage" and before the merge step.
- [x] The step counts directories matching `coverage-shard-*` under `/tmp/shards` and compares against the existing `TOTAL_SHARDS` env var (12). If the count is short, it prints a `::error::` annotation naming the shortfall and exits 1, failing the job before any merge/badge-update logic runs.
- [x] Implements Option 1 from the issue's recommendation list ("Fail-fast on shard count mismatch"), which the issue lists as the preferred option.

---

### Checklist

- [x] I used a coding agent (Claude Code, Copilot, Gemini, or Codex) to generate/review this code
- [x] I have reviewed the project's contribution guidelines
- [x] New cards target console-marketplace, not this repo (N/A — no cards touched)
- [x] isDemoData is wired correctly (N/A — no card components touched)
- [ ] I have written unit tests for the changes (N/A — this is a workflow-only YAML change; GitHub Actions workflow logic isn't unit-testable in this repo's test suite)
- [x] I have tested the changes locally and ensured they work as expected (see Validation below)
- [x] All commits are signed with DCO (`git commit -s`)

---

### Validation

Workflow YAML changes can't be executed locally in the normal sense (no local Actions runner in this environment). What was verified:

- YAML syntax parses cleanly (`python -c "import yaml; yaml.safe_load(open('.github/workflows/coverage-hourly.yml', encoding='utf-8'))"` succeeds).
- Manually traced the new step's logic against the existing merge step's own shard-counting loop (`for dir in /tmp/shards/coverage-shard-*`) to confirm the glob/counting logic matches how shards actually land on disk after `actions/download-artifact` with `pattern: coverage-shard-*`.
- `TOTAL_SHARDS` is already defined at the workflow-level `env:` block (`env.TOTAL_SHARDS: 12`), so it's available as a shell env var in the new `run:` step without any additional wiring.
- Real validation is the next scheduled/triggered run of the `Coverage Suite` workflow on `main` — this is a workflow-file change, so behavior can only be fully confirmed by an actual Actions run (e.g. if a shard is deliberately failed/skipped, or on the next natural flaky-shard occurrence).

---

### 👀 Reviewer Notes

Per the issue's own preference ordering, this implements option 1 (fail-fast on shard count). Options 2 (gate the delta) and 3 (manifest cross-check) were not implemented since the issue states option 1 is preferred when not overly disruptive, and a workflow-only fail-fast check is low effort/low risk here.
