### PR TITLE
ci: bump Go 1.26.5 to 1.26.6 in workflows to unblock CVE fix (GO-2026-6089/6090/6091/6218)

### DIFF
--- a/.github/workflows/api-contract.yml
+++ b/.github/workflows/api-contract.yml
@@ -17,7 +17,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   api-contract:

--- a/.github/workflows/auto-qa.yml
+++ b/.github/workflows/auto-qa.yml
@@ -43,7 +43,7 @@ env:
   COPILOT_ASSIGNMENT_DELAY_S: 120  # Seconds between Copilot assignments to avoid rate limiting
   ISSUE_PREFIX: "[Auto-QA]"
   NODE_VERSION: "22"
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 permissions: read-all  # default read; writes scoped to job below
 

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       # Full suite — must match what release.yml runs or main can still

--- a/.github/workflows/nightly-test-suite.yml
+++ b/.github/workflows/nightly-test-suite.yml
@@ -18,7 +18,7 @@ concurrency:
 env:
   RESULTS_DIR: test-results/nightly
   NODE_VERSION: '22'
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
 
 jobs:
   test:

--- a/.github/workflows/nil-safety.yml
+++ b/.github/workflows/nil-safety.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 permissions: read-all  # default read; writes scoped to job below
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,7 +185,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Set up Node.js
@@ -254,7 +254,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
-          go-version: '1.26.5'
+          go-version: '1.26.6'
           cache: true
 
       - name: Set up Node.js

--- a/.github/workflows/startup-smoke.yml
+++ b/.github/workflows/startup-smoke.yml
@@ -35,7 +35,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: '1.26.5'
+  GO_VERSION: '1.26.6'
   NODE_VERSION: '22'
 
 jobs:

--- a/.github/workflows/update-guard.yml
+++ b/.github/workflows/update-guard.yml
@@ -17,7 +17,7 @@ on:
   workflow_dispatch:
 
 env:
-  GO_VERSION: "1.26.5"
+  GO_VERSION: "1.26.6"
 
 permissions: read-all  # default read; writes scoped to job below
 


### PR DESCRIPTION
## What

Bumps the Go version pin from `1.26.5` to `1.26.6` in all 8 GitHub Actions workflow files (9 occurrences — `release.yml` has two). This is the **only remaining gap**: `go.mod` (`go 1.26.6`) and both Dockerfiles (`golang:1.26.6-alpine`) are already at 1.26.6 on `main`; only the workflow pins lagged.

## Why — the CVE re-revert deadlock

Sec-check/scanner agents bump `go.mod` to `go 1.26.6` to close 4 Go stdlib CVEs:

- **GO-2026-6089** — net/http HTTP/2 DoS
- **GO-2026-6090** — crypto/tls DoS
- **GO-2026-6091** — html/template XSS
- **GO-2026-6218** — net/url DoS

But every CI workflow pins Go **1.26.5** via `actions/setup-go`, which defaults `GOTOOLCHAIN=local` and refuses to fetch 1.26.6. So `goreleaser`/build fails with:

```
go: go.mod requires go >= 1.26.6 (running go 1.26.5; GOTOOLCHAIN=local)
```

An auto-issue is filed, the scanner reverts the `go.mod` bump, and the CVEs reopen. The loop repeats.

Agents cannot break this loop: their tokens lack `workflows:write`, so they can't touch `.github/workflows/*`. This maintainer-scoped PR bumps the workflow pins so the `go.mod` fix can finally stick.

## Scope

- Changes **only** files under `.github/workflows/`. No `go.mod`, Dockerfile, or source changes.
- Only the `1.26.5` → `1.26.6` version value is changed; existing quoting style preserved per file.

## Merge note

**This PR must be merged by a maintainer with `workflows:write`** — the console App/bot cannot modify workflow files.

Refs #22588
