### PR TITLE
fix: capture PVC-migration hook logs and fix shell mismatch on deploy-vllm-d

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -608,6 +608,31 @@ jobs:
               --timeout 10m
           }
 
+          # Dumps the pre-upgrade PVC-migration hook Job's diagnostics.
+          # helm.sh/hook-delete-policy on that Job includes hook-failed, so a
+          # failed Job (and its pod/logs) is deleted by Helm shortly after
+          # `helm upgrade` returns — and deleted again by
+          # before-hook-creation on the NEXT retry attempt. This must run
+          # immediately after each failed deploy_helm call, before any retry
+          # or recovery step touches the release, or the logs are gone for
+          # good. Every command is best-effort (|| true) so a diagnostics
+          # failure never masks or replaces the real deploy failure.
+          dump_migration_hook_diagnostics() {
+            local job_name="${{ env.HELM_RELEASE_NAME }}-kubestellar-console-pvc-migration"
+            echo "::group::PVC migration hook Job/Pod status"
+            kubectl -n kc get jobs,pods -l app.kubernetes.io/component=pvc-migration -o wide || true
+            echo "::endgroup::"
+            echo "::group::PVC migration hook Job describe (events, failure reason)"
+            kubectl -n kc describe job "$job_name" || true
+            echo "::endgroup::"
+            echo "::group::PVC migration hook Job logs"
+            kubectl -n kc logs "job/$job_name" --all-containers --tail=200 --prefix || true
+            echo "::endgroup::"
+            echo "::group::Recent namespace events"
+            kubectl -n kc get events --sort-by=.lastTimestamp | tail -40 || true
+            echo "::endgroup::"
+          }
+
           MAX_ATTEMPTS=2
           for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
             echo "Deploy attempt $attempt of $MAX_ATTEMPTS..."
@@ -616,8 +641,11 @@ jobs:
               exit 0
             fi
 
+            echo "::warning::Deploy attempt $attempt failed"
+            dump_migration_hook_diagnostics
+
             if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-              echo "::warning::Deploy attempt $attempt failed, recovering and retrying..."
+              echo "::warning::Recovering and retrying..."
               sleep 30
               recover_release
               cleanup_stuck_pods

--- a/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
+++ b/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
@@ -101,11 +101,26 @@ spec:
             capabilities:
               drop:
                 - ALL
+          env:
+            # alpine/k8s has no non-root user baked in, so under an
+            # OpenShift-assigned arbitrary UID (runAsNonRoot with no fixed
+            # runAsUser) the default $HOME (/root) is not writable by that
+            # UID. kubectl and any tool cache/config writes would fail.
+            # /tmp is world-writable (sticky bit) regardless of UID, so
+            # pointing HOME there avoids the failure without needing a
+            # fixed UID or an extra writable volume.
+            - name: HOME
+              value: /tmp
           command:
-            - /bin/bash
+            # alpine/k8s ships /bin/sh (busybox ash), not bash. The script
+            # below is POSIX-sh compatible (no [[, <<<, arrays, or other
+            # bashisms) so it runs unmodified under sh. `set -o pipefail`
+            # is not POSIX; omitted since the script uses no pipelines
+            # whose exit status matters.
+            - /bin/sh
             - -c
             - |
-              set -euo pipefail
+              set -eu
 
               NAMESPACE="{{ .Release.Namespace }}"
               MAIN_PVC="{{ include "kubestellar-console.fullname" . }}"
@@ -121,7 +136,7 @@ spec:
                 local pvc_name=$1
                 echo "Checking PVC: $pvc_name"
 
-                if ! kubectl get pvc "$pvc_name" -n "$NAMESPACE" &>/dev/null; then
+                if ! kubectl get pvc "$pvc_name" -n "$NAMESPACE" >/dev/null 2>&1; then
                   echo "  PVC does not exist (new install). Skipping."
                   return 0
                 fi

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -17,13 +17,21 @@ nameOverride: ""
 fullnameOverride: ""
 
 # Image used by the pre-upgrade PVC migration Job.
-# Use the official Kubernetes kubectl image from registry.k8s.io.
 # bitnami/kubectl no longer publishes versioned tags on Docker Hub
