### PR TITLE
fix(ci): deep probe ran kubectl with all contexts concatenated

### DIFF
--- a/.github/workflows/ci-cluster-probe.yml
+++ b/.github/workflows/ci-cluster-probe.yml
@@ -148,61 +148,166 @@ jobs:
             echo "::endgroup::"
           done
 
-      - name: Deep probe ci-3 (pending pods, leaked namespace provenance)
+      - name: Deep probe (pending pods, pod inventory, leaked namespace provenance)
         shell: bash
         env:
           KUBECONFIG: ${{ steps.groundtruth-kubeconfig.outputs.path }}
         run: |
           set -uo pipefail
 
-          ctx="$(echo "${LIVE_CLUSTER_CONTEXTS:-}" | tr ',' '\n' | tr -d '[:space:]' | grep -E 'ci-3$' | head -1 || true)"
-          if [ -z "$ctx" ]; then
-            echo "No ci-3 context found in LIVE_CLUSTER_CONTEXTS; skipping deep probe"
-            echo "_No \`ci-3\` context found; deep probe skipped._" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
+          # NOTE: the previous version of this step built $ctx with
+          #   echo "$LIVE_CLUSTER_CONTEXTS" | tr ',' '\n' | tr -d '[:space:]' | grep -E 'ci-3$'
+          # The second `tr` deleted the newlines the first one had just inserted,
+          # re-joining every context into ONE line that still ended in `ci-3`, so
+          # grep matched it and kubectl was invoked with the concatenated garbage
+          # context "ks-console-ci-1ks-console-ci-2ks-console-ci-3". Every query
+          # silently returned nothing. Split into an array exactly like the
+          # per-context loop in the previous step, and strip whitespace per element.
+
+          contexts_raw="${LIVE_CLUSTER_CONTEXTS:-}"
+          if [ -z "$contexts_raw" ]; then
+            echo "::error::LIVE_CLUSTER_CONTEXTS is empty; nothing to deep probe"
+            exit 1
           fi
-          echo "Deep probe context: ${ctx}"
+          IFS=',' read -r -a contexts <<< "$contexts_raw"
 
-          echo "::group::Pending pods on ${ctx}"
-          pending="$(kubectl --context "$ctx" get pods -A --field-selector=status.phase=Pending -o wide 2>/dev/null | head -40 || true)"
-          if [ -n "$pending" ]; then echo "$pending"; else echo "(none pending)"; fi
-          echo "::endgroup::"
+          summary="$GITHUB_STEP_SUMMARY"
+          {
+            echo
+            echo "## Deep probe: pod inventory in \`hive-hosted-*\` namespaces"
+            echo
+            echo "| Context | \`hive-hosted\` ns | Pods in those ns | Pending | Running | Other |"
+            echo "| --- | --- | --- | --- | --- | --- |"
+          } >> "$summary"
 
