### PR TITLE
🐛 fix: truthful pod markers on clusters pages + loud kubectl groundtruth truncation

### DIFF
--- a/web/e2e/visual-login/semantic/cluster-groundtruth.spec.ts
+++ b/web/e2e/visual-login/semantic/cluster-groundtruth.spec.ts
@@ -72,8 +72,8 @@ test('cluster dashboard can be checked against live Kubernetes ground truth @int
   await expectGroundTruthField(page, 'clusters-total', groundTruth.contexts.reachable)
   await expectGroundTruthField(page, 'nodes-ready', groundTruth.nodes.ready)
   await expectGroundTruthField(page, 'nodes-total', groundTruth.nodes.total)
+  // The /clusters summary only attests the all-phase pod total (backend
+  // ClusterHealth.PodCount has no phase breakdown); running/pending/crashloop
+  // are attested and compared on the pods page instead.
   await expectGroundTruthField(page, 'pods-total', groundTruth.pods.total)
-  await expectGroundTruthField(page, 'pods-running', groundTruth.pods.running)
-  await expectGroundTruthField(page, 'pods-pending', groundTruth.pods.pending)
-  await expectGroundTruthField(page, 'pods-crashloop', groundTruth.pods.crashLoopBackOff)
 })

--- a/web/e2e/visual-login/semantic/live-canary-ui.spec.ts
+++ b/web/e2e/visual-login/semantic/live-canary-ui.spec.ts
@@ -110,14 +110,21 @@ test('live canary UI matches Kubernetes groundtruth without screenshot baselines
       'nodes-total': clusterApiFacts.clusters.nodesTotal,
       'pods-total': clusterApiFacts.clusters.podsTotal,
     })
+    // Truncated kubectl ground truth must never silently pass as a smaller
+    // "expected" value (run 33725278436: `get pods -A` failed silently on one
+    // context, producing expected=36 vs a truthful UI total of 127).
+    expect(
+      groundTruth.listingFailures ?? [],
+      'kubectl groundtruth listing must be complete before comparing cluster stats',
+    ).toEqual([])
+    // The /clusters summary only attests the all-phase pod total (backend
+    // ClusterHealth.PodCount); phase breakdowns (running/pending/crashloop)
+    // are attested and compared on the pods page, which has per-pod data.
     await assertGroundtruthFields(page, {
       'clusters-total': groundTruth.contexts.reachable,
       'nodes-ready': groundTruth.nodes.ready,
       'nodes-total': groundTruth.nodes.total,
       'pods-total': groundTruth.pods.total,
-      'pods-running': groundTruth.pods.running,
-      'pods-pending': groundTruth.pods.pending,
-      'pods-crashloop': groundTruth.pods.crashLoopBackOff,
     }, route)
     await assertLiveLayoutStable(page)
     await assertNoVisibleTextCollisions(page)

--- a/web/harness/groundtruth/collectK8sGroundTruth.ts
+++ b/web/harness/groundtruth/collectK8sGroundTruth.ts
@@ -32,17 +32,99 @@ function writeTempKubeconfig(): TempKubeconfig {
   }
 }
 
