### PR TITLE
🐛 fix: attest a real zero on /deployments instead of suppressing markers

### DIFF
--- a/web/src/components/deployments/Deployments.tsx
+++ b/web/src/components/deployments/Deployments.tsx
@@ -75,9 +75,15 @@ function DeploymentsContent() {
   const attestedAvailable = attestedDeployments.filter(
     d => Number(d.availableReplicas || 0) >= Number(d.replicas || 0),
   ).length
-  const deploymentGroundtruthFields = attestedTotal > 0
-    ? { 'deployments-total': attestedTotal, 'deployments-available': attestedAvailable }
-    : undefined
+  // Always attest, even at zero. Suppressing the markers when the list is
+  // empty makes the harness report `markerCount: 0` / reason "missing", which
+  // is strictly less informative than attesting the real value: a rendered 0
+  // says "the page believes there are no deployments", which is exactly the
+  // condition worth failing on when the listing feed is broken.
+  const deploymentGroundtruthFields = {
+    'deployments-total': attestedTotal,
+    'deployments-available': attestedAvailable,
+  }
 
   // Cache stats to prevent showing 0 during refresh
   const cachedStats = useRef({ total: 0, healthy: 0, issues: 0 })

--- a/web/src/components/deployments/__tests__/Deployments.groundtruth.test.tsx
+++ b/web/src/components/deployments/__tests__/Deployments.groundtruth.test.tsx
@@ -144,14 +144,19 @@ describe('Deployments groundtruth attestation', () => {
     })
   }, IMPORT_TIMEOUT_MS)
 
-  it.each(ATTESTING_BLOCKS)('block %s attests nothing rather than a zero when no deployments are loaded', async blockId => {
-    // With no data there is nothing to attest. Emitting 0 here would assert
-    // "the cluster genuinely has 0 deployments", which we cannot know yet;
-    // omitting the fields lets the harness poll until data arrives.
+  it.each(ATTESTING_BLOCKS)('block %s attests a real zero when no deployments are loaded', async blockId => {
+    // Attest 0 rather than suppressing the markers. An earlier revision omitted
+    // the fields here, which made the live harness report markerCount: 0 /
+    // reason "missing" — strictly less informative than a rendered 0, which
+    // states plainly that the page believes there are no deployments. That is
+    // the exact condition worth failing on when the listing feed is broken.
     mockDeployments = []
     const { Deployments } = await import('../Deployments')
     render(<Deployments />)
     expect(capturedGetStatValue).not.toBeNull()
-    expect(capturedGetStatValue!(blockId).groundtruthFields).toBeUndefined()
+    expect(capturedGetStatValue!(blockId).groundtruthFields).toEqual({
+      'deployments-total': 0,
+      'deployments-available': 0,
+    })
   }, IMPORT_TIMEOUT_MS)
 })


### PR DESCRIPTION
## What this corrects

#23102 gated the groundtruth attestation on `attestedTotal > 0`, on the reasoning that emitting `0` would falsely assert "this cluster genuinely has no deployments".

That was the wrong call. On the live canary the deployments listing really is empty (**#23107**), so the markers stopped rendering at all and the harness went from

```
"actual": 0,    "markerCount": 1, "reason": "mismatch"
```

to

```
"actual": null, "markerCount": 0, "reason": "missing"
```

Both fail, but the second is less informative. A rendered `0` says the page believes there are no deployments — the exact condition worth failing on when the feed is broken. A missing marker only says the page declined to answer, which reads like an attestation wiring bug rather than the data bug it actually is.

## The real bug is #23107

Worth being explicit: **this PR does not make the promote gate pass**, and it shouldn't. The live page shows `Total Deployments: 0` next to `Pod Issues: 76`, because it never calls `/api/mcp/deployments` — only `deployment-issues`. That's tracked in #23107 with the endpoint evidence from the promote artifact.

This change just makes the gate name that condition honestly instead of masking it behind a missing marker.

## What #23102 got right, and keeps

The scope fix stands: attest from the unfiltered listing using the harness's availability predicate (`availableReplicas >= replicas`), not from the cluster-filtered/cached tile values. That was a real bug — the filtered tiles' `0` beat the correct unfiltered value because `createMergedStatValueGetter` only falls through on `undefined`/`'-'`, and `0` is neither.

## Tests

The third case in `Deployments.groundtruth.test.tsx` is inverted to assert `{deployments-total: 0, deployments-available: 0}` where it previously asserted `undefined`, with a comment recording why, so this doesn't get "fixed" back. The other two cases (unfiltered totals, and correct totals under a filter that excludes everything) are unchanged and still pass.

Refs #23107