### PR TITLE
🐛 fix: bootstrap live test user on kc-live so the signed-session promote gate can pass

### DIFF
--- a/.github/workflows/console-live-promote.yml
+++ b/.github/workflows/console-live-promote.yml
@@ -606,6 +606,27 @@ jobs:
               value: "true"
             - name: WATCHDOG_RUNTIME_FILE
               value: /tmp/kc-watcher-runtime.env
+            # The 'production live signed session' smoke (#23089) validates a
+            # CI-minted kc_auth JWT against this release. JWTAuth's
+            # ValidateUserActive requires the user row encoded in the JWT to
+            # exist in THIS pod's store with a matching role — but only the
+            # private canary release ever set these bootstrap envs, so the
+            # live pod's /api/me always answered 401 "Invalid token"
+            # (rejected stale user token: user is no longer active), the SPA
+            # showed "Session expired" and hard-redirected to /login, and the
+            # promote gate failed on every run. Mirror the canary bootstrap
+            # here so the signed-session invariant can actually be exercised
+            # against the promoted release. The user is only reachable with a
+            # JWT signed by this release's jwt-secret (same trust boundary as
+            # every real session).
+            - name: CONSOLE_LIVE_TEST_USER_BOOTSTRAP
+              value: "true"
+            - name: CONSOLE_LIVE_TEST_USER_ID
+              value: "$CONSOLE_LIVE_TEST_USER_ID"
+            - name: CONSOLE_LIVE_TEST_GITHUB_LOGIN
+              value: "$CONSOLE_LIVE_TEST_GITHUB_LOGIN"
+            - name: CONSOLE_LIVE_TEST_USER_ROLE
+              value: "$CONSOLE_LIVE_TEST_USER_ROLE"
           EOF
 
           # Dumps the pre-upgrade PVC-migration hook Job's diagnostics.