-function jsonList<T>(args: string[], kubeconfigPath?: string): T[] {
+const KUBECTL_LIST_REQUEST_TIMEOUT = '20s'
+const KUBECTL_LIST_RETRY_CHUNK_SIZE = '100'
+const PER_NAMESPACE_FALLBACK_BUDGET_MS = 30_000
+const LISTING_ERROR_SNIPPET_LENGTH = 300
+
+function describeKubectlError(error: unknown): string {
+  const stderr = (error as { stderr?: unknown })?.stderr
+  const message = typeof stderr === 'string' && stderr.trim()
+    ? stderr.trim()
+    : error instanceof Error ? error.message : String(error)
+  // Keep the first line and strip URLs/IPs so evidence reports never leak
+  // API server endpoints.
+  return message.split(/\r?\n/)[0]
+    .replace(/https?:\/\/\S+/g, '<url>')
+    .replace(/\b\d{1,3}(\.\d{1,3}){3}(:\d+)?\b/g, '<ip>')
+    .slice(0, LISTING_ERROR_SNIPPET_LENGTH)
+}
+
+function jsonListWithError<T>(args: string[], kubeconfigPath?: string): { items: T[]; error?: string } {
   try {
     const parsed = JSON.parse(kubectl([...args, '-o', 'json'], kubeconfigPath)) as KubectlJsonList<T>
-    return parsed.items || []
-  } catch {
-    return []
+    return { items: parsed.items || [] }
+  } catch (error) {
+    return { items: [], error: describeKubectlError(error) }
   }
 }
 
-function jsonListAcrossContexts<T>(contexts: string[], args: string[], kubeconfigPath?: string): T[] {
-  return contexts.flatMap(context => jsonList<T>(['--context', context, ...args], kubeconfigPath))
+// A silently-truncated listing is worse than a loud failure: run 33725278436
+// compared UI totals against kubectl ground truth that was missing one whole
+// context's pods (36 vs a truthful 127) because errors were swallowed here.
+// Failures now retry cluster-scoped listing once (with pagination and a
+// request timeout), then fall back to per-namespace listing under a time
+// budget, and anything still incomplete is recorded so callers can refuse to
+// treat the counts as exact.
+function jsonListAcrossContexts<T>(
+  contexts: string[],
+  args: string[],
+  kubeconfigPath: string | undefined,
+  failures: Array<{ context: string; resource: string; error: string }>,
+  resource: string,
+  namespacedFallbackResource?: string,
+): T[] {
+  return contexts.flatMap(context => {
+    const contextArgs = ['--context', context, ...args, `--request-timeout=${KUBECTL_LIST_REQUEST_TIMEOUT}`]
+    const direct = jsonListWithError<T>(contextArgs, kubeconfigPath)
+    if (!direct.error) return direct.items
+
+    const retried = jsonListWithError<T>([...contextArgs, `--chunk-size=${KUBECTL_LIST_RETRY_CHUNK_SIZE}`], kubeconfigPath)
+    if (!retried.error) return retried.items
+
+    if (!namespacedFallbackResource) {
+      failures.push({ context, resource, error: retried.error })
+      return []
+    }
+
+    const namespaces = jsonListWithError<{ metadata?: { name?: string } }>(
+      ['--context', context, 'get', 'namespaces', `--request-timeout=${KUBECTL_LIST_REQUEST_TIMEOUT}`],
+      kubeconfigPath,
+    )
+    if (namespaces.error) {
+      failures.push({ context, resource, error: `${retried.error}; namespace fallback unavailable: ${namespaces.error}` })
+      return []
+    }
+
+    const items: T[] = []
+    const fallbackErrors: string[] = []
+    const fallbackStartedAt = Date.now()
+    let ranOutOfBudget = false
+    for (const namespace of namespaces.items) {
+      const name = namespace.metadata?.name
+      if (!name) continue
+      if (Date.now() - fallbackStartedAt > PER_NAMESPACE_FALLBACK_BUDGET_MS) {
+        ranOutOfBudget = true
+        break
+      }
+      const scoped = jsonListWithError<T>(
+        ['--context', context, 'get', namespacedFallbackResource, '-n', name, '--request-timeout=10s'],
+        kubeconfigPath,
+      )
+      if (scoped.error) fallbackErrors.push(`${name}: ${scoped.error}`)
+      else items.push(...scoped.items)
+    }
+
+    if (ranOutOfBudget || fallbackErrors.length > 0) {
+      const reasons = [
+        `cluster-scoped list failed: ${retried.error}`,
+        ranOutOfBudget ? `per-namespace fallback exceeded ${PER_NAMESPACE_FALLBACK_BUDGET_MS}ms budget` : '',
+        fallbackErrors.length > 0 ? `fallback failed for ${fallbackErrors.length} namespace(s): ${fallbackErrors.slice(0, 3).join('; ')}` : '',
+      ].filter(Boolean).join('; ')
+      failures.push({ context, resource, error: reasons })
+    }
+    return items
+  })
 }
 
 function configuredContexts(kubeconfigPath?: string): string[] {
@@ -97,16 +179,20 @@ export function collectK8sGroundTruth(runId = process.env.GITHUB_RUN_ID || Strin
       }
     })
 
-    const groundTruth = normalizeK8sState({
-      runId,
-      contextNames: contexts,
-      reachableContexts: reachable,
-      nodes: jsonListAcrossContexts<K8sNode>(reachable, ['get', 'nodes'], kubeconfigPath),
-      pods: jsonListAcrossContexts<K8sPod>(reachable, ['get', 'pods', '-A'], kubeconfigPath),
-      namespaces: jsonListAcrossContexts<unknown>(reachable, ['get', 'namespaces'], kubeconfigPath),
-      deployments: jsonListAcrossContexts<K8sDeployment>(reachable, ['get', 'deployments', '-A'], kubeconfigPath),
-      createdNamespaces: [],
-    })
+    const listingFailures: Array<{ context: string; resource: string; error: string }> = []
+    const groundTruth = {
+      ...normalizeK8sState({
+        runId,
+        contextNames: contexts,
+        reachableContexts: reachable,
+        nodes: jsonListAcrossContexts<K8sNode>(reachable, ['get', 'nodes'], kubeconfigPath, listingFailures, 'nodes'),
+        pods: jsonListAcrossContexts<K8sPod>(reachable, ['get', 'pods', '-A'], kubeconfigPath, listingFailures, 'pods', 'pods'),
+        namespaces: jsonListAcrossContexts<unknown>(reachable, ['get', 'namespaces'], kubeconfigPath, listingFailures, 'namespaces'),
+        deployments: jsonListAcrossContexts<K8sDeployment>(reachable, ['get', 'deployments', '-A'], kubeconfigPath, listingFailures, 'deployments', 'deployments'),
+        createdNamespaces: [],
+      }),
+      listingFailures,
+    }
 
     const redacted = redactK8sGroundTruth(groundTruth)
     const outDir = path.resolve(process.cwd(), 'test-results/reports')

--- a/web/harness/groundtruth/k8sTypes.ts
+++ b/web/harness/groundtruth/k8sTypes.ts
@@ -1,6 +1,16 @@
+export interface K8sListingFailure {
+  context: string
+  resource: string
+  error: string
+}
+
 export interface K8sGroundTruth {
   runId: string
   skipped?: string
+  /** kubectl listings that failed even after fallback — counts derived from a
+   *  run with failures here are incomplete and must not be compared as exact
+   *  ground truth. Absent on reports written before this field existed. */
+  listingFailures?: K8sListingFailure[]
   contexts: {
     configured: number
     reachable: number

--- a/web/harness/groundtruth/redactK8sGroundTruth.ts
+++ b/web/harness/groundtruth/redactK8sGroundTruth.ts
@@ -2,11 +2,21 @@ import type { K8sGroundTruth } from './k8sTypes'
 import { sanitizeJson } from '../evidence/sanitizeEvidence'
 
 export function redactK8sGroundTruth(groundTruth: K8sGroundTruth): K8sGroundTruth {
+  const redactContextName = (name: string, index: number) => `context-${index + 1}-${name.replace(/[^a-z0-9]/gi, '').slice(0, 12)}`
   return sanitizeJson({
     ...groundTruth,
     contexts: {
       ...groundTruth.contexts,
-      names: groundTruth.contexts.names.map((name, index) => `context-${index + 1}-${name.replace(/[^a-z0-9]/gi, '').slice(0, 12)}`),
+      names: groundTruth.contexts.names.map(redactContextName),
     },
+    ...(groundTruth.listingFailures !== undefined ? {
+      listingFailures: groundTruth.listingFailures.map(failure => {
+        const index = groundTruth.contexts.names.indexOf(failure.context)
+        return {
+          ...failure,
+          context: index >= 0 ? redactContextName(failure.context, index) : 'context-unknown',
+        }
+      }),
+    } : {}),
   })
 }

--- a/web/src/components/clusters/clusterStatValues.ts
+++ b/web/src/components/clusters/clusterStatValues.ts
@@ -95,13 +95,17 @@ export function getClusterDashboardStatValue(
     case 'pods':
       return {
         value: hasData ? stats.totalPods : '-',
+        // The clusters summary only knows each cluster's total pod count
+        // (backend ClusterHealth.PodCount counts every phase). Do NOT attest
+        // running/pending/crashloop here — those markers previously mirrored
+        // the total (and hardcoded zeros), which broke the live groundtruth
+        // canary once a monitored cluster had non-running pods. Phase
+        // breakdowns are attested by the pods page, which has real per-pod
+        // data (usePodsView).
         groundtruthFields: {
           'pods-total': hasData ? stats.totalPods : '-',
-          'pods-running': hasData ? stats.totalPods : '-',
-          'pods-pending': 0,
-          'pods-crashloop': 0,
         },
-        sublabel: 'running pods',
+        sublabel: 'total pods',
         onClick: () => { emitClusterStatsDrillDown('pods'); navigate(ROUTES.WORKLOADS) },
         isClickable: hasData }
     default:

--- a/web/src/components/clusters/useClustersView.ts
+++ b/web/src/components/clusters/useClustersView.ts
@@ -195,10 +195,11 @@ export function useClustersView(): ClustersViewState {
     'clusters-unreachable': stats.unreachable,
     'nodes-total': stats.totalNodes,
     'nodes-ready': stats.healthyNodes,
+    // Only the all-phase total is known at the clusters-summary level; pod
+    // phase breakdowns are attested by the pods page (usePodsView), which has
+    // real per-pod data. The removed running/pending/crashloop entries used
+    // to mirror the total and hardcode zeros, which was untruthful.
     'pods-total': stats.totalPods,
-    'pods-running': stats.totalPods,
-    'pods-pending': 0,
-    'pods-crashloop': 0,
   }
 
   return {

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -227,8 +227,11 @@ export function useUniversalStats() {
         return {
           value: totalPods,
           groundtruthFields: {
+            // totalPods is the all-phase cluster total; do not attest it as
+            // 'pods-running' (it previously did, breaking the live canary
+            // whenever monitored clusters had non-running pods). pending and
+            // crashloop come from real pod-issue data and stay attested.
             'pods-total': totalPods,
-            'pods-running': totalPods,
             'pods-pending': pendingPods,
             'pods-crashloop': crashLoopPods,
           },


### PR DESCRIPTION
## Summary

Iteration 4 on the `Console Live Promote` gate (#23089 → #23090 → #23091 → #23092). Run 33725278436 passed the badge/forbidden-UI assertions and moved to `assertGroundtruthFields` on `/clusters?groundtruth=1`: `pods-total`/`pods-running` expected **36**, actual **127**. Evidence shows **both sides were wrong**:

## Root cause A — harness silently truncated kubectl ground truth

`collectK8sGroundTruth`'s `jsonList` swallowed every kubectl error and returned `[]`. `get pods -A` failed silently on one of the three contexts, so the "expected" baseline was missing that cluster's ~91 pods (36 = the other two clusters only — the backend's 127 is arithmetically exact: 36 + 91, and that same cluster is the one carrying the 76 stuck `hive-hosted-*` pods, hive#5768). Namespaces (92, including the hive ones) and nodes (6) listed fine on the same context, masking the gap.

**Fix:** listings capture stderr (URLs/IPs stripped), retry cluster-scoped once with pagination + request timeout, fall back to per-namespace listing under a 30s budget for pods/deployments, and record anything still incomplete in a new `groundTruth.listingFailures` field. `live-canary-ui.spec` now **fails closed** when `listingFailures` is non-empty — truncated kubectl data can never again masquerade as a smaller "expected" value. The recorded error text will also tell us exactly why ci-3's cluster-scoped listing fails.

## Root cause B — clusters pages fabricated phase markers (real console bug)

The clusters-summary surfaces attested `'pods-running': stats.totalPods` and hardcoded `'pods-pending': 0` / `'pods-crashloop': 0` (`clusterStatValues.ts`, `useClustersView.ts`), and `useUniversalStats` attested `'pods-running': totalPods`. Backend `ClusterHealth.PodCount` counts **every phase**, so the UI claimed 127 "running" while 76 of those pods are Pending/Unschedulable; the stat sublabel "running pods" had the same lie.

**Fix:** clusters pages attest only `pods-total` (sublabel corrected to "total pods"). Phase breakdowns (`running`/`pending`/`crashloop`) remain attested and strictly compared on the pods routes (`usePodsView` has real per-pod data; `live-core-pages.spec` and `live-browser-matrix.spec` keep those assertions). The `/clusters` expectations in `live-canary-ui.spec` and `cluster-groundtruth.spec` drop the phase fields — matching what `live-core-pages.spec` already asserted for `/clusters`.

## Invariant status

Strengthened, not weakened: totals must still match exactly; truncated kubectl data now fails loudly; phase-level comparisons stay enforced where real data exists; no tolerance added anywhere.

Related #23089

🤖 Generated with [Claude Code](https://claude.com/claude-code)