### PR TITLE
🐛 fix: attribute live warning badges to external nightly-E2E CI before failing the promote gate

### DIFF
--- a/web/e2e/visual-login/helpers/liveSiteAssertions.ts
+++ b/web/e2e/visual-login/helpers/liveSiteAssertions.ts
@@ -509,21 +509,57 @@ export async function assertNoForbiddenLiveUi(page: Page) {
       })
       .filter((entry): entry is { text: string; count: number } => Boolean(entry && entry.count > 0))
 
+    // Count firing, unacknowledged warning-severity alerts whose provenance is
+    // the external nightly-E2E CI monitoring feed. The alert rules engine tags
+    // exactly those alerts with resourceKind 'WorkflowRun'
+    // (alertRulesEngine.ts evaluateNightlyE2EFailure); every infrastructure
+    // evaluator uses 'Cluster'/'Pod'/'Node' kinds. These alerts reflect the
+    // health of monitored EXTERNAL CI (llm-d nightly runs), not the health of
+    // this live deployment, so the navbar "N warnings" pill legitimately shows
+    // them (#23089 follow-up: 76 failed llm-d nightly runs blocked promotion).
+    let externalCiWarningAlerts = 0
+    try {
+      const rawAlerts = localStorage.getItem('kc_alerts')
+      const parsedAlerts: unknown = rawAlerts ? JSON.parse(rawAlerts) : []
+      if (Array.isArray(parsedAlerts)) {
+        externalCiWarningAlerts = parsedAlerts.filter((alert) => {
+          const candidate = alert as { status?: string; acknowledgedAt?: string; severity?: string; resourceKind?: string } | null
+          return Boolean(candidate)
+            && candidate!.status === 'firing'
+            && !candidate!.acknowledgedAt
+            && candidate!.severity === 'warning'
+            && candidate!.resourceKind === 'WorkflowRun'
+        }).length
+      }
+    } catch {
+      // Unparseable alert storage — treat as zero external alerts so every
+      // warning badge stays infra-attributed (fail closed).
+    }
+
     return {
       demoModeStorage: localStorage.getItem('kc-demo-mode'),
       forbiddenMatches,
       warningBadges,
+      externalCiWarningAlerts,
     }
   }, forbiddenLiveUiPatterns)
 
+  // A warning badge is infrastructure-attributable unless its full count is
+  // explained by external-CI monitoring alerts. Any excess means clusters,
+  // pods, or the agent contributed warnings — that still fails the gate.
+  const infraWarningBadges = state.warningBadges.filter(badge => badge.count > state.externalCiWarningAlerts)
+
   await recordLiveUiFailures(page, {
     forbiddenMatches: state.forbiddenMatches,
-    warningBadges: process.env.LIVE_UI_ALLOW_WARNING_BADGES === 'true' ? [] : state.warningBadges,
+    warningBadges: process.env.LIVE_UI_ALLOW_WARNING_BADGES === 'true' ? [] : infraWarningBadges,
   })
   expect(state.demoModeStorage, 'live UI must not keep demo mode enabled in localStorage').not.toBe('true')
   expect(state.forbiddenMatches, 'live UI must not show demo/local-agent/error drawer artifacts').toEqual([])
   if (process.env.LIVE_UI_ALLOW_WARNING_BADGES !== 'true') {
-    expect(state.warningBadges, 'live UI must not show nonzero warning badges after settling').toEqual([])
+    expect(
+      infraWarningBadges,
+      `live UI must not show warning badges beyond external nightly-E2E CI alerts after settling (external CI warning alerts: ${state.externalCiWarningAlerts})`,
+    ).toEqual([])
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #23089 / #23090. With the signed-session gate fixed, `Console Live Promote` (manual dispatch run 33707479410) advanced to the semantic canary and failed at `assertNoForbiddenLiveUi` — the warning-badge invariant — with:

```
warningBadges: [{ count: 76, text: "76 warnings" }]
```

## Root cause — not a regression, not a demo artifact

- The "76 warnings" pill is the navbar **AgentStatusIndicator** rendering `useDashboardHealth().message`, whose `warningCount` aggregates firing warning-severity alerts.
- All 76 come from the **'Nightly E2E Failure' preset alert rule**: `evaluateNightlyE2EFailure` creates one warning alert per completed-and-failed llm-d nightly E2E run across the 13 monitored workflows. Verified against the GitHub Actions API: those 13 workflows currently report **exactly 76 failures** in their last 10 runs each.
- Groundtruth from the same run shows the live clusters are clean (3/3 contexts reachable, 6/6 nodes ready, 36/36 pods running, 0 failed, 0 crashloops) — nothing about the live deployment is unhealthy.
- Net effect: the REQUIRED promote gate was coupling KubeStellar Console production promotion to the health of **external llm-d nightly GPU CI**, which the console intentionally monitors and surfaces.

## Fix — attribute, don't loosen

The alert rules engine tags nightly-E2E alerts (and only those) with `resourceKind: 'WorkflowRun'`; infrastructure evaluators use Cluster/Pod/Node kinds. Alerts persist as plain JSON under `kc_alerts`. The matcher now:

1. Counts firing, unacknowledged, warning-severity `WorkflowRun` alerts from `kc_alerts` in the same page sample.
2. Fails on any warning badge whose count **exceeds** that external-CI alert count — so a single warning contributed by clusters, pods, backend, or the local agent still fails the gate.
3. Fails closed if alert storage is unparseable (external count = 0 → every badge stays infra-attributed).

The load-bearing `forbiddenMatches` invariant (demo mode / local-agent / error-drawer artifacts) is untouched, as are the demo-mode-storage, blank-card, and stuck-loader checks. `LIVE_UI_ALLOW_WARNING_BADGES` remains available and unchanged.

Related #23089

🤖 Generated with [Claude Code](https://claude.com/claude-code)