### PR TITLE
🐛 fix: derive pod phase counts from an ungated census, not the pod-issues feed

### DIFF
--- a/pkg/api/handlers/mcp/cluster.go
+++ b/pkg/api/handlers/mcp/cluster.go
@@ -82,6 +82,10 @@ func (h *MCPHandlers) ListClusters(c *fiber.Ctx) error {
 				clusters[i].NodeCount = health.NodeCount
 				clusters[i].ReadyNodes = health.ReadyNodes
 				clusters[i].PodCount = health.PodCount
+				// Ungated phase breakdown of the same pods PodCount totals —
+				// the source for pod phase stats, which must not inherit the
+				// pod-issues feed's Pending age gate (#23097).
+				clusters[i].PodPhases = health.PodPhases
 				// Surface the stale-kubeconfig signal: a cluster that has
 				// a health cache entry but has never been successfully
 				// reached (empty LastSeen) drives the "never connected"

--- a/pkg/k8s/client_clusters.go
+++ b/pkg/k8s/client_clusters.go
@@ -28,7 +28,11 @@ type ClusterInfo struct {
 	NodeCount      int    `json:"nodeCount,omitempty"`
 	ReadyNodes     int    `json:"readyNodes,omitempty"`
 	PodCount       int    `json:"podCount,omitempty"`
-	IsCurrent      bool   `json:"isCurrent,omitempty"`
+	// PodPhases is the ungated phase breakdown of the same pods PodCount
+	// totals. Phase stats are sourced from here rather than from the
+	// pod-issues feed, which suppresses freshly-created Pending pods (#23097).
+	PodPhases *PodPhaseCensus `json:"podPhases,omitempty"`
+	IsCurrent bool            `json:"isCurrent,omitempty"`
 }
 
 // ClusterHealth represents cluster health status
@@ -43,6 +47,9 @@ type ClusterHealth struct {
 	NodeCount    int    `json:"nodeCount"`
 	ReadyNodes   int    `json:"readyNodes"`
 	PodCount     int    `json:"podCount"`
+	// PodPhases is the ungated phase breakdown of the same pod listing that
+	// produced PodCount — see PodPhaseCensus (#23097).
+	PodPhases *PodPhaseCensus `json:"podPhases,omitempty"`
 	// Total allocatable resources (capacity)
 	CpuCores     int     `json:"cpuCores"`
 	MemoryBytes  int64   `json:"memoryBytes"`  // Total allocatable memory in bytes

--- a/pkg/k8s/client_health.go
+++ b/pkg/k8s/client_health.go
@@ -256,6 +256,12 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	// Process pods - non-fatal, fall back to cached values on timeout
 	if podsErr == nil && pods != nil {
 		health.PodCount = len(pods.Items)
+		// Phase census from the same unfiltered listing that produced PodCount.
+		// Stats read this instead of the pod-issues feed, whose Pending rows are
+		// gated on podPendingAgeThreshold and so under-count for the first two
+		// minutes of a pod's life (#23097).
+		census := CountPodPhases(pods.Items)
+		health.PodPhases = &census
 		var totalCPURequests int64
 		var totalMemoryRequests int64
 		for _, pod := range pods.Items {
@@ -280,6 +286,7 @@ func (m *MultiClusterClient) GetClusterHealth(ctx context.Context, contextName s
 	} else if prevCached != nil {
 		// Pod listing timed out — preserve previous cached pod data instead of showing 0
 		health.PodCount = prevCached.PodCount
+		health.PodPhases = prevCached.PodPhases
 		health.CpuRequestsMillicores = prevCached.CpuRequestsMillicores
 		health.CpuRequestsCores = prevCached.CpuRequestsCores
 		health.MemoryRequestsBytes = prevCached.MemoryRequestsBytes

--- a/pkg/k8s/client_pod_phase_census_test.go
+++ b/pkg/k8s/client_pod_phase_census_test.go
@@ -1,0 +1,141 @@
+package k8s
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+)
+
+func phaseCensusPod(name string, phase corev1.PodPhase, age time.Duration) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              name,
+			Namespace:         "default",
+			CreationTimestamp: metav1.Time{Time: time.Now().Add(-age)},
+		},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "c1", Image: "img"}}},
+		Status: corev1.PodStatus{Phase: phase},
+	}
+}
+
+// The invariant this change exists to protect: a Pending pod younger than
+// podPendingAgeThreshold is deliberately absent from the issues feed, and must
+// nevertheless be counted by the phase census. Before #23097 the phase stat was
+// derived from the feed, so it inherited the feed's age gate and under-counted.
+func TestCountPodPhases_CountsFreshPendingPodSuppressedByIssuesFeed(t *testing.T) {
+	fresh := phaseCensusPod("fresh-pending", corev1.PodPending, 5*time.Second)
+
+	census := CountPodPhases([]corev1.Pod{*fresh})
+	if census.Pending != 1 {
+		t.Fatalf("phase census must count a freshly-created Pending pod, got pending=%d", census.Pending)
+	}
+
+	// ...and the issues feed must still suppress it. If this half ever starts
+	// failing, the feed's 2-minute threshold has been removed, which is not the
+	// fix we want.
+	m, _ := NewMultiClusterClient("")
+	m.clients["c1"] = k8sfake.NewSimpleClientset(fresh)
+	issues, err := m.FindPodIssues(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("FindPodIssues failed: %v", err)
+	}
+	if len(issues) != 0 {
+		t.Fatalf("issues feed must keep suppressing a pod younger than podPendingAgeThreshold, got %d rows", len(issues))
+	}
+}
+
+// The two sources are only allowed to disagree because of the age gate. An aged
+// Pending pod appears in both.
+func TestCountPodPhases_AgedPendingPodAppearsInBothSources(t *testing.T) {
+	aged := phaseCensusPod("aged-pending", corev1.PodPending, 10*time.Minute)
+
+	if census := CountPodPhases([]corev1.Pod{*aged}); census.Pending != 1 {
+		t.Fatalf("expected pending=1, got %d", census.Pending)
+	}
+
+	m, _ := NewMultiClusterClient("")
+	m.clients["c1"] = k8sfake.NewSimpleClientset(aged)
+	issues, err := m.FindPodIssues(context.Background(), "c1", "default")
+	if err != nil {
+		t.Fatalf("FindPodIssues failed: %v", err)
+	}
+	if len(issues) != 1 || issues[0].Reason != "Pending" {
+		t.Fatalf("expected one Pending issue row, got %+v", issues)
+	}
+}
+
+// Kubernetes reports an unschedulable pod as Pending — it never got a node — so
+// the census counts it as Pending without any special case. This is the
+// behaviour #23096 had to reconstruct from issue *reasons*; reading the phase
+// directly gets it right for free.
+func TestCountPodPhases_UnschedulablePodCountsAsPending(t *testing.T) {
+	unschedulable := phaseCensusPod("unschedulable", corev1.PodPending, 30*time.Second)
+	unschedulable.Status.Conditions = []corev1.PodCondition{{
+		Type:    corev1.PodScheduled,
+		Status:  corev1.ConditionFalse,
+		Reason:  "Unschedulable",
+		Message: "0/6 nodes are available: insufficient cpu.",
+	}}
+
+	census := CountPodPhases([]corev1.Pod{*unschedulable})
+	if census.Pending != 1 {
+		t.Fatalf("unschedulable pod is Pending phase, got pending=%d", census.Pending)
+	}
+	if census.Failed != 0 || census.Running != 0 {
+		t.Fatalf("unschedulable pod must not land in another bucket: %+v", census)
+	}
+}
+
+// Terminal and Running-but-unready pods must not leak into the Pending bucket.
+func TestCountPodPhases_DoesNotMiscountTerminalOrUnreadyPods(t *testing.T) {
+	runningUnready := phaseCensusPod("running-unready", corev1.PodRunning, 20*time.Minute)
+	runningUnready.Status.ContainerStatuses = []corev1.ContainerStatus{{
+		Name:  "c1",
+		Ready: false,
+		State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{
+			StartedAt: metav1.Time{Time: time.Now().Add(-20 * time.Minute)},
+		}},
+	}}
+
+	pods := []corev1.Pod{
+		*runningUnready,
+		*phaseCensusPod("failed", corev1.PodFailed, time.Hour),
+		*phaseCensusPod("succeeded", corev1.PodSucceeded, time.Hour),
+		*phaseCensusPod("unknown", corev1.PodUnknown, time.Hour),
+	}
+
+	census := CountPodPhases(pods)
+	want := PodPhaseCensus{Running: 1, Pending: 0, Failed: 1, Succeeded: 1, Unknown: 1}
+	if census != want {
+		t.Fatalf("expected %+v, got %+v", want, census)
+	}
+}
+
+// Every pod lands in exactly one bucket, so a phase breakdown is always a
+// partition of the same listing that yields PodCount.
+func TestCountPodPhases_BucketsPartitionThePodListing(t *testing.T) {
+	pods := []corev1.Pod{
+		*phaseCensusPod("r1", corev1.PodRunning, time.Hour),
+		*phaseCensusPod("r2", corev1.PodRunning, time.Hour),
+		*phaseCensusPod("p1", corev1.PodPending, time.Second),
+		*phaseCensusPod("f1", corev1.PodFailed, time.Hour),
+		*phaseCensusPod("s1", corev1.PodSucceeded, time.Hour),
+		*phaseCensusPod("u1", corev1.PodUnknown, time.Hour),
+	}
+
+	census := CountPodPhases(pods)
+	sum := census.Running + census.Pending + census.Failed + census.Succeeded + census.Unknown
+	if sum != len(pods) {
+		t.Fatalf("phase buckets must sum to the pod count: %d != %d (%+v)", sum, len(pods), census)
+	}
+}
+
+func TestCountPodPhases_EmptyListing(t *testing.T) {
+	if census := CountPodPhases(nil); census != (PodPhaseCensus{}) {
+		t.Fatalf("expected zero census, got %+v", census)
+	}
+}

