### PR TITLE
fix(ci): remove stale scanner-checks-failing label on guardrail pass

### DIFF
--- a/.github/workflows/scanner-merge-guardrails.yml
+++ b/.github/workflows/scanner-merge-guardrails.yml
@@ -221,6 +221,26 @@ jobs:
               }
             }
             
+            // All guardrails passed -- clear any stale `scanner-checks-failing` label left
+            // over from a prior run that genuinely failed (or, before #22442, a false-fail
+            // on in-flight checks). removeLabel 404s if the label isn't currently on the
+            // PR; that's the expected/common case, not an error, so it's caught and ignored.
+            const STALE_FAILING_LABEL = 'scanner-checks-failing';
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: pr.number,
+                name: STALE_FAILING_LABEL
+              });
+              core.info(`🧹 Removed stale '${STALE_FAILING_LABEL}' label.`);
+            } catch (e) {
+              if (e.status !== 404) {
+                throw e;
+              }
+              // Label wasn't present -- nothing to clean up.
+            }
+
             core.info('✅ All scanner merge guardrails passed');
             core.summary
               .addHeading('Scanner Merge Guardrails: Passed')


### PR DESCRIPTION
## Problem

#22442 fixed `enforce-guardrails` so it no longer false-fails while required checks (build-gate, Analyze Go, Lint warning regression check) are still pending — it now distinguishes genuinely-failing checks from pending ones and only fails on real violations.

However, the workflow only ever calls `github.rest.issues.addLabels(...)` to *add* the `scanner-checks-failing` label on the failure path. It never *removes* that label once the guardrail concludes success. PRs that were mislabeled by the old false-fail bug (e.g. #22441, #22438) still carry `scanner-checks-failing` even though `enforce-guardrails` now reports `completed`/`success` and `mergeable=true`. The stale label leaves them effectively blocked, and the Forge App (`kubestellar-hive[bot]`) won't self-merge a PR that still carries a failing-guardrail label.

## Fix

On the genuine-success path (after circuit breaker, rate limit, genuinely-failing-checks, and pending-checks are all clear), remove the `scanner-checks-failing` label if present:

```js
await github.rest.issues.removeLabel({ owner, repo, issue_number: pr.number, name: STALE_FAILING_LABEL });
```

`removeLabel` throws (404) when the label isn't on the PR — the common case — so that specific status is caught and swallowed; any other error still propagates.

The pending/deferred path is untouched (it defers evaluation and returns early, before this code runs). The genuine-failure path is untouched (still `addLabels(['scanner-checks-failing'])` + `core.setFailed`). This is purely additive: PRs that pass the guardrail get the stale label cleared so they can be self-merged.