### PR TITLE
🐛 Fix pvc-migration hook runAsNonRoot failure on non-OpenShift clusters

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -602,6 +602,8 @@ jobs:
               --set securityContext.runAsUser=null \
               --set securityContext.runAsGroup=null \
               --set podSecurityContext.fsGroup=null \
+              --set migration.runAsUser=null \
+              --set migration.runAsGroup=null \
               --set podLabels.team=kubestellar \
               --atomic \
               --cleanup-on-fail \

--- a/deploy/helm/kubestellar-console/README.md
+++ b/deploy/helm/kubestellar-console/README.md
@@ -468,7 +468,9 @@ If you are not using the overlay file, you can also null the fields manually:
 helm upgrade kc ./deploy/helm/kubestellar-console -n kubestellar-console \
   --set securityContext.runAsUser=null \
   --set securityContext.runAsGroup=null \
-  --set podSecurityContext.fsGroup=null
+  --set podSecurityContext.fsGroup=null \
+  --set migration.runAsUser=null \
+  --set migration.runAsGroup=null
 ```
 
 ### `container has runAsNonRoot and image has non-numeric user (appuser)`

--- a/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
+++ b/deploy/helm/kubestellar-console/templates/pre-upgrade-pvc-migration.yaml
@@ -91,16 +91,33 @@ spec:
         - name: migrate-pvcs
           image: "{{ .Values.migration.image.repository }}:{{ .Values.migration.image.tag }}"
           imagePullPolicy: IfNotPresent
-          # OpenShift's restricted-v2 SCC forbids runAsUser: 0 (root) and
-          # requires the UID to fall within the namespace's allowed range
-          # (e.g. [1001240000, 1001249999]). Setting runAsNonRoot: true
-          # without an explicit runAsUser lets OpenShift inject an allowed
-          # UID automatically. alpine/k8s has no hard-coded USER directive
-          # so Kubernetes can override the UID at runtime (#22925).
+          # Two conflicting admission regimes must both pass here:
+          #  - Plain Kubernetes (Kind, Minikube, OKE console-live): nothing
+          #    injects a UID, and the kubelet can only verify runAsNonRoot
+          #    against a NUMERIC effective UID. alpine/k8s has no USER
+          #    directive (runs as root), so runAsNonRoot: true without an
+          #    explicit numeric runAsUser is refused at container start:
+          #    "container has runAsNonRoot and image will run as root"
+          #    (#22907/#22919/#22946).
+          #  - OpenShift restricted-v2 SCC: forbids runAsUser: 0 and rejects
+          #    any fixed UID outside the namespace's assigned range; it
+          #    injects an in-range UID itself when runAsUser is unset
+          #    (#22925).
+          # Both are satisfied by defaulting migration.runAsUser/runAsGroup
+          # to a numeric non-root UID in values.yaml and nulling them on
+          # OpenShift (values-openshift.yaml or --set
+          # migration.runAsUser=null), mirroring the chart's existing
+          # securityContext.runAsUser pattern for the app container.
           # HOME=/tmp (set below) ensures kubectl cache writes succeed
-          # regardless of which UID is injected.
+          # regardless of which UID runs the container.
           securityContext:
             runAsNonRoot: true
+            {{- if .Values.migration.runAsUser }}
+            runAsUser: {{ .Values.migration.runAsUser }}
+            {{- end }}
+            {{- if .Values.migration.runAsGroup }}
+            runAsGroup: {{ .Values.migration.runAsGroup }}
+            {{- end }}
             allowPrivilegeEscalation: false
             capabilities:
               drop:

--- a/deploy/helm/kubestellar-console/values-openshift.yaml
+++ b/deploy/helm/kubestellar-console/values-openshift.yaml
@@ -35,3 +35,10 @@ securityContext:
   runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
+
+# The pvc-migration pre-upgrade hook container follows the same SCC rule:
+# drop the fixed UID/GID (numeric defaults in values.yaml, needed on plain
+# Kubernetes) so restricted-v2 injects an in-range UID (#22925/#22946).
+migration:
+  runAsUser: null
+  runAsGroup: null

--- a/deploy/helm/kubestellar-console/values.yaml
+++ b/deploy/helm/kubestellar-console/values.yaml
@@ -32,6 +32,23 @@ migration:
   image:
     repository: alpine/k8s
     tag: "1.32.4"
+  # Numeric non-root UID/GID for the migrate-pvcs hook container.
+  # alpine/k8s has no USER directive baked in (runs as root), and the
+  # kubelet can only verify runAsNonRoot against a numeric UID, so on
+  # plain Kubernetes (Kind, Minikube, OKE console-live) an explicit
+  # numeric non-root UID is REQUIRED or the container is refused at
+  # start: "container has runAsNonRoot and image will run as root"
+  # (#22907/#22919/#22946). 65532 is the conventional "nonroot" UID
+  # (distroless convention); it does not need to exist in the image's
+  # /etc/passwd, and the hook sets HOME=/tmp so kubectl cache/config
+  # writes work for any UID.
+  # NOTE: on OpenShift these MUST be null (use values-openshift.yaml or
+  # --set migration.runAsUser=null --set migration.runAsGroup=null): the
+  # restricted-v2 SCC only admits UIDs from the namespace's assigned
+  # range and injects an in-range UID itself when unset (#22925). Same
+  # rule as securityContext.runAsUser / podSecurityContext.fsGroup above.
+  runAsUser: 65532
+  runAsGroup: 65532
 
 serviceAccount:
   create: true


### PR DESCRIPTION
## Problem

`Console Live Promote` has failed every scheduled run since 2026-08-26. The pre-upgrade `pvc-migration` hook pod is refused at container start on the console-live cluster:

```
Warning  Failed  pod/kc-live-kubestellar-console-pvc-migration-h4ldl
  Error: container has runAsNonRoot and image will run as root (container: migrate-pvcs)