--- a/web/e2e/visual-login/helpers/liveSiteAssertions.ts
+++ b/web/e2e/visual-login/helpers/liveSiteAssertions.ts
@@ -26,7 +26,27 @@ const LIVE_CANARY_TEST_USER = {
 
 const LIVE_NAVIGATION_ATTEMPTS = 3
 const TEXT_COLLISION_RATIO_LIMIT = 0.30
+// Sentinel returned when a page.evaluate poll iteration is torn down by an
+// in-flight navigation ("Execution context was destroyed"). Returning it keeps
+// expect.poll retrying across the navigation instead of aborting the whole
+// test with a cryptic evaluate error (#23089).
+const POLL_EVAL_CONTEXT_DESTROYED = -1
 let lastLiveRouteNavigationAt = 0
+
+// Runs fetch('/api/me') inside the page so the check exercises the real
+// browser cookie jar + same-origin credentials path. fetch() rejections inside
+// the page map to 0; an evaluate torn down by a navigation maps to the
+// POLL_EVAL_CONTEXT_DESTROYED sentinel so expect.poll keeps retrying.
+function pollApiMeStatus(page: Page): Promise<number> {
+  return page.evaluate(async () => {
+    try {
+      const response = await fetch('/api/me', { credentials: 'same-origin' })
+      return response.status
+    } catch {
+      return 0
+    }
+  }).catch(() => POLL_EVAL_CONTEXT_DESTROYED)
+}
 
 type LiveApiEndpointFact = {
   status: number | null
@@ -336,14 +356,7 @@ export async function establishLiveCanarySession(page: Page, baseUrl: string) {
     await gotoLiveCanaryRoute(page, baseUrl, '/')
     await dismissOptionalLiveOverlays(page)
     await expect
-      .poll(() => page.evaluate(async () => {
-        try {
-          const response = await fetch('/api/me', { credentials: 'same-origin' })
-          return response.status
-        } catch {
-          return 0
-        }
-      }), {
+      .poll(() => pollApiMeStatus(page), {
         message: 'signed live canary cookie must validate against /api/me before dashboard navigation',
         timeout: 20_000,
       })
@@ -357,20 +370,13 @@ export async function establishLiveCanarySession(page: Page, baseUrl: string) {
   await gotoLiveCanaryRoute(page, baseUrl, '/auth/github', 'commit')
   await page.waitForURL(url => !url.pathname.startsWith('/auth/callback'), { timeout: 15_000 }).catch(() => undefined)
   await expect
-    .poll(() => page.evaluate(async () => {
-      try {
-        const response = await fetch('/api/me', { credentials: 'same-origin' })
-        return response.status
-      } catch {
-        return 0
-      }
-    }), {
+    .poll(() => pollApiMeStatus(page), {
       message: 'live canary dev session must validate against /api/me before dashboard navigation',
       timeout: 20_000,
     })
     .toBe(200)
   await expect
-    .poll(() => page.evaluate(() => localStorage.getItem('token')), {
+    .poll(() => page.evaluate(() => localStorage.getItem('token')).catch(() => 'poll-eval-context-destroyed'), {
       message: 'live canary dev login should settle into cookie-only auth before loading live data',
       timeout: 20_000,
     })


### PR DESCRIPTION
## Summary

`Console Live Promote` has failed every scheduled run since the deploy-stage fixes (#22947/#22958) let it reach the smoke tests again — always at the REQUIRED Playwright step **Run production auth/session smoke**, test `production live signed session reaches dashboard`, so production has not promoted. Latest failure: run 33701914033 (2026-09-03T01:00Z).

## Root cause (from run 33701914033 evidence artifact)

- The failure page snapshot shows the live site rendering **"Session expired — Redirecting to sign in..."** while serving the candidate build (`vmain-fb14bb751`), i.e. the freshly minted `kc_auth` JWT was rejected with 401 and the SPA hard-redirected to `/login` — that navigation is what destroys the Playwright eval context mid-`expect.poll` (`Execution context was destroyed`). Earlier runs (e.g. 33392685897) hit the same 401 as a plain poll timeout.
- `JWTAuth` → `ValidateUserActive` (`pkg/api/middleware/auth.go`) requires the user encoded in the JWT to **exist in the serving pod's store** with a matching role; otherwise `/api/me` returns 401 `Invalid token` ("rejected stale user token: user is no longer active").
- The server has a bootstrap for exactly this (`CONSOLE_LIVE_TEST_USER_BOOTSTRAP` in `pkg/api/server.go`), but **only the canary release's Helm values set it** — the canary pod logs `[Auth] bootstrapped live test user` into its throwaway sqlite, while the canary smoke only exercises unauthenticated endpoints (`/health`, unauth `/api/me` = 401). The signed-cookie flow is only ever exercised against `kc-live`, whose values never included the bootstrap envs — so the minted JWT can never validate there, every run 401s, the gate fails, and the deploy rolls back (23 flip-flops of the live ReplicaSet over ~8 days).

## Fix

1. **Workflow** (`.github/workflows/console-live-promote.yml`): mirror the canary's `CONSOLE_LIVE_TEST_USER_BOOTSTRAP` / `CONSOLE_LIVE_TEST_USER_ID` / `CONSOLE_LIVE_TEST_GITHUB_LOGIN` / `CONSOLE_LIVE_TEST_USER_ROLE` envs into the `kc-live` prod values so the promoted release seeds the test user at startup. The user is only reachable with a JWT signed by the release's `jwt-secret` (same secret the CI mint uses) — the same trust boundary as every real session.
2. **Test helper** (`web/e2e/visual-login/helpers/liveSiteAssertions.ts`): the `establishLiveCanarySession` polls now map an evaluate torn down by navigation to a sentinel and keep polling, so a genuine auth failure surfaces as the faithful invariant message (`signed live canary cookie must validate against /api/me...`) instead of a cryptic evaluate crash.

The promotion gate invariant is unchanged: a real signed session must still reach 200 on `/api/me` and render without login/session-expired UI. Only the mechanism is fixed.

Fixes #23089

🤖 Generated with [Claude Code](https://claude.com/claude-code)