-          sample_ns="$(kubectl --context "$ctx" get ns -o name 2>/dev/null \
-            | grep 'hive-hosted' | head -1 | sed 's|^namespace/||' || true)"
+          for ctx in "${contexts[@]}"; do
+            ctx="$(echo "$ctx" | tr -d '[:space:]')"
+            [ -n "$ctx" ] || continue
+
+            echo "::group::Deep probe ${ctx}"
+            echo "Deep probe context: ${ctx}"
+
+            # ---- Leaked namespace list ------------------------------------------
+            leaked_ns="$(kubectl --context "$ctx" get ns -o name 2>/dev/null \
+              | sed 's|^namespace/||' | grep '^hive-hosted' || true)"
+            if [ -n "$leaked_ns" ]; then
+              leaked_count="$(echo "$leaked_ns" | wc -l | tr -d ' ')"
+            else
+              leaked_count=0
+            fi
+            echo "hive-hosted-namespace-count: ${leaked_count}"
+
+            # ---- 1. Pending pods cluster-wide (unfiltered count alongside) ------
+            echo "--- pending pods cluster-wide (field-selector) ---"
+            pending_all="$(kubectl --context "$ctx" get pods -A \
+              --field-selector=status.phase=Pending -o wide 2>/dev/null | head -80 || true)"
+            if [ -n "$pending_all" ]; then echo "$pending_all"; else echo "(none pending cluster-wide)"; fi
+
+            all_pods_count="$(kubectl --context "$ctx" get pods -A --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+            [ -n "$all_pods_count" ] || all_pods_count=0
+            echo "total-pods-cluster-wide: ${all_pods_count}"
+
+            # ---- 2. Pods restricted to hive-hosted-* namespaces -----------------
+            # Distinguishes "N Pending pods" from "namespaces with Deployments but
+            # zero pods" -- an empty listing here with leaked_count>0 means the
+            # ReplicaSets never created pods at all.
+            pods_in_leaked=0
+            pending_in_leaked=0
+            running_in_leaked=0
+            other_in_leaked=0
+
+            if [ "$leaked_count" -gt 0 ]; then
+              echo "--- pods -o wide restricted to hive-hosted-* namespaces ---"
+              leaked_pods="$(kubectl --context "$ctx" get pods -A -o wide --no-headers 2>/dev/null \
+                | awk '$1 ~ /^hive-hosted/' || true)"
+              if [ -n "$leaked_pods" ]; then
+                echo "$leaked_pods" | head -100
+                pods_in_leaked="$(echo "$leaked_pods" | wc -l | tr -d ' ')"
+                pending_in_leaked="$(echo "$leaked_pods" | awk '$4=="Pending"' | wc -l | tr -d ' ')"
+                running_in_leaked="$(echo "$leaked_pods" | awk '$4=="Running"' | wc -l | tr -d ' ')"
+                other_in_leaked="$(echo "$leaked_pods" | awk '$4!="Pending" && $4!="Running"' | wc -l | tr -d ' ')"
+              else
+                echo "(ZERO pods exist in any hive-hosted-* namespace on ${ctx})"
+              fi
+              echo "pods-in-hive-hosted-namespaces: ${pods_in_leaked} (Pending=${pending_in_leaked} Running=${running_in_leaked} Other=${other_in_leaked})"
+
+              # ---- Per-namespace: does a pod exist at all? ----------------------
+              echo "--- per-namespace pod counts (workloads vs actual pods) ---"
+              printf '%-52s %8s %8s %8s\n' NAMESPACE PODS DEPLOYS RS
+              while IFS= read -r ns; do
+                [ -n "$ns" ] || continue
+                np="$(kubectl --context "$ctx" get pods -n "$ns" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+                nd="$(kubectl --context "$ctx" get deploy -n "$ns" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+                nr="$(kubectl --context "$ctx" get rs -n "$ns" --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+                printf '%-52s %8s %8s %8s\n' "$ns" "${np:-0}" "${nd:-0}" "${nr:-0}"
+              done <<< "$(echo "$leaked_ns" | head -120)"
+
+              # ---- 5. Scheduler verdict for pods that DO exist -----------------
+              echo "--- PodScheduled condition messages (the scheduler's real reason) ---"
+              sched="$(kubectl --context "$ctx" get pods -A \
+                -o jsonpath='{range .items[?(@.metadata.namespace)]}{.metadata.namespace}{"\t"}{.metadata.name}{"\t"}{.status.phase}{"\t"}{range .status.conditions[?(@.type=="PodScheduled")]}{.status}{" "}{.reason}{" "}{.message}{end}{"\n"}{end}' \
+                2>/dev/null | awk -F'\t' '$1 ~ /^hive-hosted/' || true)"
+              if [ -n "$sched" ]; then
+                echo "$sched" | head -80
+                echo "--- tally of distinct PodScheduled messages ---"
+                echo "$sched" | awk -F'\t' '{print $4}' | sort | uniq -c | sort -rn | head -20
+              else
+                echo "(no pods in hive-hosted-* namespaces, so no PodScheduled conditions to report)"
+              fi
+
+              # ---- 3. Deployment status conditions for ~3 sample namespaces ----
+              # Reveals ReplicaSet-level failure (quota/limitrange) vs pods existing
+              # but unschedulable.
+              echo "--- Deployment .status.conditions for up to 3 sample namespaces ---"
+              while IFS= read -r ns; do
+                [ -n "$ns" ] || continue
+                echo "### namespace ${ns}"
+                kubectl --context "$ctx" get deploy -n "$ns" --no-headers 2>&1 | head -10 || true
+                kubectl --context "$ctx" get deploy -n "$ns" \
+                  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}  replicas={.status.replicas}{" ready="}{.status.readyReplicas}{" unavailable="}{.status.unavailableReplicas}{"\n"}  conditions={.status.conditions}{"\n"}{end}' \
+                  2>&1 | head -40 || true
+                echo "--- ReplicaSets in ${ns} (failure to create pods shows here) ---"
+                kubectl --context "$ctx" get rs -n "$ns" -o wide --no-headers 2>&1 | head -10 || true
+                echo "--- ResourceQuota / LimitRange in ${ns} ---"
+                kubectl --context "$ctx" get resourcequota,limitrange -n "$ns" 2>&1 | head -10 || true
+              done <<< "$(echo "$leaked_ns" | head -3)"
+
+              # ---- 4. Provenance dump on the first sample namespace ------------
+              sample_ns="$(echo "$leaked_ns" | head -1)"
+              echo "Sample leaked namespace: ${sample_ns}"
+
+              echo "--- namespace manifest ${sample_ns} (labels/annotations record the creator) ---"
+              kubectl --context "$ctx" get ns "$sample_ns" -o yaml 2>&1 || true
+
+              echo "--- namespace description ${sample_ns} ---"
+              kubectl --context "$ctx" describe ns "$sample_ns" 2>&1 || true
+
+              echo "--- events in ${sample_ns} (if any remain) ---"
+              ev="$(kubectl --context "$ctx" get events -n "$sample_ns" --sort-by=.lastTimestamp 2>/dev/null | head -20 || true)"
+              if [ -n "$ev" ]; then
+                echo "$ev"
+              else
+                echo "(NO EVENTS REMAIN -- these namespaces are ~52-55 days old and the"
+                echo " default etcd event TTL is 1h, so event-based provenance is gone.)"
+              fi
+            else
+              echo "(no hive-hosted-* namespaces on ${ctx})"
+            fi
+
+            {
+              printf '| `%s` | %s | %s | %s | %s | %s |\n' \
+                "$ctx" "$leaked_count" "$pods_in_leaked" "$pending_in_leaked" "$running_in_leaked" "$other_in_leaked"
+            } >> "$summary"
+
+            echo "::endgroup::"
+          done
 
           {
             echo
-            echo "## Provenance hunt on \`${ctx}\`"
-            echo
-          } >> "$GITHUB_STEP_SUMMARY"
-
-          if [ -z "$sample_ns" ]; then
-            echo "No hive-hosted namespaces present on ${ctx}"
-            echo "_No \`hive-hosted*\` namespaces present._" >> "$GITHUB_STEP_SUMMARY"
-            exit 0
-          fi
-
-          echo "Sample leaked namespace: ${sample_ns}"
-          echo "Sample leaked namespace: \`${sample_ns}\`" >> "$GITHUB_STEP_SUMMARY"
-
-          echo "::group::Namespace manifest ${sample_ns} (labels/annotations record the creator)"
-          kubectl --context "$ctx" get ns "$sample_ns" -o yaml 2>&1 || true
-          echo "::endgroup::"
-
-          echo "::group::Namespace description ${sample_ns}"
-          kubectl --context "$ctx" describe ns "$sample_ns" 2>&1 || true
-          echo "::endgroup::"
-
-          echo "::group::Events in ${sample_ns} (if any remain)"
-          kubectl --context "$ctx" get events -n "$sample_ns" --sort-by=.lastTimestamp 2>/dev/null | head -20 || true
-          echo "::endgroup::"
-
-          {
-            echo
-            echo "Namespace labels/annotations and remaining events are in the step logs"
-            echo "under the collapsed \`Namespace manifest\` and \`Events\` groups."
-          } >> "$GITHUB_STEP_SUMMARY"
+            echo "Per-namespace pod counts, Deployment/ReplicaSet status conditions,"
+            echo "PodScheduled messages, and namespace labels/annotations are in the"
+            echo "collapsed \`Deep probe <context>\` step-log groups."
+          } >> "$summary"
 
       - name: Note disposability
         if: always()


