### PR TITLE
🐛 fix: stop Helm pruning the console-live ServiceAccount during promote

### DIFF
--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -281,6 +281,27 @@ jobs:
             --from-file=config="$GROUNDTRUTH_KUBECONFIG_PATH" \
             --dry-run=client -o yaml | kubectl apply -f -
 
+      - name: Ensure live ServiceAccount exists
+        shell: bash
+        run: |
+          set -euo pipefail
+          export KUBECONFIG="$DEPLOY_KUBECONFIG"
+          # Repair + standing guard for #22957: both the canary and live pods
+          # run as $LIVE_SERVICE_ACCOUNT, but the SA used to be managed by
+          # nobody (serviceAccount.create: false in both releases), so
+          # rollback debris from the failed pvc-migration era (#22946) left a
+          # cluster where the Helm upgrade/rollback cycle deletes the SA:
+          # the perpetual rollback-target revision still lists the SA in its
+          # manifest while the upgrade renders none, so Helm prunes it
+          # mid-upgrade and the Deployment's ReplicaSet immediately fails
+          # with 'serviceaccount "kc-live-kubestellar-console" not found'
+          # (scheduled run 33346472599). Recreate it idempotently before
+          # anything deploys; a no-op when it already exists. The live helm
+          # upgrade below (serviceAccount.create: true) then adopts it into
+          # the release so an upgrade can never prune it again.
+          kubectl -n "$LIVE_NAMESPACE" create serviceaccount "$LIVE_SERVICE_ACCOUNT" \
+            --dry-run=client -o yaml | kubectl apply -f -
+
       - name: Deploy candidate to private canary
         id: deploy_canary
         shell: bash
@@ -523,8 +544,19 @@ jobs:
           clusterName: "$LIVE_CLUSTER_NAME"
           service:
             type: ClusterIP
+          # The live release OWNS the shared ServiceAccount (#22957). It used
+          # to be create: false (SA pre-created out of band), but the release
+          # state on console-live still records the SA from older revisions,
+          # so rendering no SA made Helm prune it mid-upgrade (present in the
+          # old release manifest, absent from the new one). The Deployment's
+          # ReplicaSet then failed instantly with "serviceaccount not found",
+          # the 10m --wait expired, and the atomic rollback wedged on the
+          # immutable PVC (#22946). With create: true the SA is part of every
+          # rendered upgrade, so Helm reconciles it instead of deleting it.
+          # The canary release keeps create: false and only references the
+          # SA — exactly one release may own it.
           serviceAccount:
-            create: false
+            create: true
             name: "$LIVE_SERVICE_ACCOUNT"
           persistence:
             enabled: true


### PR DESCRIPTION
## Problem

Every scheduled **Console Live Promote** run fails (run [33346472599](https://github.com/kubestellar/console/actions/runs/33346472599)) with:

```
Warning FailedCreate replicaset/kc-live-kubestellar-console-65b46b9d48
  Error creating: pods ... serviceaccount "kc-live-kubestellar-console" not found
```

The pvc-migration hook is **not** the culprit anymore — the hook Job (with its own `-pvc-migration` SA/Role/RoleBinding hook resources) completes successfully since #22947. The missing SA is the **main release ServiceAccount** referenced by the Deployment's ReplicaSet.

## Root cause

Both the canary and live releases deploy with `serviceAccount.create: false` — **no release owns the SA**; it was expected to pre-exist. But the corrupted release state left on console-live by the earlier hook-failure/rollback loop still records the SA inside the perpetual rollback-target revision's manifest (Helm's own log confirms the drift: `resource exists on cluster but not in original release, using cluster state as baseline` for both the ServiceAccount and the PVC).

So each scheduled run cycles:

1. `helm upgrade` renders **no** SA while the stored release manifest **has** one → Helm v4 treats it as "removed from chart" and **prunes the SA mid-upgrade**.
2. Pod creation is rejected instantly (`serviceaccount not found`), Deployment stuck at `Replicas: 0/1`, 10m `--wait` expires.
3. The `--atomic` rollback then wedges on the immutable PVC patch (`VolumeName: "csi-..." → ""`) — the failure predicted in #22946.
4. The workflow's follow-up `helm rollback` restores the old revision **including the SA**, re-arming the identical failure for the next scheduled slot.

## Fix (workflow-only; the chart is already correct)

- **Live prod values: `serviceAccount.create: true`** (same name via `$LIVE_SERVICE_ACCOUNT`, verified identical through the `kubestellar-console.serviceAccountName` helper). The SA is now part of every rendered upgrade, so Helm reconciles/adopts it instead of pruning it. Once one upgrade succeeds, the release snapshot also re-owns the PVC, so subsequent rollbacks no longer hit the immutability error.
- **New idempotent pre-flight step** (`kubectl create sa --dry-run=client | kubectl apply -f -`) recreates the SA if absent before the canary/live deploys — this unwedges the currently-broken cluster on the next run with **no manual action needed**, and is a no-op afterwards.
- The canary release keeps `create: false` and only references the SA — exactly one release may own it.

## Why this differs from prior fixes

#22908 (hook diagnostics/stale-job cleanup), #22923/#22929/#22947 (hook `runAsNonRoot`/SCC/UID) all targeted the pre-upgrade hook, which now works. This PR targets the main release SA ownership and the Helm-prune cycle — a distinct failure layer.

## Validation

- `helm template` with live-like values: main SA `kc-live-kubestellar-console` + hook SA `kc-live-kubestellar-console-pvc-migration` both render; Deployment references the main SA.
- `helm template` clean with default values and `values-openshift.yaml`.
- Workflow YAML parses.

Fixes #22957
Refs #22946