### PR TITLE
✨ feat(a11y): allow dismissing Tooltip with Escape key on keyboard focus

### DIFF
--- a/web/src/components/ui/Tooltip.tsx
+++ b/web/src/components/ui/Tooltip.tsx
@@ -22,7 +22,7 @@
  *   </Tooltip>
  */
 
-import React, { type ReactNode, useId } from 'react'
+import React, { type ReactNode, useId, useState } from 'react'
 import { cn } from '../../lib/cn'
 
 // ── Named constants ─────────────────────────────────────────────────────────
@@ -104,9 +104,25 @@ export function Tooltip({
   disabled,
 }: TooltipProps) {
   const tooltipId = useId()
+  const [isDismissed, setIsDismissed] = useState(false)
 
   if (disabled || content == null || content === '') {
     return <>{children}</>
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape' && !isDismissed) {
+      e.stopPropagation()
+      setIsDismissed(true)
+    }
+  }
+
+  const handlePointerLeave = () => {
+    if (isDismissed) setIsDismissed(false)
+  }
+
+  const handleBlur = () => {
+    if (isDismissed) setIsDismissed(false)
   }
 
   // Clone the child so `aria-describedby` lands on the actual focusable
@@ -136,7 +152,12 @@ export function Tooltip({
     : children
 
   return (
-    <div className={cn('group relative inline-flex', wrapperClassName)}>
+    <div
+      className={cn('group relative inline-flex', wrapperClassName)}
+      onKeyDown={handleKeyDown}
+      onPointerLeave={handlePointerLeave}
+      onBlur={handleBlur}
+    >
       {childWithAria}
       <span
         id={tooltipId}
@@ -144,7 +165,8 @@ export function Tooltip({
         className={cn(
           'absolute z-dropdown',
           SIDE_POSITION_MAP[side],
-          'pointer-events-none opacity-0 group-hover:opacity-100 group-focus-within:opacity-100',
+          'pointer-events-none opacity-0',
+          !isDismissed && 'group-hover:opacity-100 group-focus-within:opacity-100',
           'transition-opacity',
           TOOLTIP_FADE_DURATION_CLASS,
           'bg-card text-card-foreground border border-border shadow-lg',

--- a/web/src/components/ui/__tests__/Tooltip.test.tsx
+++ b/web/src/components/ui/__tests__/Tooltip.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { Tooltip } from '../Tooltip'
 
 describe('Tooltip', () => {
@@ -131,5 +131,23 @@ describe('Tooltip', () => {
       expect(bubble.className).toContain(expected[side])
       unmount()
     }
+  })
+
+  it('dismisses tooltip when Escape key is pressed and restores on pointer leave / blur', () => {
+    const { container } = render(
+      <Tooltip content="Helpful text">
+        <button data-testid="trigger">Trigger</button>
+      </Tooltip>,
+    )
+    const bubble = screen.getByRole('tooltip')
+    const wrapper = container.firstChild as HTMLElement
+
+    expect(bubble.className).toContain('group-hover:opacity-100')
+
+    fireEvent.keyDown(wrapper, { key: 'Escape' })
+    expect(bubble.className).not.toContain('group-hover:opacity-100')
+
+    fireEvent.pointerLeave(wrapper)
+    expect(bubble.className).toContain('group-hover:opacity-100')
   })
 })


### PR DESCRIPTION
Ref #22881

### Description
Implements WAI-ARIA Tooltip keyboard pattern for \components/ui/Tooltip.tsx\:
- Pressing \Escape\ while focused on the tooltip trigger dismisses the tooltip bubble without moving focus.
- Pointer leave or blur resets the dismissal state so subsequent hover/focus interactions continue to show the tooltip.

### Changes
- Added \isDismissed\ state and \onKeyDown\ / \onPointerLeave\ / \onBlur\ event handlers in \Tooltip.tsx\.
- Added unit tests in \Tooltip.test.tsx\ testing \Escape\ dismissal and restoration.

Signed-off-by: Vijay Misal <misalvijay153@gmail.com>