```

The failed hook then cascades into `pre-upgrade hooks failed` → helm rollback → `PersistentVolumeClaim ... spec is immutable` → `UPGRADE FAILED` (run [33311744159](https://github.com/kubestellar/console/actions/runs/33311744159)).

## Why the previous attempts did not clear it

- **#22908** added workflow-side diagnostics and stale-Job cleanup. Valuable (it surfaced the real error) but it never touched the hook's securityContext.
- **#22923** set `runAsNonRoot: false` + `runAsUser: 0` on the container. That would have passed the kubelet check, but it was replaced almost immediately by **#22929** (for #22925) because OpenShift's restricted-v2 SCC forbids `runAsUser: 0`. #22929 reverted to `runAsNonRoot: true` with **no** `runAsUser` — which works on OpenShift (the SCC injects an in-range UID) but reintroduced the failure on every non-OpenShift cluster: `alpine/k8s` has no `USER` directive, so with nothing injecting a UID the container's effective user is root and the kubelet refuses to start it. The console-live cluster (OKE, `oci-bv` storage) is plain Kubernetes, so every promote since has failed.

## Fix (differs from both prior attempts)

Mirror the chart's long-standing pattern for the **app** container (`securityContext.runAsUser: 1001` in `values.yaml`, nulled on OpenShift):

- `values.yaml`: new `migration.runAsUser: 65532` / `migration.runAsGroup: 65532` — explicit numeric non-root UID (distroless "nonroot" convention; the UID need not exist in `/etc/passwd`, and the hook already sets `HOME=/tmp` so kubectl cache/config writes work for any UID).
- `templates/pre-upgrade-pvc-migration.yaml`: render `runAsUser`/`runAsGroup` conditionally so nulling them drops the fields; `runAsNonRoot: true` is kept (PodSecurity `restricted` still satisfied).
- `values-openshift.yaml` + the OpenShift `deploy_helm` in `build-deploy.yml` + README: null `migration.runAsUser`/`runAsGroup` so restricted-v2 keeps injecting its own in-range UID — OpenShift behavior is unchanged from today.

Verified with `helm template`: default values render `runAsUser/runAsGroup: 65532` on the `migrate-pvcs` container; the OpenShift overlay renders neither field.

Fixes #22946
Refs #22907 #22919