-# (manifest unknown for 1.36+), so we switched to the upstream image.
+# (manifest unknown for 1.36+), so we moved to registry.k8s.io/kubectl.
+# That image is distroless (go-runner + a single static `kubectl` binary,
+# entrypoint /bin/kubectl) and ships NO shell at all — not bash, not even
+# /bin/sh — so the Job's `/bin/bash -c "<script>"` command failed instantly
+# on every attempt (failed: 1/1, backoffLimit exhausted) with no useful
+# logs. alpine/k8s bundles kubectl on top of a normal Alpine root
+# filesystem, so /bin/sh (busybox ash) is present; the migration script is
+# POSIX-sh compatible (see command in pre-upgrade-pvc-migration.yaml), and
+# Alpine has no fixed non-root user baked in, so it still honors the Job's
+# runAsNonRoot/allowPrivilegeEscalation=false securityContext.
 migration:
   image:
-    repository: registry.k8s.io/kubectl
-    tag: "v1.32.4"
+    repository: alpine/k8s
+    tag: "1.32.4"
 
 serviceAccount:
   create: true


### PR DESCRIPTION
## Problem

The pre-upgrade PVC-migration hook Job (`kc-kubestellar-console-pvc-migration`) has been failing on every attempt of the `deploy-vllm-d` job in `.github/workflows/build-deploy.yml` since the migration image was switched to `registry.k8s.io/kubectl`:

`status: Failed, message: Job Failed. failed: 1/1` (backoffLimit: 3, all attempts fail)

The prior fix (#22402) correctly shortened `activeDeadlineSeconds` so the Job fails fast instead of hanging past Helm's timeout, but the underlying script failure was never visible — the deploy job doesn't capture the hook pod's logs, and `helm.sh/hook-delete-policy: ...,hook-failed` deletes the failed Job (and its pod/logs) almost immediately after Helm reports the failure.

## Root cause

`registry.k8s.io/kubectl:v1.32.4` is a distroless image — built from `go-runner` wrapping `gcr.io/distroless/static`, with entrypoint `/bin/kubectl` directly. Verified by pulling and inspecting its layers/config directly: the image contains **no shell binary at all** — not `/bin/bash`, not even `/bin/sh`. The Job's command was `/bin/bash -c "<script>"`, so the container failed instantly on every attempt with no useful output — exactly matching the observed `failed: 1/1` signature.

## Fix

**Part 1 — make the failure visible in CI:**
- Added `dump_migration_hook_diagnostics()` to the `Deploy with Helm` retry loop in `build-deploy.yml`, called immediately after each failed `helm upgrade` attempt (before `recover_release`/`cleanup_stuck_pods` or the next attempt's `before-hook-creation` delete can remove the Job). Captures:
  - `kubectl -n kc get jobs,pods -l app.kubernetes.io/component=pvc-migration -o wide`
  - `kubectl -n kc describe job kc-kubestellar-console-pvc-migration`
  - `kubectl -n kc logs job/kc-kubestellar-console-pvc-migration --all-containers --tail=200 --prefix`
  - `kubectl -n kc get events --sort-by=.lastTimestamp | tail -40`
  - Every command is best-effort (`|| true`) so diagnostics capture can never itself fail the deploy step.

**Part 2 — fix the actual bug:**
- Switched `migration.image` from `registry.k8s.io/kubectl:v1.32.4` to `alpine/k8s:1.32.4`, which bundles `kubectl` on a normal Alpine root filesystem (busybox `/bin/sh` present). Verified the `1.32.4` tag exists directly against the registry.
- Switched the Job's command from `/bin/bash` to `/bin/sh`, and removed the one bashism in the script (`&>/dev/null` → `>/dev/null 2>&1`; `set -euo pipefail` → `set -eu` since `pipefail` is non-POSIX and the script has no pipelines whose exit status matters). The rest of the script was already POSIX-sh compatible (no `[[`, `<<<`, arrays — only `local`, which busybox ash supports).
- Added `HOME=/tmp` to the migration container's env: `alpine/k8s` has no non-root user baked in, so under OpenShift's arbitrary-UID assignment (`runAsNonRoot: true` with no fixed `runAsUser`) the default `$HOME` (`/root`) is not writable by that UID, which would otherwise break kubectl's cache/config writes.

RBAC was also reviewed: the script only ever calls `kubectl get pvc` and `kubectl delete pvc` — no `patch`, no PV access — and the existing Role already grants `get, list, watch, delete` on PVCs, so RBAC was not a contributing cause.

Fixes #22407

🤖 Generated with [Claude Code](https://claude.com/claude-code)