### PR TITLE
refactor(updater): expose test seams for polling intervals and SHA detection

### DIFF
--- a/pkg/agent/updater/checker.go
+++ b/pkg/agent/updater/checker.go
@@ -9,9 +9,12 @@ import (
 	"github.com/kubestellar/console/pkg/safego"
 )
 
-const (
+var (
 	developerCheckInterval = 15 * time.Minute
 	releaseCheckInterval   = 60 * time.Minute
+)
+
+const (
 	healthCheckRetries     = 15
 	healthCheckDelay       = 2 * time.Second
 	// defaultGitHubRepo is the fallback GitHub owner/repo used when

--- a/pkg/agent/updater/poller.go
+++ b/pkg/agent/updater/poller.go
@@ -10,6 +10,12 @@ import (
 	"github.com/kubestellar/console/pkg/sanitize"
 )
 
+var (
+	initialStartupDelay      = 30 * time.Second
+	fetchLatestMainSHAFn     = fetchLatestMainSHAWithRepo
+	detectCurrentSHAFn       = detectCurrentSHA
+)
+
 func (uc *UpdateChecker) run(ctx context.Context) {
 	uc.mu.Lock()
 	interval := releaseCheckInterval
@@ -22,7 +28,7 @@ func (uc *UpdateChecker) run(ctx context.Context) {
 	select {
 	case <-ctx.Done():
 		return
-	case <-time.After(30 * time.Second):
+	case <-time.After(initialStartupDelay):
 	}
 
 	ticker := time.NewTicker(interval)
@@ -72,14 +78,14 @@ func (uc *UpdateChecker) checkDeveloperChannel() {
 		return
 	}
 
-	latestSHA, err := fetchLatestMainSHAWithRepo(repoPath)
+	latestSHA, err := fetchLatestMainSHAFn(repoPath)
 	if err != nil {
 		slog.Error("[AutoUpdate] failed to check main SHA", "error", err)
 		return
 	}
 
 	// Re-read currentSHA from repo in case it was updated externally
-	if freshSHA := detectCurrentSHA(repoPath); freshSHA != "" {
+	if freshSHA := detectCurrentSHAFn(repoPath); freshSHA != "" {
 		uc.mu.Lock()
 		uc.currentSHA = freshSHA
 		currentSHA = freshSHA


### PR DESCRIPTION
Fixes #23341.

### Summary
Exposes package-level test seams in \pkg/agent/updater\ to unblock unit testing without altering production behavior:
- Changes \developerCheckInterval\ and \eleaseCheckInterval\ from \const\ to package-level \ar\ in \pkg/agent/updater/checker.go\.
- Adds package-level \ar initialStartupDelay = 30 * time.Second\ in \pkg/agent/updater/poller.go\ and uses it in the startup delay select arm.
- Replaces direct calls to \etchLatestMainSHAWithRepo\ and \detectCurrentSHA\ in \checkDeveloperChannel\ with package-level function variables \etchLatestMainSHAFn\ and \detectCurrentSHAFn\.

This provides the exact seams required by issue #23341 so the quality agent can follow up with additive unit tests for the ticker and developer channel branches.