### PR DESCRIPTION
## The bug

Run [33759616506](https://github.com/kubestellar/console/actions/runs/33759616506) printed the group header literally as:

```
##[group]Pending pods on ks-console-ci-1ks-console-ci-2ks-console-ci-3
(none pending)
No hive-hosted namespaces present on ks-console-ci-1ks-console-ci-2ks-console-ci-3
```

Root cause is in the context selection on the deep-probe step:

```bash
ctx="$(echo "$LIVE_CLUSTER_CONTEXTS" | tr ',' '\n' | tr -d '[:space:]' | grep -E 'ci-3$' | head -1)"
```

`tr -d '[:space:]'` deletes the newlines that `tr ',' '\n'` had just inserted, re-joining all three contexts into one line. That line still *ends* in `ci-3`, so `grep -E 'ci-3$'` matched it, and `ctx` became the concatenated garbage. Every `kubectl --context` call then matched no context and returned empty — the `(none pending)` was an artifact, not a finding.

Verified against the exact production value:

```
OLD: ctx=[ks-console-ci-1ks-console-ci-2ks-console-ci-3]   # reproduces the log
NEW: ctx=[ks-console-ci-1] / [ks-console-ci-2] / [ks-console-ci-3]
```

## The fix

Split with `IFS=',' read -r -a contexts`, the same idiom the working per-context loop in the preceding step already uses, and run the pod/provenance inventory **per context inside the loop**. Whitespace and trailing commas are tolerated. The earlier identity/hub/leak-census loop is untouched.

## Expanded diagnostics

So the re-run can actually distinguish "76 Pending pods" from "namespaces with Deployments but zero pods":

1. `get pods -A -o wide` restricted to `hive-hosted-*`, plus an unfiltered cluster-wide count
2. Per-namespace `PODS / DEPLOYS / RS` table — a namespace whose ReplicaSet never created a pod is visible as `PODS=0 DEPLOYS>=1`
3. Deployment `.status.conditions`, ReplicaSets, and ResourceQuota/LimitRange for 3 sample namespaces (quota/limitrange rejection vs unschedulable pods)
4. Existing namespace yaml/describe/events provenance dump, now stating explicitly when no events remain (namespaces are ~52-55 days old; default event TTL is 1h)
5. `PodScheduled` condition messages for pods that exist, plus a tally of distinct scheduler messages

## Safety

Strictly read-only — `get` and `describe` only, no apply/delete/patch/scale/exec anywhere. Kubeconfig handling is byte-for-byte unchanged; no kubeconfig or credential is printed. YAML parse and `bash -n` on the extracted step script both verified locally.

Diagnostics for hivecommons/hive#5768.