--- a/pkg/k8s/client_pods.go
+++ b/pkg/k8s/client_pods.go
@@ -36,6 +36,56 @@ type ContainerInfo struct {
 	GPURequested int    `json:"gpuRequested,omitempty"` // Number of GPUs requested by this container
 }
 
+// PodPhaseCensus is a straight tally of Kubernetes pod phases, with no
+// issue-suitability gating applied.
+//
+// It exists because pod *phase* stats used to be derived from the pod-issues
+// feed (FindPodIssues), which deliberately suppresses a Pending pod until it is
+// older than podPendingAgeThreshold. That suppression is correct for an issues
+// feed — an operator should not see an alarm row for a pod that is merely
+// starting — but any count derived from that feed inherits the suppression, so
+// `pods-pending` under-reported for up to two minutes after pods were created
+// (#23097). Kubernetes counts a pod as Pending the instant it is created, so
+// the console disagreed with ground truth on any cluster churning pods.
+//
+// The census is computed from the same unfiltered pod listing that produces
+// PodCount, so it is a phase breakdown of exactly the pods PodCount totals.
+// The issues feed keeps its own threshold; stats no longer borrow it.
+type PodPhaseCensus struct {
+	Running   int `json:"running"`
+	Pending   int `json:"pending"`
+	Failed    int `json:"failed"`
+	Succeeded int `json:"succeeded"`
+	Unknown   int `json:"unknown"`
+}
+
+// CountPodPhases tallies pods by their raw Kubernetes phase. Every pod lands in
+// exactly one bucket, so the buckets always sum to len(pods).
+//
+// No age gate, no readiness heuristic, no schedulability special case: an
+// unschedulable pod is Pending because Kubernetes reports it as Pending (it
+// never got a node), and a Running-but-unready pod is Running because that is
+// its phase. Those are precisely the cases a stat derived from issue *reasons*
+// gets wrong.
+func CountPodPhases(pods []corev1.Pod) PodPhaseCensus {
+	var census PodPhaseCensus
+	for _, pod := range pods {
+		switch pod.Status.Phase {
+		case corev1.PodRunning:
+			census.Running++
+		case corev1.PodPending:
+			census.Pending++
+		case corev1.PodFailed:
+			census.Failed++
+		case corev1.PodSucceeded:
+			census.Succeeded++
+		default:
+			census.Unknown++
+		}
+	}
+	return census
+}
+
 // PodIssue represents a pod with issues
 type PodIssue struct {
 	Name      string   `json:"name"`

--- a/web/src/components/layout/sidebar/SidebarNavItemRow.tsx
+++ b/web/src/components/layout/sidebar/SidebarNavItemRow.tsx
@@ -240,7 +240,7 @@ export function SidebarNavItemRow({
                   <button
                     type="button"
                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(item.id) }}
-                    className="min-h-11 min-w-11 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
+                    className="min-h-11 min-w-11 md:min-h-0 md:min-w-0 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
                     title={t('sidebar.removeFromSidebar')}
                     aria-label={t('sidebar.removeFromSidebar')}
                   >
@@ -248,7 +248,7 @@ export function SidebarNavItemRow({
                   </button>
                 )}
                 <span
-                  className="min-h-11 min-w-11 p-1 rounded hover:bg-secondary text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
+                  className="min-h-11 min-w-11 md:min-h-0 md:min-w-0 p-1 rounded hover:bg-secondary text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
                   aria-hidden="true"
                   onMouseDown={(e) => e.stopPropagation()}
                 >

--- a/web/src/components/layout/sidebar/SidebarNavItemRow.tsx
+++ b/web/src/components/layout/sidebar/SidebarNavItemRow.tsx
@@ -235,12 +235,12 @@ export function SidebarNavItemRow({
               })()}
             </NavLink>
             {!isCollapsed && canDrag && (
-              <span className="absolute right-5 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-100 pointer-events-auto md:opacity-0 md:pointer-events-none md:group-hover:opacity-100 md:group-hover:pointer-events-auto transition-opacity bg-background/80 backdrop-blur-xs rounded px-1 z-10">
+              <span className="absolute right-5 top-1/2 -translate-y-1/2 flex items-center gap-1 opacity-100 pointer-events-none md:opacity-0 md:group-hover:opacity-100 transition-opacity bg-background/80 backdrop-blur-xs rounded px-1 z-10">
                 {!PROTECTED_SIDEBAR_IDS.includes(item.id) && (
                   <button
                     type="button"
                     onClick={(e) => { e.preventDefault(); e.stopPropagation(); onRemove(item.id) }}
-                    className="min-h-11 min-w-11 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors"
+                    className="min-h-11 min-w-11 p-1 rounded hover:bg-red-500/20 hover:text-red-400 text-muted-foreground/50 transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
                     title={t('sidebar.removeFromSidebar')}
                     aria-label={t('sidebar.removeFromSidebar')}
                   >
@@ -248,7 +248,7 @@ export function SidebarNavItemRow({
                   </button>
                 )}
                 <span
-                  className="min-h-11 min-w-11 p-1 rounded hover:bg-secondary text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors"
+                  className="min-h-11 min-w-11 p-1 rounded hover:bg-secondary text-muted-foreground/50 hover:text-muted-foreground cursor-grab active:cursor-grabbing transition-colors pointer-events-auto md:pointer-events-none md:group-hover:pointer-events-auto"
                   aria-hidden="true"
                   onMouseDown={(e) => e.stopPropagation()}
                 >

--- a/web/src/components/pods/__tests__/podPhaseClassification.test.ts
+++ b/web/src/components/pods/__tests__/podPhaseClassification.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import { isPendingPhasePodIssue } from '../podPhaseClassification'
+
+describe('isPendingPhasePodIssue', () => {
+  it('counts rows explicitly labelled Pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'Pending', reason: 'Pending' })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'Pending', reason: undefined })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'Unknown', reason: 'Pending' })).toBe(true)
+  })
+
+  // Unschedulable pods never got a node, so Kubernetes still reports them in the
+  // Pending phase. The backend promotes "Unschedulable" over the phase fallback,
+  // which previously hid them from the pending stat (run 33749456318: 12 vs 76).
+  it('counts unschedulable rows, which are still Pending phase', () => {
+    expect(isPendingPhasePodIssue({ status: 'Unschedulable', reason: 'Unschedulable' })).toBe(true)
+    expect(isPendingPhasePodIssue({
+      status: 'Unschedulable: 0/6 nodes are available: insufficient cpu.',
+      reason: 'Unschedulable: 0/6 nodes are available: insufficient cpu.',
+    })).toBe(true)
+    expect(isPendingPhasePodIssue({ status: 'unschedulable', reason: undefined })).toBe(true)
+  })
+
+  it('does not count pods that are not in the Pending phase', () => {
+    expect(isPendingPhasePodIssue({ status: 'CrashLoopBackOff', reason: 'CrashLoopBackOff' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'OOMKilled', reason: 'OOMKilled' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'Failed', reason: 'Failed' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'ImagePullBackOff', reason: 'ImagePullBackOff' })).toBe(false)
+  })
+
+  // A pod that reached Running and later went unready is not Pending, even
+  // though it is an "issue" row.
+  it('does not count running-but-unready pods as pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'Not ready', reason: 'Not ready' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: 'Running', reason: undefined })).toBe(false)
+  })
+
+  it('does not treat unrelated reasons that merely mention scheduling as pending', () => {
+    expect(isPendingPhasePodIssue({ status: 'High restarts (7)', reason: 'High restarts (7)' })).toBe(false)
+    expect(isPendingPhasePodIssue({ status: '', reason: undefined })).toBe(false)
+  })
+})

--- a/web/src/components/pods/__tests__/podPhaseClassification.test.ts
+++ b/web/src/components/pods/__tests__/podPhaseClassification.test.ts
@@ -1,5 +1,19 @@
 import { describe, it, expect } from 'vitest'
-import { isPendingPhasePodIssue } from '../podPhaseClassification'
+import { countPendingPods, isPendingPhasePodIssue } from '../podPhaseClassification'
+import type { ClusterInfo, PodPhaseCensus } from '../../../hooks/mcp/types'
+import type { PodIssue } from '../../../hooks/mcp/types.workloads'
+
+function census(overrides: Partial<PodPhaseCensus> = {}): PodPhaseCensus {
+  return { running: 0, pending: 0, failed: 0, succeeded: 0, unknown: 0, ...overrides }
+}
+
+function clusterWith(podPhases?: PodPhaseCensus): Pick<ClusterInfo, 'podPhases'> {
+  return { podPhases }
+}
+
+function issue(overrides: Partial<PodIssue> = {}): Pick<PodIssue, 'status' | 'reason'> {
+  return { status: 'Running', reason: '', ...overrides }
+}
 
 describe('isPendingPhasePodIssue', () => {
   it('counts rows explicitly labelled Pending', () => {
@@ -37,5 +51,90 @@ describe('isPendingPhasePodIssue', () => {
   it('does not treat unrelated reasons that merely mention scheduling as pending', () => {
     expect(isPendingPhasePodIssue({ status: 'High restarts (7)', reason: 'High restarts (7)' })).toBe(false)
     expect(isPendingPhasePodIssue({ status: '', reason: undefined })).toBe(false)
+  })
+})
+
+describe('countPendingPods', () => {
+  // The bug this change fixes (#23097). The pod-issues feed withholds a Pending
+  // pod until it is older than the backend's 2-minute podPendingAgeThreshold,
+  // so a stat derived from that feed reports 0 while Kubernetes — and the
+  // groundtruth canary — already count the pod. The census is ungated.
+  it('counts freshly-created Pending pods that the issues feed still suppresses', () => {
+    const clusters = [clusterWith(census({ running: 4, pending: 3 }))]
+    // Feed is empty: all three pods are younger than the age gate.
+    const podIssues: Pick<PodIssue, 'status' | 'reason'>[] = []
+
+    expect(countPendingPods(clusters, podIssues)).toBe(3)
+    // Guard against a regression to the feed-derived count.
+    expect(countPendingPods(clusters, podIssues)).not.toBe(podIssues.length)
+  })
+
+  it('sums the census across clusters', () => {
+    const clusters = [
+      clusterWith(census({ pending: 2 })),
+      clusterWith(census({ pending: 5 })),
+      clusterWith(census({ pending: 0, running: 9 })),
+    ]
+    expect(countPendingPods(clusters, [])).toBe(7)
+  })
+
+  // The census must not pick up phases that are not Pending, whatever the
+  // issues feed says about them.
+  it('ignores running, terminal and unknown-phase pods in the census', () => {
+    const clusters = [clusterWith(census({ running: 12, failed: 3, succeeded: 8, unknown: 2, pending: 1 }))]
+    const podIssues = [
+      issue({ status: 'Not ready', reason: 'Not ready' }),
+      issue({ status: 'CrashLoopBackOff', reason: 'CrashLoopBackOff' }),
+      issue({ status: 'Failed', reason: 'Failed' }),
+    ]
+    expect(countPendingPods(clusters, podIssues)).toBe(1)
+  })
+
+  // Kubernetes reports unschedulable pods in the Pending phase, so the backend
+  // census already includes them — #23096's behaviour is preserved, and now it
+  // holds without having to reconstruct the phase from an issue reason.
+  it('includes unschedulable pods via the census, matching #23096', () => {
+    const clusters = [clusterWith(census({ pending: 76 }))]
+    // The feed labels 64 of them Unschedulable and only 12 plain Pending.
+    const podIssues = [
+      ...Array.from({ length: 64 }, () =>
+        issue({ status: 'Unschedulable: 0/6 nodes are available.', reason: 'Unschedulable: 0/6 nodes are available.' })),
+      ...Array.from({ length: 12 }, () => issue({ status: 'Pending', reason: 'Pending' })),
+    ]
+    expect(countPendingPods(clusters, podIssues)).toBe(76)
+  })
+
+  describe('fallback when no cluster reports a census', () => {
+    // Older backend, or health data not collected yet. Behaviour must be
+    // exactly #23096's classifier — including its unschedulable handling.
+    it('classifies issue rows, keeping unschedulable pods as Pending', () => {
+      const clusters = [clusterWith(undefined), clusterWith(undefined)]
+      const podIssues = [
+        issue({ status: 'Pending', reason: 'Pending' }),
+        issue({ status: 'Unschedulable: insufficient cpu', reason: 'Unschedulable: insufficient cpu' }),
+        issue({ status: 'CrashLoopBackOff', reason: 'CrashLoopBackOff' }),
+        issue({ status: 'Not ready', reason: 'Not ready' }),
+      ]
+      expect(countPendingPods(clusters, podIssues)).toBe(2)
+    })
+
+    it('falls back for an empty cluster list', () => {
+      expect(countPendingPods([], [issue({ status: 'Pending', reason: 'Pending' })])).toBe(1)
+      expect(countPendingPods([], [])).toBe(0)
+    })
+  })
+
+  // A partially-collected fleet must not silently fall back and mix counting
+  // strategies: clusters that report a census are authoritative for their pods.
+  it('uses the census when only some clusters report one', () => {
+    const clusters = [clusterWith(census({ pending: 4 })), clusterWith(undefined)]
+    const podIssues = [issue({ status: 'Pending', reason: 'Pending' })]
+    expect(countPendingPods(clusters, podIssues)).toBe(4)
+  })
+
+  it('treats a census of all zeroes as authoritative, not as missing data', () => {
+    const clusters = [clusterWith(census())]
+    const podIssues = [issue({ status: 'Pending', reason: 'Pending' })]
+    expect(countPendingPods(clusters, podIssues)).toBe(0)
   })
 })

--- a/web/src/components/pods/__tests__/usePodsView.test.ts
+++ b/web/src/components/pods/__tests__/usePodsView.test.ts
@@ -149,6 +149,91 @@ describe('usePodsView', () => {
     expect(result.current.stats.healthy).toBe(7)
   })
 
+  // #23097: the pending stat is a phase count and must come from the backend
+  // phase census, not the pod-issues feed. The feed withholds Pending pods
+  // younger than podPendingAgeThreshold, so deriving the stat from it
+  // under-counted for the first two minutes of a pod's life.
+  it('counts freshly-created Pending pods from the phase census even when the issues feed is empty', () => {
+    const clusters = [makeCluster({
+      podCount: 10,
+      podPhases: { running: 7, pending: 3, failed: 0, succeeded: 0, unknown: 0 },
+    })]
+    // No issue rows at all: every Pending pod is younger than the age gate.
+    const { result } = renderUsePodsView({ podIssues: [], clusters })
+
+    expect(result.current.stats.pending).toBe(3)
+    // The feed itself is untouched — no phantom rows were invented for them.
+    expect(result.current.filteredPodIssues).toEqual([])
+    expect(result.current.stats.issues).toBe(0)
+  })
+
+  it('prefers the census over the issue rows when both are present', () => {
+    const clusters = [makeCluster({
+      podCount: 20,
+      // 5 Pending pods; only 2 are old enough to have surfaced as issues.
+      podPhases: { running: 15, pending: 5, failed: 0, succeeded: 0, unknown: 0 },
+    })]
+    const issues = [
+      makeIssue({ name: 'p1', reason: 'Pending', status: 'Pending' }),
+      makeIssue({ name: 'p2', reason: 'Pending', status: 'Pending' }),
+    ]
+    const { result } = renderUsePodsView({ podIssues: issues, clusters })
+
+    expect(result.current.stats.pending).toBe(5)
+  })
+
+  it('scopes the census to the globally selected clusters', () => {
+    mockIsAllClustersSelected = false
+    mockSelectedClusters = ['cluster-a']
+    const clusters = [
+      makeCluster({ name: 'cluster-a', podCount: 4, podPhases: { running: 2, pending: 2, failed: 0, succeeded: 0, unknown: 0 } }),
+      makeCluster({ name: 'cluster-b', podCount: 9, podPhases: { running: 2, pending: 7, failed: 0, succeeded: 0, unknown: 0 } }),
+    ]
+    const { result } = renderUsePodsView({ podIssues: [], clusters })
+
+    expect(result.current.stats.pending).toBe(2)
+    expect(result.current.stats.totalPods).toBe(4)
+  })
+
+  it('does not miscount running-unready or terminal pods as pending', () => {
+    const clusters = [makeCluster({
+      podCount: 12,
+      podPhases: { running: 8, pending: 0, failed: 3, succeeded: 1, unknown: 0 },
+    })]
+    const issues = [
+      makeIssue({ name: 'unready', reason: 'Not ready', status: 'Not ready' }),
+      makeIssue({ name: 'crash', reason: 'CrashLoopBackOff', status: 'CrashLoopBackOff' }),
+      makeIssue({ name: 'oom', reason: 'OOMKilled', status: 'OOMKilled' }),
+    ]
+    const { result } = renderUsePodsView({ podIssues: issues, clusters })
+
+    expect(result.current.stats.pending).toBe(0)
+    expect(result.current.stats.crashloop).toBe(1)
+  })
+
+  // #23096 must keep working: unschedulable pods are Pending. Via the census
+  // that is automatic (Kubernetes reports them as Pending); with no census the
+  // issue-row classifier still has to get it right.
+  it('counts unschedulable pods as pending via the census and via the fallback', () => {
+    const withCensus = [makeCluster({
+      podCount: 80,
+      podPhases: { running: 4, pending: 76, failed: 0, succeeded: 0, unknown: 0 },
+    })]
+    const unschedulableIssues = [
+      makeIssue({ name: 'u1', reason: 'Unschedulable: insufficient cpu', status: 'Unschedulable: insufficient cpu' }),
+      makeIssue({ name: 'u2', reason: 'Unschedulable: insufficient cpu', status: 'Unschedulable: insufficient cpu' }),
+    ]
+    const censusResult = renderUsePodsView({ podIssues: unschedulableIssues, clusters: withCensus })
+    expect(censusResult.result.current.stats.pending).toBe(76)
+
+    // No census reported (older backend / health not yet collected).
+    const fallbackResult = renderUsePodsView({
+      podIssues: unschedulableIssues,
+      clusters: [makeCluster({ podCount: 80 })],
+    })
+    expect(fallbackResult.result.current.stats.pending).toBe(2)
+  })
+
   it('filters pod issues by the customFilter text search (name/namespace/cluster/reason)', () => {
     mockCustomFilter = 'crash'
     const issues = [

--- a/web/src/components/pods/podPhaseClassification.ts
+++ b/web/src/components/pods/podPhaseClassification.ts
@@ -1,4 +1,5 @@
 import type { PodIssue } from '../../hooks/mcp/types.workloads'
+import type { ClusterInfo } from '../../hooks/mcp/types'
 
 /**
  * Backend `FindPodIssues` labels an unschedulable pod with the raw issue string
@@ -32,4 +33,31 @@ function isUnschedulableLabel(value: string | undefined): boolean {
 export function isPendingPhasePodIssue(issue: Pick<PodIssue, 'status' | 'reason'>): boolean {
   if (issue.reason === 'Pending' || issue.status === 'Pending') return true
   return isUnschedulableLabel(issue.reason) || isUnschedulableLabel(issue.status)
+}
+
+/**
+ * Number of pods in the Kubernetes `Pending` phase across the given clusters.
+ *
+ * Prefers the backend phase census (`cluster.podPhases`), which is tallied from
+ * the same unfiltered pod listing that produces `podCount` and applies no
+ * gating whatsoever. The pod-issues feed deliberately withholds a Pending pod
+ * until it is older than the backend's 2-minute `podPendingAgeThreshold` — the
+ * right call for an alarm feed, but a stat derived from that feed inherits the
+ * suppression and under-reports for the first two minutes of a pod's life
+ * (#23097). Reading the census keeps the feed's threshold intact while stopping
+ * stats from borrowing a UI heuristic.
+ *
+ * Falls back to classifying issue rows (#23096) when no cluster reports a
+ * census — an older backend, or health data not yet collected. The fallback is
+ * the previous behaviour, so it can under-count, but it never over-counts.
+ */
+export function countPendingPods(
+  clusters: Pick<ClusterInfo, 'podPhases'>[],
+  podIssues: Pick<PodIssue, 'status' | 'reason'>[],
+): number {
+  const withCensus = clusters.filter(cluster => cluster.podPhases)
+  if (withCensus.length > 0) {
+    return withCensus.reduce((sum, cluster) => sum + (cluster.podPhases?.pending || 0), 0)
+  }
+  return podIssues.filter(isPendingPhasePodIssue).length
 }

--- a/web/src/components/pods/podPhaseClassification.ts
+++ b/web/src/components/pods/podPhaseClassification.ts
@@ -1,0 +1,35 @@
+import type { PodIssue } from '../../hooks/mcp/types.workloads'
+
+/**
+ * Backend `FindPodIssues` labels an unschedulable pod with the raw issue string
+ * `Unschedulable: <message>` and, because "Unschedulable" outranks the phase
+ * fallback in `podPrimaryReasonPriority`, promotes it to the row's
+ * status/reason. Those pods are still in the Kubernetes `Pending` phase — they
+ * simply never got a node — so a `reason === 'Pending'` test alone under-counts
+ * them.
+ *
+ * The live groundtruth canary compares `pods-pending` against
+ * `pods.filter(phase === 'Pending')`, which does include unschedulable pods.
+ * Run 33749456318 reported 12 against a truthful 76 for exactly this reason:
+ * 64 of the Pending pods were unschedulable and therefore labelled
+ * `Unschedulable` instead of `Pending`.
+ *
+ * Only pods whose *primary* label is Unschedulable are treated as Pending here.
+ * A pod that reached `Running` and later went unready is reported with a
+ * different status (e.g. `Not ready`) and must not be counted.
+ */
+const UNSCHEDULABLE_PREFIX = 'unschedulable'
+
+function isUnschedulableLabel(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().toLowerCase().startsWith(UNSCHEDULABLE_PREFIX)
+}
+
+/**
+ * True when a pod-issue row represents a pod in the Kubernetes `Pending` phase:
+ * either explicitly labelled `Pending`, or labelled `Unschedulable` (which
+ * implies Pending).
+ */
+export function isPendingPhasePodIssue(issue: Pick<PodIssue, 'status' | 'reason'>): boolean {
+  if (issue.reason === 'Pending' || issue.status === 'Pending') return true
+  return isUnschedulableLabel(issue.reason) || isUnschedulableLabel(issue.status)
+}

--- a/web/src/components/pods/usePodsView.ts
+++ b/web/src/components/pods/usePodsView.ts
@@ -8,6 +8,7 @@ import { useToast } from '../ui/Toast'
 import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import type { PodIssue } from '../../hooks/mcp/types.workloads'
+import { isPendingPhasePodIssue } from './podPhaseClassification'
 import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { StatBlockValue } from '../ui/StatsOverview'
 
@@ -208,7 +209,7 @@ export function usePodsView({
     // Dedup issue rows by pod name to avoid under-counting healthy pods (#7348)
     const uniqueIssuePods = new Set(filteredPodIssues.map(p => `${p.cluster}/${p.namespace}/${p.name}`))
     const issueCount = filteredPodIssues.length
-    const pendingCount = filteredPodIssues.filter(p => p.reason === 'Pending' || p.status === 'Pending').length
+    const pendingCount = filteredPodIssues.filter(isPendingPhasePodIssue).length
     const crashLoopCount = filteredPodIssues.filter(p =>
       /crashloop|crash loop/i.test([p.reason, p.status].filter(Boolean).join(' '))
     ).length

--- a/web/src/components/pods/usePodsView.ts
+++ b/web/src/components/pods/usePodsView.ts
@@ -8,7 +8,7 @@ import { useToast } from '../ui/Toast'
 import { useBackendHealth } from '../../hooks/useBackendHealth'
 import { kubectlProxy } from '../../lib/kubectlProxy'
 import type { PodIssue } from '../../hooks/mcp/types.workloads'
-import { isPendingPhasePodIssue } from './podPhaseClassification'
+import { countPendingPods } from './podPhaseClassification'
 import type { ClusterInfo } from '../../hooks/mcp/types'
 import type { StatBlockValue } from '../ui/StatsOverview'
 
@@ -209,7 +209,11 @@ export function usePodsView({
     // Dedup issue rows by pod name to avoid under-counting healthy pods (#7348)
     const uniqueIssuePods = new Set(filteredPodIssues.map(p => `${p.cluster}/${p.namespace}/${p.name}`))
     const issueCount = filteredPodIssues.length
-    const pendingCount = filteredPodIssues.filter(isPendingPhasePodIssue).length
+    // Phase counts come from the ungated backend census, not the pod-issues
+    // feed, so a freshly-created Pending pod is counted immediately instead of
+    // being hidden by the feed's 2-minute alarm threshold (#23097). Scoped to
+    // the same visibleClusters that produce totalPods.
+    const pendingCount = countPendingPods(visibleClusters, filteredPodIssues)
     const crashLoopCount = filteredPodIssues.filter(p =>
       /crashloop|crash loop/i.test([p.reason, p.status].filter(Boolean).join(' '))
     ).length

--- a/web/src/hooks/mcp/types.ts
+++ b/web/src/hooks/mcp/types.ts
@@ -7,6 +7,17 @@
 //   - types.resources.ts  (ConfigMap/Secret/ServiceAccount/PVC/PV/ResourceQuota/LimitRange/RBAC)
 // Public exports are preserved — external callers keep importing from './types'.
 
+/** Straight tally of Kubernetes pod phases with no issue-suitability gating
+ *  applied — the backend's `PodPhaseCensus` (pkg/k8s/client_pods.go). Buckets
+ *  always partition the cluster's pod listing, so they sum to `podCount`. */
+export interface PodPhaseCensus {
+  running: number
+  pending: number
+  failed: number
+  succeeded: number
+  unknown: number
+}
+
 export interface ClusterInfo {
   name: string
   context: string
@@ -22,6 +33,10 @@ export interface ClusterInfo {
   nodeCount?: number
   readyNodes?: number
   podCount?: number
+  /** Ungated Kubernetes phase breakdown of the same pods `podCount` totals.
+   *  Phase stats read this instead of the pod-issues feed, which suppresses
+   *  Pending pods younger than the backend's 2-minute threshold (#23097). */
+  podPhases?: PodPhaseCensus
   // Total allocatable resources (capacity)
   cpuCores?: number
   memoryBytes?: number

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -12,7 +12,7 @@ import {
   useOperators,
   useGPUNodes } from './useMCP'
 import { useIngresses } from './mcp/networking'
-import { isPendingPhasePodIssue } from '../components/pods/podPhaseClassification'
+import { countPendingPods } from '../components/pods/podPhaseClassification'
 import { useCachedPVCs, useCachedWarningEvents } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
@@ -69,7 +69,10 @@ export function useUniversalStats() {
   const { rules: alertRules } = useAlertRules()
 
   // ─── Cluster-derived values (memoized) ───
-  const safeClusters = deduplicatedClusters || []
+  // Memoized so the `|| []` fallback does not mint a fresh array identity on
+  // every render and invalidate every downstream cluster memo — including the
+  // pending phase count, which now depends on it (#23097).
+  const safeClusters = useMemo(() => deduplicatedClusters || [], [deduplicatedClusters])
   const {
     totalClusters, healthyClusters, unhealthyClusters, unreachableClusters,
     healthyNodes, totalNodes, totalPods, totalCPUs, totalMemoryGB, totalStorageGB, uniqueNamespaces,
@@ -94,13 +97,16 @@ export function useUniversalStats() {
   // ─── Pod-derived values ───
   const podIssuesList = podIssues || []
   const { pendingPods, crashLoopPods, highRestartPods } = useMemo(() => ({
-    // Unschedulable pods are still in the Kubernetes Pending phase; matching
-    // only the literal 'Pending' label under-counts them. See
-    // podPhaseClassification.
-    pendingPods: podIssuesList.filter(isPendingPhasePodIssue).length,
+    // Pending is a *phase*, so it comes from the backend phase census rather
+    // than the pod-issues feed. The feed withholds Pending pods younger than
+    // its 2-minute alarm threshold, and a stat derived from it inherited that
+    // suppression (#23097). The census also gets unschedulable pods right for
+    // free — Kubernetes reports them as Pending — which is the case #23096 had
+    // to reconstruct from issue reasons, and which the fallback still handles.
+    pendingPods: countPendingPods(safeClusters, podIssuesList),
     crashLoopPods: podIssuesList.filter(p => /crashloop|crash loop/i.test([p.status, p.reason, ...(p.issues || [])].filter(Boolean).join(' '))).length,
     highRestartPods: podIssuesList.filter(p => p.restarts > HIGH_RESTART_THRESHOLD).length,
-  }), [podIssuesList])
+  }), [podIssuesList, safeClusters])
 
   // ─── Deployment-derived values ───
   const allDeployments = deployments || []

--- a/web/src/hooks/useUniversalStats.ts
+++ b/web/src/hooks/useUniversalStats.ts
@@ -12,6 +12,7 @@ import {
   useOperators,
   useGPUNodes } from './useMCP'
 import { useIngresses } from './mcp/networking'
+import { isPendingPhasePodIssue } from '../components/pods/podPhaseClassification'
 import { useCachedPVCs, useCachedWarningEvents } from './useCachedData'
 import { useAlerts, useAlertRules } from './useAlerts'
 import { StatBlockValue } from '../components/ui/StatsOverview'
@@ -93,7 +94,10 @@ export function useUniversalStats() {
   // ─── Pod-derived values ───
   const podIssuesList = podIssues || []
   const { pendingPods, crashLoopPods, highRestartPods } = useMemo(() => ({
-    pendingPods: podIssuesList.filter(p => p.status === 'Pending').length,
+    // Unschedulable pods are still in the Kubernetes Pending phase; matching
+    // only the literal 'Pending' label under-counts them. See
+    // podPhaseClassification.
+    pendingPods: podIssuesList.filter(isPendingPhasePodIssue).length,
     crashLoopPods: podIssuesList.filter(p => /crashloop|crash loop/i.test([p.status, p.reason, ...(p.issues || [])].filter(Boolean).join(' '))).length,
     highRestartPods: podIssuesList.filter(p => p.restarts > HIGH_RESTART_THRESHOLD).length,
   }), [podIssuesList])


### PR DESCRIPTION
## Problem

`FindPodIssues` (`pkg/k8s/client_pods.go`) emits a row for a Pending pod only when it is older than `podPendingAgeThreshold` (2 minutes) **and** has no other issue:

```go
if pod.Status.Phase == corev1.PodPending {
    if len(podIssues) == 0 && pod.CreationTimestamp.Time.Before(now.Add(-podPendingAgeThreshold)) {
        podIssues = appendUniquePodIssue(podIssues, "Pending")
    }
}
```

That gate is correct for an **issues feed** — nobody wants an alarm row for a pod that is merely starting. But the pod *phase* stats were computed **from that feed**, so they inherited the suppression. `pods-pending` under-counted for up to two minutes after pods were created, while Kubernetes counts a pod as Pending the instant it exists.

The live-canary groundtruth check compares `pods-pending` against `kubectl get pods -A | filter(phase === 'Pending')` (`normalizeK8sState.ts`), which has no such gate. Any cluster churning pods during the check could produce a spurious mismatch in a gate that blocks production promotion. This did not cause the failures #23096 addressed (those 76 pods were long-lived), but it is a latent flake source.

## Root cause detail

Two different populations were being conflated. `pods-total` already came from an ungated source (`cluster.podCount`, the length of the health collector's pod listing), but `pods-pending` came from the issues feed. A phase is a property of a pod; issue-suitability is a UI alarm heuristic. Deriving the former from the latter meant every heuristic in the feed — the 2-minute age gate, the `len(podIssues) == 0` exclusivity condition, the `getPrimaryPodIssue` reason-priority ordering — silently became part of the definition of "pending".

## Fix — option (a)

The issue offered two directions. I chose **(a) a phase census independent of the issues feed**.

Option (b) — have the feed carry the raw phase alongside the issue reason — cannot actually fix this case. A young Pending pod with no other issue is **entirely absent** from the feed: there is no row on which to carry a phase. Making the feed emit phase-only rows for pods it deliberately withholds would break the feed's contract, and the issue is explicit that the feed keeps its threshold.

New `PodPhaseCensus` + `CountPodPhases` (`pkg/k8s/client_pods.go`) tally pods by raw `pod.Status.Phase` with no gating at all. It is computed in the cluster health collector (`pkg/k8s/client_health.go`) from the **same unfiltered pod listing that already produces `PodCount`** — so the census is a phase breakdown of exactly the pods `podCount` totals, and the buckets always partition that listing. It costs one extra pass over a slice already in memory; no new API calls. It is surfaced as `ClusterInfo.podPhases` in `ListClusters`, alongside `podCount`, with the same cached-fallback behaviour on pod-listing timeout.

Frontend `countPendingPods` sums the census across the visible clusters, falling back to #23096's `isPendingPhasePodIssue` row classifier when **no** cluster reports a census (older backend, or health data not yet collected). The fallback is exactly the previous behaviour — it can under-count, but never over-counts.

**The issues feed is unchanged.** `podPendingAgeThreshold` is still applied, still gates the feed, and a test asserts that it does.

## Relationship to #23096

This is stacked on #23096 and preserves it. Reading the phase directly makes its unschedulable case correct *for free* — Kubernetes reports an unschedulable pod as Pending because it never got a node — but the classifier it added is still live on the fallback path, still exported, and its original 5 unit tests are untouched and green. Tests here assert the unschedulable behaviour holds via **both** paths.

## Tests assert the invariant and can fail

Verified by mutation, not just by passing:

- Reintroducing the age gate inside `CountPodPhases` fails 3 Go tests.
- Removing the census preference from `countPendingPods` fails 9 frontend tests.

Go (`pkg/k8s/client_pod_phase_census_test.go`) — the central test asserts **both halves** of the invariant on one fresh Pending pod: the census counts it, and `FindPodIssues` still suppresses it. If the second half ever starts failing, someone removed the feed's threshold, which is not the fix wanted here. Plus: aged Pending appears in both sources; unschedulable counts as Pending; terminal/Running-unready are not miscounted; buckets sum to the listing length.

Frontend — census beats the empty feed while the feed itself stays empty (no phantom rows invented); census preferred over issue rows when both exist; scoped to the global cluster selection; running-unready and terminal not counted; unschedulable correct via census *and* via fallback; an all-zero census is authoritative rather than treated as missing data.

Targeted runs: `pkg/k8s` and `pkg/api/handlers/mcp` green; `web/src/components/pods` + `web/src/hooks` 7439 passed / 0 failed. `gofmt` and `go vet` clean; `tsc --noEmit` clean.

`useUniversalStats.ts` lint warnings go **down** 13 → 11: the new memo dependency required memoizing `safeClusters`, which also resolves three pre-existing `react-hooks/exhaustive-deps` warnings.

Fixes #23097
Refs #23096, #23089
