### PR TITLE
🐛 fix: count unschedulable pods as Pending so /pods matches K8s groundtruth

### DIFF
--- a/web/e2e/enterprise-compliance.spec.ts
+++ b/web/e2e/enterprise-compliance.spec.ts
@@ -1,6 +1,10 @@
 import { test, expect } from '@playwright/test'
 import { setupDemoMode, mockApiFallback } from './helpers/setup'
 
+// Click near the top-left corner of sidebar items: the right side hosts a
+// hover-action overlay (pin/close icons) that intercepts centered clicks.
+const SIDEBAR_ITEM_CLICK_OFFSET_PX = 8
+
 test.describe('Enterprise Compliance Portal', () => {
   test.beforeEach(async ({ page }) => {
     // Standard setup for authenticated demo state
@@ -75,9 +79,12 @@ test.describe('Enterprise Compliance Portal', () => {
         // collapsible and the list is scrollable, so the target item may be
         // rendered outside the viewport — scroll it into view before clicking
         // to avoid selector-drift timeouts.
+        // Click near the left edge: sidebar items render a right-aligned
+        // hover-action overlay (pin/close icons) with pointer-events-auto
+        // that intercepts center clicks on narrow viewports.
         const navItem = page.locator(`[data-testid="sidebar-item"][data-test-label="${vertical.label}"]`)
         await navItem.scrollIntoViewIfNeeded()
-        await navItem.click()
+        await navItem.click({ position: { x: SIDEBAR_ITEM_CLICK_OFFSET_PX, y: SIDEBAR_ITEM_CLICK_OFFSET_PX } })
         
         // Wait for navigation and header update
         await expect(page.getByTestId('dashboard-title')).toHaveText(vertical.title, { timeout: 15000 })
@@ -96,7 +103,7 @@ test.describe('Enterprise Compliance Portal', () => {
     // Click 'Frameworks' and verify navigation
     const frameworksItem = sidebar.locator('[data-testid="sidebar-item"][data-test-label="Frameworks"]')
     await frameworksItem.scrollIntoViewIfNeeded()
-    await frameworksItem.click()
+    await frameworksItem.click({ position: { x: SIDEBAR_ITEM_CLICK_OFFSET_PX, y: SIDEBAR_ITEM_CLICK_OFFSET_PX } })
     await expect(page.getByTestId('dashboard-title')).toHaveText(/Compliance Frameworks/i)
   })
 

--- a/web/src/components/pods/__tests__/podPhaseClassification.test.ts
+++ b/web/src/components/pods/__tests__/podPhaseClassification.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { isPendingPhasePodIssue } from '../podPhaseClassification'
+
+describe('isPendingPhasePodIssue', () => {
+  it('counts rows explicitly labelled Pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'Pending', reason: 'Pending' })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'Pending', reason: undefined })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'Unknown', reason: 'Pending' })).toBe(true)
+  })
+
+  // Unschedulable pods never got a node, so Kubernetes still reports them in the
+  // Pending phase. The backend promotes "Unschedulable" over the phase fallback,
+  // which previously hid them from the pending stat (run 33749456318: 12 vs 76).
+  it('counts unschedulable rows, which are still Pending phase', () => {
+    expect(isPendingPhasePodIssue({ status: 'Unschedulable', reason: 'Unschedulable' })).toBe(true)
+    expect(isPendingPhasePodIssue({
+      status: 'Unschedulable: 0/6 nodes are available: insufficient cpu.',
+      reason: 'Unschedulable: 0/6 nodes are available: insufficient cpu.',
+    })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'unschedulable', reason: undefined })).toBe(true)
+  })
+
+  it('does not count pods that are not in the Pending phase', () => {
+    expect(isPendingPhasePodIssue({ status: 'CrashLoopBackOff', reason: 'CrashLoopBackOff' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'OOMKilled', reason: 'OOMKilled' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'Failed', reason: 'Failed' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'ImagePullBackOff', reason: 'ImagePullBackOff' })).toBe(false)
+  })
+
+  // A pod that reached Running and later went unready is not Pending, even
+  // though it is an "issue" row.
+  it('does not count running-but-unready pods as pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'Not ready', reason: 'Not ready' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'Running', reason: undefined })).toBe(false)
+  })
+
+  it('does not treat unrelated reasons that merely mention scheduling as pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'High restarts (7)', reason: 'High restarts (7)' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: '', reason: undefined })).toBe(false)
+  })
+})

--- a/web/src/components/pods/podPhaseClassification.ts
+++ b/web/src/components/pods/podPhaseClassification.ts
@@ -1,0 +1,35 @@
+import type { PodIssue } from '../../hooks/mcp/types.workloads'
+
+/**
+ * Backend `FindPodIssues` labels an unschedulable pod with the raw issue string
+ * `Unschedulable: <message>` and, because "Unschedulable" outranks the phase
+ * fallback in `podPrimaryReasonPriority`, promotes it to the row's
+ * status/reason. Those pods are still in the Kubernetes `Pending` phase — they
+ * simply never got a node — so a `reason === 'Pending'` test alone under-counts
+ * them.
+ *
+ * The live groundtruth canary compares `pods-pending` against
+ * `pods.filter(phase === 'Pending')`, which does include unschedulable pods.
+ * Run 33749456318 reported 12 against a truthful 76 for exactly this reason:
+ * 64 of the Pending pods were unschedulable and therefore labelled
+ * `Unschedulable` instead of `Pending`.
+ *
+ * Only pods whose *primary* label is Unschedulable are treated as Pending here.
+ * A pod that reached `Running` and later went unready is reported with a
+ * different status (e.g. `Not ready`) and must not be counted.
+ */
+const UNSCHEDULABLE_PREFIX = 'unschedulable'
+
+function isUnschedulableLabel(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().toLowerCase().startsWith(UNSCHEDULABLE_PREFIX)
+}
+
+/**
+ * True when a pod-issue row represents a pod in the Kubernetes `Pending` phase:
+ * either explicitly labelled `Pending`, or labelled `Unschedulable` (which
+ * implies Pending).
+ */
+export function isPendingPhasePodIssue(issue: Pick<PodIssue, 'status' | 'reason'>): boolean {
+  if (issue.reason === 'Pending' || issue.status === 'Pending') return true
+  return isUnschedulableLabel(issue.reason) || isUnschedulableLabel(issue.status)
+}

--- a/web/src/components/pods/usePodsView.ts
+++ b/web/src/components/pods/usePodsView.ts
@@ -8,6 +8,7 @@ import { useToast } from '../ui/Toast'
 import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import type { PodIssue } from '../../hooks/mcp/types.workloads'
+import { isPendingPhasePodIssue } from './podPhaseClassification'
 import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { StatBlockValue } from '../ui/StatsOverview'
 
@@ -208,7 +209,7 @@ export function usePodsView({
     // Dedup issue rows by pod name to avoid under-counting healthy pods (#7348)
     const uniqueIssuePods = new Set(filteredPodIssues.map(p => `${p.cluster}/${p.namespace}/${p.name}`))
     const issueCount = filteredPodIssues.length
-    const pendingCount = filteredPodIssues.filter(p => p.reason === 'Pending' || p.status === 'Pending').length
+    const pendingCount = filteredPodIssues.filter(isPendingPhasePodIssue).length
     const crashLoopCount = filteredPodIssues.filter(p =>
       /crashloop|crash loop/i.test([p.reason, p.status].filter(Boolean).join(' '))
     ).length

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -12,6 +12,7 @@ import {
   useOperators,
   useGPUNodes } from './useMCP'
 import { useIngresses } from './mcp/networking'
+import { isPendingPhasePodIssue } from '../components/pods/podPhaseClassification'
 import { useCachedPVCs, useCachedWarningEvents } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
@@ -93,7 +94,10 @@ export function useUniversalStats() {
   // ─── Pod-derived values ───
   const podIssuesList = podIssues || []
   const { pendingPods, crashLoopPods, highRestartPods } = useMemo(() => ({
-    pendingPods: podIssuesList.filter(p => p.status === 'Pending').length,
+    // Unschedulable pods are still in the Kubernetes Pending phase; matching
+    // only the literal 'Pending' label under-counts them. See
+    // podPhaseClassification.
+    pendingPods: podIssuesList.filter(isPendingPhasePodIssue).length,
     crashLoopPods: podIssuesList.filter(p => /crashloop|crash loop/i.test([p.status, p.reason, ...(p.issues || [])].filter(Boolean).join(' '))).length,
     highRestartPods: podIssuesList.filter(p => p.restarts > HIGH_RESTART_THRESHOLD).length,
   }), [podIssuesList])


### PR DESCRIPTION
## Problem

Promote run [33749456318](https://github.com/kubestellar/console/actions/runs/33749456318) — the first run carrying #23095 — cleared the `/clusters` groundtruth gate and failed one stage later, in `live-core-pages.spec.ts` on `/pods`:

```
Error: live /pods stats must match Kubernetes ground truth
  { field: "pods-pending", expected: 76, actual: 12, route: "/pods" }
```

### #23095 is confirmed working

That run's `groundtruth.json` shows the collector fix landed correctly:

| | before (run 33725278436) | now |
|---|---|---|
| `pods.total` | 36 (truncated) | **127** — matches UI exactly |
| `deployments.total` | 10 | 88 |
| `listingFailures` | *(absent)* | `[]` |

The silent-truncation bug is gone and `/clusters` now passes. This PR addresses the next, distinct failure.

## Root cause

Both numbers were computed correctly — they were measuring **different things**.

Backend `FindPodIssues` (`pkg/k8s/client_pods.go`) labels an unschedulable pod with the raw issue string `Unschedulable: <message>`. Because `"Unschedulable"` sits above the phase fallback in `podPrimaryReasonPriority`, `getPrimaryPodIssue` promotes it to the row's `status`/`reason`.

`usePodsView` counted pending as:

```ts
p.reason === 'Pending' || p.status === 'Pending'
```

so every unschedulable pod fell out of the tally. On `ks-console-ci-3` the leaked `hive-hosted-hosted-*` namespaces (kubestellar/hive#5768) hold 64 such pods, leaving only the 12 that were plain-`Pending` past `podPendingAgeThreshold` with no other issue — hence **12 vs a truthful 76**.

Unschedulable pods never got a node, so Kubernetes still reports them in the `Pending` phase — exactly what the canary's groundtruth counts (`normalizeK8sState`: `phase === 'Pending'`).

**The console stat was the wrong one.** This is a real user-facing bug independent of the canary: the `/pods` "pending pods" tile under-reported real pending work by 5x, hiding 64 stuck pods from operators.

## Fix

New `isPendingPhasePodIssue` treats a row as Pending when it is labelled `Pending` **or** when its primary label is `Unschedulable`. Matching on the *primary* label keeps `Running`-but-unready pods (`Not ready`) and terminal states (`CrashLoopBackOff`, `OOMKilled`, `Failed`) out of the count. Unit tests cover each of those cases.

## The invariant is not weakened

No tolerance, no namespace scoping, no exclusions, no fail-open. The comparison stays an exact `toEqual([])` against unmodified Kubernetes ground truth. Only the console's definition of "pending" was corrected to match Kubernetes — option (c), a genuine console counting bug.

Related #23089