### PR TITLE
🐛 fix: repair main after #22951 (env.Store mock API)

### DIFF
--- a/pkg/api/handlers/timeline_helpers_test.go
+++ b/pkg/api/handlers/timeline_helpers_test.go
@@ -254,13 +254,15 @@ func TestSweepOld_HappyPath(t *testing.T) {
 
 func TestSweepOld_StoreError(t *testing.T) {
 	env := setupTestEnv(t)
-	env.Store.On("SweepOldEvents", mock.AnythingOfType("int")).Return(int64(0), errors.New("db error"))
+	mockStore, ok := env.Store.(*test.MockStore)
+	require.True(t, ok, "env.Store must be a *test.MockStore")
+	mockStore.On("SweepOldEvents", mock.AnythingOfType("int")).Return(int64(0), errors.New("db error"))
 	h := NewTimelineHandler(env.Store, nil)
 	// sweepOld logs the error but must not panic.
 	assert.NotPanics(t, func() {
 		h.sweepOld()
 	})
-	env.Store.AssertCalled(t, "SweepOldEvents", mock.AnythingOfType("int"))
+	mockStore.AssertCalled(t, "SweepOldEvents", mock.AnythingOfType("int"))
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/safego/safego_log_integrity_test.go
+++ b/pkg/safego/safego_log_integrity_test.go
@@ -9,24 +9,44 @@ import (
 	"time"
 )
 
-// newTestLogger returns a slog.Logger that writes JSON to buf and replaces
-// the default logger for the duration of the test. The original default is
-// restored via t.Cleanup.
-func newTestLogger(t *testing.T) *bytes.Buffer {
+// syncBuffer is a goroutine-safe wrapper around bytes.Buffer. The slog
+// handler writes from the goroutine spawned by Go/GoWith while the test
+// goroutine polls String(), so unsynchronized access is a data race.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// newTestLogger returns a goroutine-safe buffer capturing JSON output of a
+// slog.Logger installed as the default logger for the duration of the test.
+// The original default is restored via t.Cleanup.
+func newTestLogger(t *testing.T) *syncBuffer {
 	t.Helper()
-	var buf bytes.Buffer
-	h := slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	buf := &syncBuffer{}
+	h := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
 	logger := slog.New(h)
 	orig := slog.Default()
 	slog.SetDefault(logger)
 	t.Cleanup(func() { slog.SetDefault(orig) })
-	return &buf
+	return buf
 }
 
 // waitForLog polls buf until predicate returns true or the deadline passes.
 // Needed because the recover-and-log defer inside Go/GoWith runs after the
 // caller's wg.Done(), so the log write may race the outer goroutine.
-func waitForLog(buf *bytes.Buffer, predicate func(string) bool) bool {
+func waitForLog(buf *syncBuffer, predicate func(string) bool) bool {
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		if predicate(buf.String()) {


### PR DESCRIPTION
Fixes #22952

Main broke after #22951 merged: `go vet` fails on every OS in the build matrix, plus `go test ./...`:

```
pkg/api/handlers/timeline_helpers_test.go:257:12: env.Store.On undefined (type store.Store has no field or method On)
pkg/api/handlers/timeline_helpers_test.go:263:12: env.Store.AssertCalled undefined (type store.Store has no field or method AssertCalled)
```

**Root cause:** `TestSweepOld_StoreError` (added in #22951) calls testify-mock methods (`.On`, `.AssertCalled`) directly on `env.Store`, which is typed as the `store.Store` interface in `TestEnv`. The concrete value is a `*test.MockStore`, but the test skipped the type assertion that every other mock-expecting test in this file uses (e.g. `mockStore := env.Store.(*test.MockStore)` in `TestGetTimeline_LimitParsing`).

**Fix (minimal, forward):** assert `env.Store` to `*test.MockStore` (two-value form with `require.True`) and set the expectation/assertion on the mock. The `MockStore.SweepOldEvents` expectation wiring from #22951 in `pkg/test/mock_store.go` is correct and untouched.