### PR TITLE
fix(hooks): upgrade swallowed parse error from console.warn to console.error in useDashboardCards

### DIFF
--- a/web/src/hooks/useDashboardCards.ts
+++ b/web/src/hooks/useDashboardCards.ts
@@ -25,7 +25,7 @@ function safeJsonParse<T>(raw: string, fallback: T, context: string): T {
   try {
     return JSON.parse(raw) as T
   } catch (err) {
-    console.warn(`[useDashboardCards] Failed to parse ${context}, using default`, err)
+    console.error(`[useDashboardCards] Failed to parse ${context}, using default`, err)
     return fallback
   }
 }


### PR DESCRIPTION
Fixes #23228.

### Summary
Upgrades \console.warn\ to \console.error\ inside \safeJsonParse\ in \web/src/hooks/useDashboardCards.ts\ as recommended by the Auto-QA Resilience check. This ensures failed JSON parse attempts (e.g. corrupt or invalid stored collapsed state) are clearly logged for debugging rather than downgraded.